### PR TITLE
Phase 3: Equities second-pass audit bug fixes

### DIFF
--- a/apps/backtest/bt_equity_mean_reversion.cpp
+++ b/apps/backtest/bt_equity_mean_reversion.cpp
@@ -8,6 +8,7 @@
 #include "trade_ngin/core/time_utils.hpp"
 #include "trade_ngin/data/database_pooling.hpp"
 #include "trade_ngin/data/postgres_database.hpp"
+#include "trade_ngin/core/holiday_checker.hpp"
 #include "trade_ngin/instruments/equity.hpp"
 #include "trade_ngin/instruments/instrument_registry.hpp"
 #include "trade_ngin/portfolio/portfolio_manager.hpp"
@@ -50,6 +51,12 @@ int main() {
         }
         auto app_config = app_config_result.value();
         INFO("Configuration loaded for portfolio: " + app_config.portfolio_id);
+
+        // Wire the shared HolidayChecker into EquityInstrument's static slot so
+        // any market-hours queries on equity instruments consult the calendar.
+        auto holiday_checker_ptr = std::make_shared<HolidayChecker>(
+            "include/trade_ngin/core/holidays.json");
+        EquityInstrument::set_holiday_checker(holiday_checker_ptr);
 
         // ========================================
         // SETUP DATABASE CONNECTION

--- a/apps/backtest/bt_equity_validation.cpp
+++ b/apps/backtest/bt_equity_validation.cpp
@@ -643,14 +643,17 @@ int main() {
                         log_returns.push_back(std::log(price_history[j] / price_history[j-1]));
                     }
                 }
-                if (!log_returns.empty()) {
+                // Sample std dev (n-1) to match MeanReversionStrategy::calculate_volatility.
+                // Previously used population (n) -- ~2.5% drift on 20-day windows caused
+                // spurious validation failures. Audit §1.19.
+                if (log_returns.size() >= 2) {
                     double ret_mean = std::accumulate(log_returns.begin(), log_returns.end(), 0.0) / log_returns.size();
                     double ret_sq = 0;
                     for (double r : log_returns) {
                         double diff = r - ret_mean;
                         ret_sq += diff * diff;
                     }
-                    manual_vol = std::sqrt(ret_sq / log_returns.size()) * std::sqrt(252.0);
+                    manual_vol = std::sqrt(ret_sq / (log_returns.size() - 1)) * std::sqrt(252.0);
                 } else {
                     manual_vol = 0.01;
                 }

--- a/apps/strategies/live_equity_mean_reversion.cpp
+++ b/apps/strategies/live_equity_mean_reversion.cpp
@@ -115,6 +115,13 @@ int main(int argc, char* argv[]) {
         auto app_config = app_config_result.value();
         INFO("Configuration loaded successfully for portfolio: " + app_config.portfolio_id);
 
+        // Wire the shared HolidayChecker into EquityInstrument's static slot so
+        // that EquityInstrument::is_market_open() actually consults the calendar.
+        // Same checker is reused below for the previous-trading-day lookup.
+        auto holiday_checker_ptr = std::make_shared<HolidayChecker>(
+            "include/trade_ngin/core/holidays.json");
+        EquityInstrument::set_holiday_checker(holiday_checker_ptr);
+
         // Setup database connection pool
         INFO("Initializing database connection pool...");
         std::string conn_string = app_config.database.get_connection_string();
@@ -424,35 +431,19 @@ int main(int argc, char* argv[]) {
         // Find the actual previous trading day (skip weekends and holidays)
         // Mirrors the logic in live_portfolio.cpp for futures
         // ========================================
-        HolidayChecker holiday_checker("include/trade_ngin/core/holidays.json");
+        const HolidayChecker& holiday_checker = *holiday_checker_ptr;
 
-        // Walk backwards from yesterday to find the most recent trading day
-        auto previous_date = now - std::chrono::hours(24);
-        for (int lookback = 0; lookback < 5; ++lookback) {
-            auto check_time_t = std::chrono::system_clock::to_time_t(previous_date);
-            std::tm check_tm = *std::localtime(&check_time_t);
-            int dow = check_tm.tm_wday;  // 0=Sunday, 6=Saturday
-
-            // Format date string for holiday check
-            std::ostringstream date_oss;
-            date_oss << std::put_time(&check_tm, "%Y-%m-%d");
-            std::string date_str_check = date_oss.str();
-
-            bool is_weekend = (dow == 0 || dow == 6);
-            bool is_holiday = holiday_checker.is_holiday(date_str_check);
-
-            if (!is_weekend && !is_holiday) {
-                if (lookback > 0) {
-                    INFO("Previous trading day: " + date_str_check +
-                         " (skipped " + std::to_string(lookback) + " non-trading day(s))");
-                }
-                break;
-            }
-
-            DEBUG("Skipping non-trading day: " + date_str_check +
-                  (is_weekend ? " (weekend)" : " (holiday: " + holiday_checker.get_holiday_name(date_str_check) + ")"));
-            previous_date -= std::chrono::hours(24);
+        // Find the most recent trading day strictly before `now`. Walks back
+        // up to 14 days to cover worst-case US closure stacks (Christmas-week
+        // holidays + weekends, or 9/11-style multi-day exchange closures).
+        // Fails closed if exhausted rather than silently using a stale date.
+        auto prev_day_opt = holiday_checker.find_previous_trading_day(now);
+        if (!prev_day_opt.has_value()) {
+            ERROR("Failed to find a previous trading day within lookback bound. "
+                  "Holiday calendar may be misconfigured or stale. Aborting.");
+            return 1;
         }
+        auto previous_date = *prev_day_opt;
 
         // Check if today itself is a non-trading day
         int today_dow = now_tm->tm_wday;

--- a/include/trade_ngin/core/holiday_checker.hpp
+++ b/include/trade_ngin/core/holiday_checker.hpp
@@ -4,6 +4,10 @@
 #include <unordered_map>
 #include <optional>
 #include <fstream>
+#include <chrono>
+#include <ctime>
+#include <iomanip>
+#include <sstream>
 #include <nlohmann/json.hpp>
 #include "logger.hpp"
 
@@ -77,6 +81,38 @@ public:
      */
     bool reload() {
         return load_holidays();
+    }
+
+    /**
+     * @brief Find the most recent trading day strictly before `start`.
+     *
+     * Walks back day-by-day skipping weekends and holidays. Bound of 14
+     * covers worst-case US closure stacks (Christmas + week-of-holidays +
+     * weekends, or 9/11-style multi-day exchange closures).
+     *
+     * @param start Reference timestamp; the search begins at `start - 24h`.
+     * @param max_lookback_days Maximum days to walk back before giving up.
+     * @return time_point of the previous trading day, or std::nullopt if the
+     *         bound was exhausted (caller should fail closed, not fall back).
+     */
+    std::optional<std::chrono::system_clock::time_point>
+    find_previous_trading_day(std::chrono::system_clock::time_point start,
+                              int max_lookback_days = 14) const {
+        auto candidate = start - std::chrono::hours(24);
+        for (int i = 0; i < max_lookback_days; ++i) {
+            auto t = std::chrono::system_clock::to_time_t(candidate);
+            std::tm tm = *std::localtime(&t);
+            bool is_weekend = (tm.tm_wday == 0 || tm.tm_wday == 6);
+
+            std::ostringstream ds;
+            ds << std::put_time(&tm, "%Y-%m-%d");
+
+            if (!is_weekend && !is_holiday(ds.str())) {
+                return candidate;
+            }
+            candidate -= std::chrono::hours(24);
+        }
+        return std::nullopt;
     }
 
 private:

--- a/include/trade_ngin/core/types.hpp
+++ b/include/trade_ngin/core/types.hpp
@@ -277,7 +277,14 @@ enum class AssetType { FUTURE, EQUITY, OPTION, FOREX, CRYPTO, NONE };
 
 /**
  * @brief Market data bar structure
- * Represents OHLCV data for any timeframe
+ * Represents OHLCV data for any timeframe.
+ *
+ * Equity convention: for AssetType::EQUITY symbols, the loader at
+ * postgres_database.cpp (the equity SELECT) maps `closeadj` into the `close`
+ * field and proportionally rescales `open`/`high`/`low` by the `closeadj/close`
+ * ratio. So for equities the OHLC stored here is split- AND dividend-adjusted
+ * (a continuous total-return price series), not the raw exchange price.
+ * Futures bars carry raw OHLC.
  */
 struct Bar {
     Timestamp timestamp;

--- a/include/trade_ngin/strategy/mean_reversion.hpp
+++ b/include/trade_ngin/strategy/mean_reversion.hpp
@@ -127,6 +127,13 @@ private:
      * @brief Trim price/volatility history to prevent unbounded memory growth
      */
     void trim_history(MeanReversionInstrumentData& data) const;
+
+#ifdef TESTING
+public:
+    double calculate_volatility_for_test(const std::deque<double>& prices, int lookback) const {
+        return calculate_volatility(prices, lookback);
+    }
+#endif
 };
 
 }  // namespace trade_ngin

--- a/src/instruments/instrument_registry.cpp
+++ b/src/instruments/instrument_registry.cpp
@@ -221,7 +221,10 @@ Result<void> InstrumentRegistry::load_equity_instruments(
         spec.exchange = (ex_it != exchange_map.end()) ? ex_it->second : "NYSE";
         spec.currency = "USD";
         spec.tick_size = 0.01;
-        spec.commission_per_share = 0.0;
+        // Match IBKR Pro default (also used by AssetCostConfigRegistry::get_equity_default_config).
+        // Production cost path is TransactionCostManager; this default keeps the
+        // instrument-level commission accessor consistent for callers that query it.
+        spec.commission_per_share = 0.005;
 
         register_instrument(symbol, std::make_shared<EquityInstrument>(symbol, std::move(spec)));
         registered++;
@@ -362,7 +365,9 @@ std::shared_ptr<Instrument> InstrumentRegistry::create_instrument_from_db(
 
         double min_tick = get_double("Minimum Price Fluctuation");
         std::string tick_size = get_string("Tick Size");
-        double commission = 0.0;  // Not in the metadata, set a default
+        // Asset-type-aware default. Futures spec doesn't carry commission; equities
+        // get IBKR Pro $0.005/share to match get_equity_default_config().
+        double commission = (asset_type == AssetType::EQUITY) ? 0.005 : 0.0;
 
         // Create instrument based on asset type
         switch (asset_type) {

--- a/src/strategy/mean_reversion.cpp
+++ b/src/strategy/mean_reversion.cpp
@@ -170,11 +170,20 @@ Result<void> MeanReversionStrategy::on_data(const std::vector<Bar>& data) {
 
         // Update unrealized PnL for all positions based on current prices
         // (BaseStrategy::on_data does this but we override it, so compute here)
+        //
+        // average_price is set by on_execution() AFTER this on_data() completes,
+        // so a fresh entry has quantity != 0 and average_price == 0. Computing
+        // (bar.close - 0) * quantity would inflate unrealized_pnl to the full
+        // notional. Skip until cost basis is established.
         for (const auto& bar : data) {
             auto pos_it = positions_.find(bar.symbol);
             if (pos_it != positions_.end()) {
-                pos_it->second.unrealized_pnl =
-                    (bar.close - pos_it->second.average_price) * pos_it->second.quantity;
+                if (pos_it->second.average_price > Decimal(0.0)) {
+                    pos_it->second.unrealized_pnl =
+                        (bar.close - pos_it->second.average_price) * pos_it->second.quantity;
+                } else {
+                    pos_it->second.unrealized_pnl = Decimal(0.0);
+                }
             }
         }
 
@@ -298,7 +307,10 @@ double MeanReversionStrategy::calculate_volatility(const std::deque<double>& pri
         }
     }
 
-    if (returns.empty()) {
+    // Need at least 2 returns for sample std dev (n-1 denominator).
+    // With 1 return we'd divide by 0 and produce NaN, which then poisons
+    // vol-scaled position sizing downstream.
+    if (returns.size() < 2) {
         return 0.01;
     }
 
@@ -311,8 +323,11 @@ double MeanReversionStrategy::calculate_volatility(const std::deque<double>& pri
     // Sample std dev (n-1) for risk/volatility estimation (position sizing)
     double std_dev = std::sqrt(sum_squared_diff / (returns.size() - 1));
 
-    // Annualize (assuming daily data, 252 trading days)
-    return std_dev * std::sqrt(252.0);
+    double annualized = std_dev * std::sqrt(252.0);
+    if (!std::isfinite(annualized)) {
+        return 0.01;
+    }
+    return annualized;
 }
 
 double MeanReversionStrategy::generate_signal(const std::string& symbol, const MeanReversionInstrumentData& data) const {

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -6,11 +6,13 @@ set(TEST_SOURCES
     core/test_config_manager.cpp
     core/test_config_version.cpp
     core/test_config_base.cpp
+    core/test_holiday_lookback_extended_closure.cpp
     data/test_db_utils.cpp
     data/test_postgres_database.cpp
     data/test_database_pooling.cpp
     data/test_market_data_bus.cpp
     data/test_credential_store.cpp
+    data/test_bar_close_uses_adjusted.cpp
     order/test_order_manager.cpp
     order/test_utils.cpp
     risk/test_risk_manager.cpp
@@ -19,11 +21,14 @@ set(TEST_SOURCES
     # backtesting/test_engine.cpp  # Deprecated - BacktestEngine replaced by BacktestCoordinator
     execution/test_execution_engine.cpp
     portfolio/test_portfolio_manager.cpp
+    instruments/test_equity_instrument_holiday_check_wired.cpp
     strategy/test_base_strategy.cpp
     strategy/test_trend_following.cpp
     strategy/test_mean_reversion_backtest.cpp
     strategy/test_equity_backtest_db_validation.cpp
     strategy/test_equity_pnl_accounting.cpp
+    strategy/test_volatility_size_1_nan_guard.cpp
+    strategy/test_stale_unrealized_pnl_zero_avg_price.cpp
     statistics/test_normalizer.cpp
     statistics/test_pca.cpp
     statistics/test_adf.cpp

--- a/tests/core/test_holiday_lookback_extended_closure.cpp
+++ b/tests/core/test_holiday_lookback_extended_closure.cpp
@@ -1,0 +1,163 @@
+#include <gtest/gtest.h>
+#include <chrono>
+#include <cstdio>
+#include <ctime>
+#include <filesystem>
+#include <fstream>
+#include <iomanip>
+#include <sstream>
+#include <string>
+#include "trade_ngin/core/holiday_checker.hpp"
+
+using namespace trade_ngin;
+
+// Regression test for audit finding §1.9: holiday lookback was bounded at 5
+// days, which is borderline for Christmas-week stacks and outright wrong for
+// 9/11-style multi-day exchange closures. Refactored into
+// HolidayChecker::find_previous_trading_day with a 14-day bound and explicit
+// fail-closed signaling when the bound is exhausted.
+
+namespace {
+
+// Build a YYYY-MM-DD string from a time_point.
+std::string date_string(std::chrono::system_clock::time_point tp) {
+    auto t = std::chrono::system_clock::to_time_t(tp);
+    std::tm tm = *std::localtime(&t);
+    std::ostringstream ss;
+    ss << std::put_time(&tm, "%Y-%m-%d");
+    return ss.str();
+}
+
+// Parse YYYY-MM-DD into a time_point at local-midnight, plus a small fixed
+// offset so the holiday-check string formatting is consistent across systems.
+std::chrono::system_clock::time_point parse_date(const std::string& s) {
+    std::tm tm{};
+    std::istringstream iss(s);
+    iss >> std::get_time(&tm, "%Y-%m-%d");
+    tm.tm_hour = 12;  // noon to avoid any DST-edge surprise
+    auto t = std::mktime(&tm);
+    return std::chrono::system_clock::from_time_t(t);
+}
+
+// Write a holidays JSON file with the given list of dates marked as holidays.
+void write_holidays_json(const std::filesystem::path& path,
+                         const std::vector<std::string>& dates) {
+    std::ofstream out(path);
+    out << "{\n";
+    out << "  \"2024\": [\n";
+    for (size_t i = 0; i < dates.size(); ++i) {
+        out << "    {\"date\": \"" << dates[i]
+            << "\", \"name\": \"TEST\", \"type\": \"federal\"}";
+        if (i + 1 < dates.size()) out << ",";
+        out << "\n";
+    }
+    out << "  ]\n";
+    out << "}\n";
+}
+
+class HolidayLookbackTest : public ::testing::Test {
+protected:
+    void SetUp() override {
+        tmp_dir_ = std::filesystem::temp_directory_path() /
+                   ("holiday_test_" + std::to_string(::testing::UnitTest::GetInstance()
+                                                          ->current_test_info()
+                                                          ->result()
+                                                          ->test_property_count()) +
+                    "_" + std::to_string(std::rand()));
+        std::filesystem::create_directories(tmp_dir_);
+        holidays_path_ = tmp_dir_ / "holidays.json";
+    }
+
+    void TearDown() override {
+        std::error_code ec;
+        std::filesystem::remove_all(tmp_dir_, ec);
+    }
+
+    std::filesystem::path tmp_dir_;
+    std::filesystem::path holidays_path_;
+};
+
+}  // namespace
+
+// Tuesday with no holidays: previous trading day is Monday.
+TEST_F(HolidayLookbackTest, NoHolidaysReturnsYesterday) {
+    write_holidays_json(holidays_path_, {});
+    HolidayChecker checker(holidays_path_.string());
+
+    auto start = parse_date("2024-03-05");  // Tuesday
+    auto prev = checker.find_previous_trading_day(start);
+    ASSERT_TRUE(prev.has_value());
+    EXPECT_EQ(date_string(*prev), "2024-03-04");  // Monday
+}
+
+// Monday with no holidays: skip Sunday and Saturday → Friday.
+TEST_F(HolidayLookbackTest, WeekendSkippedToFriday) {
+    write_holidays_json(holidays_path_, {});
+    HolidayChecker checker(holidays_path_.string());
+
+    auto start = parse_date("2024-03-04");  // Monday
+    auto prev = checker.find_previous_trading_day(start);
+    ASSERT_TRUE(prev.has_value());
+    EXPECT_EQ(date_string(*prev), "2024-03-01");  // Friday
+}
+
+// 6 consecutive holidays before a Tuesday — pre-fix this would have silently
+// returned a stale date because the 5-bound exhausted; post-fix the 14-bound
+// walks past and returns the day before the stack.
+TEST_F(HolidayLookbackTest, SixConsecutiveClosuresWalkBackCorrectly) {
+    write_holidays_json(holidays_path_,
+                        {"2024-03-04", "2024-03-05", "2024-03-06",
+                         "2024-03-07", "2024-03-08", "2024-03-11"});
+    HolidayChecker checker(holidays_path_.string());
+
+    // Start: Tuesday 2024-03-12. Walk back skips:
+    //   03-11 (Mon holiday), 03-10 (Sun), 03-09 (Sat),
+    //   03-08 holiday, 03-07 holiday, 03-06 holiday, 03-05 holiday, 03-04 holiday
+    //   -> 03-01 (Friday) is the previous trading day.
+    auto start = parse_date("2024-03-12");
+    auto prev = checker.find_previous_trading_day(start);
+    ASSERT_TRUE(prev.has_value());
+    EXPECT_EQ(date_string(*prev), "2024-03-01");
+}
+
+// 20-day closure stack with the default 14-day bound: fail closed (nullopt).
+// The caller MUST treat this as an error, not silently use a stale date.
+TEST_F(HolidayLookbackTest, ExhaustedBoundReturnsNullopt) {
+    std::vector<std::string> all_march_days_as_holidays;
+    for (int d = 1; d <= 31; ++d) {
+        std::ostringstream s;
+        s << "2024-03-" << std::setw(2) << std::setfill('0') << d;
+        all_march_days_as_holidays.push_back(s.str());
+    }
+    // Also block the late-February days so the bound truly exhausts.
+    for (int d = 20; d <= 29; ++d) {
+        std::ostringstream s;
+        s << "2024-02-" << std::setw(2) << std::setfill('0') << d;
+        all_march_days_as_holidays.push_back(s.str());
+    }
+    write_holidays_json(holidays_path_, all_march_days_as_holidays);
+    HolidayChecker checker(holidays_path_.string());
+
+    auto start = parse_date("2024-03-15");
+    auto prev = checker.find_previous_trading_day(start, /*max_lookback_days=*/14);
+    EXPECT_FALSE(prev.has_value())
+        << "find_previous_trading_day must fail closed when the lookback bound "
+           "is exhausted, not return a stale date.";
+}
+
+// Explicit small-bound test — the original 5-day bug.
+TEST_F(HolidayLookbackTest, OldBoundOfFiveExhaustsOnSixDayStack) {
+    write_holidays_json(holidays_path_,
+                        {"2024-03-04", "2024-03-05", "2024-03-06",
+                         "2024-03-07", "2024-03-08", "2024-03-11"});
+    HolidayChecker checker(holidays_path_.string());
+
+    // Start Tuesday 2024-03-12. With bound 5 we walk back 5 days
+    // (03-11, 03-10, 03-09, 03-08, 03-07) -- all non-trading -- and exhaust
+    // before finding 03-01. The old code silently used 03-07; the new API
+    // surfaces this via nullopt.
+    auto start = parse_date("2024-03-12");
+    auto prev = checker.find_previous_trading_day(start, /*max_lookback_days=*/5);
+    EXPECT_FALSE(prev.has_value())
+        << "5-day bound must surface failure on a 6+ day closure stack.";
+}

--- a/tests/data/test_bar_close_uses_adjusted.cpp
+++ b/tests/data/test_bar_close_uses_adjusted.cpp
@@ -1,0 +1,73 @@
+#include <gtest/gtest.h>
+#include <filesystem>
+#include <fstream>
+#include <sstream>
+#include <string>
+
+// Regression test for audit finding §1.11 (the verified non-bug, kept as a
+// guard against quiet breakage).
+//
+// The equity loader at src/data/postgres_database.cpp rewrites the SELECT for
+// AssetClass::EQUITIES so that OHLC are proportionally rescaled by
+// (closeadj / close) and the `close` column maps to `closeadj`. This makes
+// equity Bars carry a continuous split/dividend-adjusted series, which the
+// strategy code depends on for signal correctness.
+//
+// A proper integration test would load a known-split equity (e.g. AAPL
+// 2020-08-31 4-for-1) and assert bar.close straddles the split smoothly. That
+// requires a populated test DB; the project doesn't currently ship one, so
+// this test substitutes a lighter-weight guard: assert the SQL query string
+// in the source file still contains the rescaling expression. Cheap, catches
+// the regression the audit cares about, no DB required.
+//
+// If the source layout changes such that this file lives elsewhere, update
+// candidate_paths_. The test deliberately probes multiple plausible roots so
+// it works from `ctest --test-dir build` and from the repo root.
+
+namespace {
+
+const char* kCandidatePaths[] = {
+    "src/data/postgres_database.cpp",
+    "../src/data/postgres_database.cpp",
+    "../../src/data/postgres_database.cpp",
+    "../../../src/data/postgres_database.cpp",
+};
+
+std::string read_file_from_candidates() {
+    for (const char* p : kCandidatePaths) {
+        std::ifstream f(p);
+        if (f.is_open()) {
+            std::stringstream ss;
+            ss << f.rdbuf();
+            return ss.str();
+        }
+    }
+    return {};
+}
+
+}  // namespace
+
+TEST(BarCloseAdjustedRegression, EquitySelectRescaleExpressionPresent) {
+    std::string source = read_file_from_candidates();
+    if (source.empty()) {
+        GTEST_SKIP() << "postgres_database.cpp not findable from cwd; "
+                        "run from repo root or build dir.";
+    }
+
+    // The proportional OHLC rescaling: open/high/low * (closeadj / close).
+    EXPECT_NE(source.find("closeadj / close"), std::string::npos)
+        << "Equity OHLC rescaling expression `(closeadj / close)` missing from "
+           "postgres_database.cpp. Without it, equity bars load raw exchange "
+           "prices instead of split/dividend-adjusted prices and strategy "
+           "signals silently corrupt across corporate actions.";
+
+    // The close-column remap: `closeadj as close`.
+    EXPECT_NE(source.find("closeadj as close"), std::string::npos)
+        << "`closeadj as close` mapping missing from equity SELECT. Bars would "
+           "carry raw close instead of adjusted.";
+
+    // The asset-class branch that gates the equity SELECT.
+    EXPECT_NE(source.find("AssetClass::EQUITIES"), std::string::npos)
+        << "Equity SELECT branch missing; loader no longer differentiates "
+           "equities from futures.";
+}

--- a/tests/instruments/test_equity_instrument_holiday_check_wired.cpp
+++ b/tests/instruments/test_equity_instrument_holiday_check_wired.cpp
@@ -1,0 +1,102 @@
+#include <gtest/gtest.h>
+#include <chrono>
+#include <ctime>
+#include <filesystem>
+#include <fstream>
+#include <memory>
+#include "trade_ngin/core/holiday_checker.hpp"
+#include "trade_ngin/instruments/equity.hpp"
+
+using namespace trade_ngin;
+
+// Regression test for audit finding §1.10: EquityInstrument::is_market_open()
+// was wired to consult HolidayChecker only via a static slot that was never
+// populated in production -- so it silently allowed Christmas-day trades.
+// Phase 3d calls EquityInstrument::set_holiday_checker() at app startup; this
+// test verifies the wired path actually rejects holiday timestamps.
+
+namespace {
+
+std::chrono::system_clock::time_point make_local(int year, int month, int day,
+                                                 int hour, int minute) {
+    std::tm tm{};
+    tm.tm_year = year - 1900;
+    tm.tm_mon = month - 1;
+    tm.tm_mday = day;
+    tm.tm_hour = hour;
+    tm.tm_min = minute;
+    tm.tm_isdst = -1;
+    auto t = std::mktime(&tm);
+    return std::chrono::system_clock::from_time_t(t);
+}
+
+class EquityInstrumentHolidayTest : public ::testing::Test {
+protected:
+    void SetUp() override {
+        tmp_dir_ = std::filesystem::temp_directory_path() /
+                   ("equity_holiday_" + std::to_string(std::rand()));
+        std::filesystem::create_directories(tmp_dir_);
+        holidays_path_ = tmp_dir_ / "holidays.json";
+
+        std::ofstream out(holidays_path_);
+        out << R"({
+  "2026": [
+    {"date": "2026-12-25", "name": "Christmas Day", "type": "federal"}
+  ]
+})";
+        out.close();
+
+        spec_.exchange = "NASDAQ";
+        spec_.currency = "USD";
+        spec_.tick_size = 0.01;
+        spec_.trading_hours = "09:30-16:00";
+
+        // Make a fresh checker and wire it into the static slot.
+        auto checker = std::make_shared<HolidayChecker>(holidays_path_.string());
+        EquityInstrument::set_holiday_checker(checker);
+    }
+
+    void TearDown() override {
+        // Reset the static so subsequent tests aren't surprised by our mock.
+        EquityInstrument::set_holiday_checker(nullptr);
+        std::error_code ec;
+        std::filesystem::remove_all(tmp_dir_, ec);
+    }
+
+    std::filesystem::path tmp_dir_;
+    std::filesystem::path holidays_path_;
+    EquitySpec spec_;
+};
+
+}  // namespace
+
+// Friday 2026-12-25 is Christmas (configured holiday). Even at 10:00 local
+// (well inside the 09:30-16:00 trading window) and a weekday, is_market_open
+// must report false because the holiday check fires.
+TEST_F(EquityInstrumentHolidayTest, ChristmasReturnsClosedWhenCheckerWired) {
+    EquityInstrument aapl("AAPL", spec_);
+    auto christmas_10am = make_local(2026, 12, 25, 10, 0);
+    EXPECT_FALSE(aapl.is_market_open(christmas_10am));
+}
+
+// Sanity: an ordinary Wednesday at 10am is open.
+TEST_F(EquityInstrumentHolidayTest, RegularWeekdayWithinHoursReturnsOpen) {
+    EquityInstrument aapl("AAPL", spec_);
+    auto wed_10am = make_local(2026, 12, 9, 10, 0);  // Wednesday
+    EXPECT_TRUE(aapl.is_market_open(wed_10am));
+}
+
+// If no checker is wired (e.g. pre-fix or after TearDown), the method falls
+// back to weekday-and-hours only. This documents the contract: the checker is
+// the holiday-aware path; without it, holidays slip through.
+TEST_F(EquityInstrumentHolidayTest, WithoutCheckerHolidayWouldBeMissed) {
+    EquityInstrument::set_holiday_checker(nullptr);
+    EquityInstrument aapl("AAPL", spec_);
+    auto christmas_10am = make_local(2026, 12, 25, 10, 0);
+    // Christmas 2026 is a Friday -- weekday, within hours -- so without a
+    // checker, the method incorrectly returns true. This is the pre-fix bug,
+    // pinned here as a contract assertion (NOT a desired behavior).
+    EXPECT_TRUE(aapl.is_market_open(christmas_10am))
+        << "Without a holiday checker, is_market_open should fall through to "
+           "weekday+hours only. If this fails, the fallback contract changed.";
+}

--- a/tests/strategy/test_equity_backtest_db_validation.cpp
+++ b/tests/strategy/test_equity_backtest_db_validation.cpp
@@ -30,11 +30,12 @@ protected:
         TestBase::SetUp();
         StateManager::reset_instance();
 
-        // Skip if DB tests not enabled
-        const char* db_tests = std::getenv("TRADE_NGIN_DB_TESTS");
-        if (!db_tests || std::string(db_tests) != "1") {
-            GTEST_SKIP() << "Database integration tests disabled. "
-                         << "Set TRADE_NGIN_DB_TESTS=1 to enable.";
+        // DB integration tests run by default. Set SKIP_DB_TESTS=1 to skip
+        // (e.g. in environments without a usable DB). Flipped from the old
+        // opt-in gate so CI surfaces failures instead of silently skipping.
+        const char* skip = std::getenv("SKIP_DB_TESTS");
+        if (skip && std::string(skip) == "1") {
+            GTEST_SKIP() << "Database integration tests skipped via SKIP_DB_TESTS=1.";
         }
 
         db_ = std::make_shared<MockPostgresDatabase>("mock://testdb");
@@ -386,12 +387,13 @@ TEST_F(EquityBacktestDBValidation, UsesUnrealizedPnLAccounting) {
         strategy->on_data({bar});
     }
 
-    // Get PnL accounting - verify UNREALIZED_ONLY is set
+    // Equity mean reversion uses MIXED accounting: realized PnL accrues on
+    // position close (with weighted-average cost basis), unrealized accrues
+    // while held. Test/code drift caught by audit §1.7 -- this previously
+    // expected UNREALIZED_ONLY.
     const auto& pnl = strategy->get_pnl_accounting();
-    // With UNREALIZED_ONLY, the accounting method should track unrealized PnL
-    // and realized PnL should remain at 0 while positions are open
-    EXPECT_EQ(pnl.method, PnLAccountingMethod::UNREALIZED_ONLY)
-        << "Equity strategy should use UNREALIZED_ONLY PnL accounting";
+    EXPECT_EQ(pnl.method, PnLAccountingMethod::MIXED)
+        << "Equity strategy should use MIXED PnL accounting";
 }
 
 // ============================================================================

--- a/tests/strategy/test_stale_unrealized_pnl_zero_avg_price.cpp
+++ b/tests/strategy/test_stale_unrealized_pnl_zero_avg_price.cpp
@@ -1,0 +1,135 @@
+#include <gtest/gtest.h>
+#include <chrono>
+#include <memory>
+#include <random>
+#include <vector>
+#include "../core/test_base.hpp"
+#include "../data/test_db_utils.hpp"
+#include "trade_ngin/strategy/mean_reversion.hpp"
+
+using namespace trade_ngin;
+using namespace trade_ngin::testing;
+
+// Regression test for audit finding §1.8: the unrealized PnL update in
+// MeanReversionStrategy::on_data() previously did not guard against
+// average_price == 0, so a fresh entry (quantity set by on_data, average_price
+// not yet set by on_execution) reported unrealized = bar.close * quantity —
+// the full notional — instead of 0.
+class StaleUnrealizedPnLTest : public TestBase {
+protected:
+    void SetUp() override {
+        TestBase::SetUp();
+        StateManager::reset_instance();
+
+        db_ = std::make_shared<MockPostgresDatabase>("mock://testdb");
+        ASSERT_TRUE(db_->connect().is_ok());
+
+        strategy_config_.capital_allocation = 100000.0;
+        strategy_config_.max_leverage = 2.0;
+        strategy_config_.asset_classes = {AssetClass::EQUITIES};
+        strategy_config_.frequencies = {DataFrequency::DAILY};
+        strategy_config_.trading_params["AAPL"] = 1.0;
+        strategy_config_.position_limits["AAPL"] = 100000.0;
+
+        mr_config_.lookback_period = 20;
+        mr_config_.vol_lookback = 20;
+        mr_config_.entry_threshold = 1.5;
+        mr_config_.exit_threshold = 0.5;
+        mr_config_.risk_target = 0.15;
+        mr_config_.position_size = 0.1;
+        mr_config_.allow_fractional_shares = true;
+
+        RiskLimits limits;
+        limits.max_position_size = 100000.0;
+        limits.max_notional_value = 1e9;
+        limits.max_drawdown = 0.9;
+        limits.max_leverage = 10.0;
+
+        strategy_ = std::make_unique<MeanReversionStrategy>(
+            "TEST_STALE_UNREAL", strategy_config_, mr_config_, db_);
+        ASSERT_TRUE(strategy_->initialize().is_ok());
+        ASSERT_TRUE(strategy_->update_risk_limits(limits).is_ok());
+        ASSERT_TRUE(strategy_->start().is_ok());
+    }
+
+    void TearDown() override {
+        if (strategy_) {
+            strategy_->stop();
+            strategy_.reset();
+        }
+        if (db_) {
+            db_->disconnect();
+            db_.reset();
+        }
+        TestBase::TearDown();
+    }
+
+    // Build a synthetic price series that warms up the strategy (so a position
+    // can be sized) and then pushes prices far enough from the mean to trigger
+    // an entry signal.
+    std::vector<Bar> build_warmup_then_breakout(const std::string& symbol) {
+        std::vector<Bar> data;
+        auto now = std::chrono::system_clock::now();
+        // 30 stable bars at $100 to populate lookback windows.
+        for (int i = 0; i < 30; ++i) {
+            Bar b;
+            b.symbol = symbol;
+            b.timestamp = now - std::chrono::hours(24 * (40 - i));
+            b.open = 100.0;
+            b.high = 100.5;
+            b.low = 99.5;
+            b.close = 100.0;
+            b.volume = 1'000'000.0;
+            data.push_back(b);
+        }
+        // 10 bars dropping 5% — wide z-score, should trigger long signal.
+        double price = 100.0;
+        for (int i = 0; i < 10; ++i) {
+            price -= 0.5;
+            Bar b;
+            b.symbol = symbol;
+            b.timestamp = now - std::chrono::hours(24 * (10 - i));
+            b.open = price + 0.1;
+            b.high = price + 0.2;
+            b.low = price - 0.2;
+            b.close = price;
+            b.volume = 1'000'000.0;
+            data.push_back(b);
+        }
+        return data;
+    }
+
+    std::shared_ptr<MockPostgresDatabase> db_;
+    StrategyConfig strategy_config_;
+    MeanReversionConfig mr_config_;
+    std::unique_ptr<MeanReversionStrategy> strategy_;
+};
+
+// Feed bars one-at-a-time (matching live mode where on_data and on_execution
+// alternate). Without calling on_execution, any newly-sized position carries
+// quantity != 0 with average_price == 0. The fix ensures unrealized_pnl stays
+// 0 in that window, not (bar.close * quantity).
+TEST_F(StaleUnrealizedPnLTest, FreshEntryReportsZeroUnrealizedNotNotional) {
+    auto bars = build_warmup_then_breakout("AAPL");
+
+    for (const auto& bar : bars) {
+        std::vector<Bar> single = {bar};
+        ASSERT_TRUE(strategy_->on_data(single).is_ok());
+        // Do NOT call on_execution -- simulating the window between data and fill.
+
+        const auto& positions = strategy_->get_positions();
+        auto it = positions.find("AAPL");
+        if (it == positions.end()) continue;
+        const Position& pos = it->second;
+
+        // If a non-zero position has been sized but cost basis is still 0,
+        // unrealized_pnl must be 0 (not (bar.close - 0) * quantity).
+        if (pos.quantity != Decimal(0.0) && pos.average_price == Decimal(0.0)) {
+            EXPECT_EQ(pos.unrealized_pnl, Decimal(0.0))
+                << "Fresh entry should report 0 unrealized while avg_price is 0; "
+                << "got " << pos.unrealized_pnl.as_double()
+                << " (qty=" << pos.quantity.as_double()
+                << ", close=" << bar.close.as_double() << ")";
+        }
+    }
+}

--- a/tests/strategy/test_volatility_size_1_nan_guard.cpp
+++ b/tests/strategy/test_volatility_size_1_nan_guard.cpp
@@ -1,0 +1,102 @@
+#include <gtest/gtest.h>
+#include <cmath>
+#include <deque>
+#include <memory>
+#include "../core/test_base.hpp"
+#include "../data/test_db_utils.hpp"
+#include "trade_ngin/strategy/mean_reversion.hpp"
+
+using namespace trade_ngin;
+using namespace trade_ngin::testing;
+
+// Regression test for audit finding §1.6: calculate_volatility() previously
+// allowed prices.size() == 2 to slip past the early-out guard, producing one
+// return and then dividing by (returns.size() - 1) == 0, yielding NaN that
+// propagated through vol-scaled position sizing.
+class VolatilitySize1NaNGuardTest : public TestBase {
+protected:
+    void SetUp() override {
+        TestBase::SetUp();
+        StateManager::reset_instance();
+
+        db_ = std::make_shared<MockPostgresDatabase>("mock://testdb");
+        ASSERT_TRUE(db_->connect().is_ok());
+
+        strategy_config_.capital_allocation = 100000.0;
+        strategy_config_.max_leverage = 2.0;
+        strategy_config_.asset_classes = {AssetClass::EQUITIES};
+        strategy_config_.frequencies = {DataFrequency::DAILY};
+        strategy_config_.trading_params["AAPL"] = 1.0;
+        strategy_config_.position_limits["AAPL"] = 1000.0;
+
+        mr_config_.lookback_period = 20;
+        mr_config_.vol_lookback = 20;
+        mr_config_.entry_threshold = 2.0;
+        mr_config_.exit_threshold = 0.5;
+        mr_config_.risk_target = 0.15;
+        mr_config_.position_size = 0.1;
+
+        strategy_ = std::make_unique<MeanReversionStrategy>(
+            "TEST_VOL_GUARD", strategy_config_, mr_config_, db_);
+        ASSERT_TRUE(strategy_->initialize().is_ok());
+    }
+
+    void TearDown() override {
+        if (strategy_) {
+            strategy_->stop();
+            strategy_.reset();
+        }
+        if (db_) {
+            db_->disconnect();
+            db_.reset();
+        }
+        TestBase::TearDown();
+    }
+
+    std::shared_ptr<MockPostgresDatabase> db_;
+    StrategyConfig strategy_config_;
+    MeanReversionConfig mr_config_;
+    std::unique_ptr<MeanReversionStrategy> strategy_;
+};
+
+TEST_F(VolatilitySize1NaNGuardTest, EmptyPriceDequeReturnsDefault) {
+    std::deque<double> prices;
+    double v = strategy_->calculate_volatility_for_test(prices, 20);
+    EXPECT_TRUE(std::isfinite(v));
+    EXPECT_DOUBLE_EQ(v, 0.01);
+}
+
+TEST_F(VolatilitySize1NaNGuardTest, SinglePriceReturnsDefault) {
+    std::deque<double> prices{100.0};
+    double v = strategy_->calculate_volatility_for_test(prices, 20);
+    EXPECT_TRUE(std::isfinite(v));
+    EXPECT_DOUBLE_EQ(v, 0.01);
+}
+
+// The audit's primary scenario: 2 prices → 1 return → division by 0 → NaN
+// pre-fix. Post-fix this must return the default 0.01.
+TEST_F(VolatilitySize1NaNGuardTest, TwoPricesReturnsDefaultNotNaN) {
+    std::deque<double> prices{100.0, 101.0};
+    double v = strategy_->calculate_volatility_for_test(prices, 20);
+    EXPECT_TRUE(std::isfinite(v)) << "vol must not be NaN with 2 prices";
+    EXPECT_DOUBLE_EQ(v, 0.01);
+}
+
+// Sparse data where prices[i-1] <= 0 skips entries, leaving only one valid return.
+TEST_F(VolatilitySize1NaNGuardTest, SparseValidPricesLeavingOneReturnYieldsDefault) {
+    std::deque<double> prices{0.0, 0.0, 100.0, 101.0};
+    double v = strategy_->calculate_volatility_for_test(prices, 20);
+    EXPECT_TRUE(std::isfinite(v));
+    EXPECT_DOUBLE_EQ(v, 0.01);
+}
+
+// Sanity: with enough data the function computes a non-default value.
+TEST_F(VolatilitySize1NaNGuardTest, EnoughPricesComputesRealValue) {
+    std::deque<double> prices;
+    for (int i = 0; i < 30; ++i) {
+        prices.push_back(100.0 + i * 0.5);
+    }
+    double v = strategy_->calculate_volatility_for_test(prices, 20);
+    EXPECT_TRUE(std::isfinite(v));
+    EXPECT_GT(v, 0.0);
+}


### PR DESCRIPTION
## Summary
Addresses 6 findings (1 HIGH, 4 MED, 1 LOW-doc) from the 2026-05-03 equities integration audit. Each fix lands with the test the audit prescribed.

| Finding | Severity | What changed |
|---|---|---|
| §1.6 vol N=1 NaN | HIGH | Tightened guard in \`MeanReversionStrategy::calculate_volatility\` |
| §1.8 stale unrealized PnL | MED | Skip recompute in \`on_data\` when \`avg_price == 0\` |
| §1.9 holiday lookback | MED | Refactored to \`HolidayChecker::find_previous_trading_day\` with 14-day bound + fail-closed |
| §1.10 EquityInstrument dead methods | MED | Wired \`set_holiday_checker\` at app startup; commission default \$0.005/share |
| §1.11 Bar.close convention | LOW (doc) | Added comment + regression-guard test on SQL rescaling |
| §1.7 + §1.19 + §1.20 | MED/LOW | Test/code drift fixes; flipped DB-test env gate to opt-out |

Tests: 15 new + 1 modified. All 360 tests pass.

## Test plan
- [x] Full build clean: \`cmake --build build -j\`
- [x] New tests pass (T3.1-T3.5)
- [x] Modified PnL accounting test passes with new MIXED expectation
- [x] Full test suite: 360/360 pass
- [ ] Smoke-run \`bt_equity_mr\` against baseline portfolio_value series
- [ ] Confirm \`live_equity_mr\` startup wires holiday checker (manual)

## Out of scope (deferred per audit §7)
Phases 1, 2, 4, 5, 6 — follow-on PRs. Phase 7 permanently deferred.

Source audit: \`docs/equities_review_2026-05-03.md\`