### PR TITLE
Phase 2: Equity margin & accounting overhaul

### DIFF
--- a/apps/backtest/bt_equity_mean_reversion.cpp
+++ b/apps/backtest/bt_equity_mean_reversion.cpp
@@ -137,6 +137,24 @@ int main() {
             return 1;
         }
 
+        // Phase 2 leverage guardrail (audit §3.3): CASH-mode equities cannot
+        // be in a portfolio with max_gross_leverage > 1.0 -- cash accounts
+        // can't borrow, so a leverage cap above 1.0 is structurally invalid.
+        // Fail fast at startup rather than silently producing nonsense margin.
+        if (app_config.risk_config.max_gross_leverage > 1.0) {
+            for (const auto& symbol : symbols) {
+                auto inst = registry.get_equity_instrument(symbol);
+                if (inst && inst->get_account_mode() == EquityAccountMode::CASH) {
+                    ERROR("Refusing to start: CASH-mode equity " + symbol +
+                          " in portfolio with max_gross_leverage=" +
+                          std::to_string(app_config.risk_config.max_gross_leverage) +
+                          " > 1.0. Set REG_T account_mode (and is_short_allowed "
+                          "if needed) or reduce max_gross_leverage to 1.0.");
+                    return 1;
+                }
+            }
+        }
+
         // Print symbols
         std::cout << "Symbols (" << symbols.size() << "): ";
         for (size_t i = 0; i < std::min(symbols.size(), size_t(10)); ++i) {

--- a/apps/strategies/live_equity_mean_reversion.cpp
+++ b/apps/strategies/live_equity_mean_reversion.cpp
@@ -202,6 +202,23 @@ int main(int argc, char* argv[]) {
             return 1;
         }
 
+        // Phase 2 leverage guardrail (audit §3.3): CASH-mode equities cannot
+        // be in a portfolio with max_gross_leverage > 1.0 -- cash accounts
+        // can't borrow, so a leverage cap above 1.0 is structurally invalid.
+        if (app_config.risk_config.max_gross_leverage > 1.0) {
+            for (const auto& symbol : symbols) {
+                auto inst = registry.get_equity_instrument(symbol);
+                if (inst && inst->get_account_mode() == EquityAccountMode::CASH) {
+                    ERROR("Refusing to start: CASH-mode equity " + symbol +
+                          " in portfolio with max_gross_leverage=" +
+                          std::to_string(app_config.risk_config.max_gross_leverage) +
+                          " > 1.0. Set REG_T account_mode (and is_short_allowed "
+                          "if needed) or reduce max_gross_leverage to 1.0.");
+                    return 1;
+                }
+            }
+        }
+
         std::cout << "Symbols: ";
         for (const auto& symbol : symbols) {
             std::cout << symbol << " ";

--- a/include/trade_ngin/instruments/equity.hpp
+++ b/include/trade_ngin/instruments/equity.hpp
@@ -66,11 +66,12 @@ struct EquitySpec {
     //   Use to inject broker-provided rates from a live locate API.
     // is_easy_to_borrow: when false, force HTB tier regardless of ADV/price
     //   signals (e.g., recent IPOs with low float despite high ADV).
-    // short_locate_fee_per_trade: flat dollar fee charged once per short
-    //   open (some brokers).
+    // (Per-trade flat locate fee deliberately omitted: the cost-path code
+    // does not yet model short-open events distinctly, so a field with no
+    // consumer would silently swallow any value the user configured.
+    // Add when the short-open cost path lands.)
     double borrow_rate_override{-1.0};
     bool is_easy_to_borrow{true};
-    double short_locate_fee_per_trade{0.0};
 };
 
 /**

--- a/include/trade_ngin/instruments/equity.hpp
+++ b/include/trade_ngin/instruments/equity.hpp
@@ -25,6 +25,18 @@ struct DividendInfo {
 };
 
 /**
+ * @brief Account model for equity margin and shorting.
+ *
+ * CASH: full position notional is posted as margin (cash deployed). No
+ * shorting. Standard retail cash-account behavior.
+ *
+ * REG_T: Reg T margin. Long positions post 50% of notional; shorts post
+ * 150% (100% proceeds + 50% maintenance margin). Shorting allowed only if
+ * EquitySpec::short_selling_allowed is also true.
+ */
+enum class EquityAccountMode { CASH, REG_T };
+
+/**
  * @brief Stock specification
  */
 struct EquitySpec {
@@ -35,11 +47,30 @@ struct EquitySpec {
     double commission_per_share{0.0};          // Commission per share
     bool is_etf{false};                        // Whether the instrument is an ETF
     bool is_marginable{true};                  // Whether the stock can be margined
-    double margin_requirement{0.5};            // Initial margin requirement (typically 50%)
     std::string sector;                        // Industry sector
     std::string industry;                      // Specific industry
     std::string trading_hours{"09:30-16:00"};  // NYSE and NASDAQ regular session hours
     std::vector<DividendInfo> dividends;       // Upcoming dividends
+
+    // Account model. Default CASH preserves safe long-only behavior; opt in
+    // to REG_T per-symbol for leveraged/short capability.
+    EquityAccountMode account_mode{EquityAccountMode::CASH};
+
+    // Shorting gate. Only meaningful when account_mode == REG_T; with CASH
+    // mode, shorts are rejected by the strategy clamp regardless of this flag.
+    bool short_selling_allowed{false};
+
+    // Borrow fee configuration.
+    // borrow_rate_override: if >= 0, use this annual rate instead of the
+    //   formula in TransactionCostManager::calculate_overnight_borrow_fees.
+    //   Use to inject broker-provided rates from a live locate API.
+    // is_easy_to_borrow: when false, force HTB tier regardless of ADV/price
+    //   signals (e.g., recent IPOs with low float despite high ADV).
+    // short_locate_fee_per_trade: flat dollar fee charged once per short
+    //   open (some brokers).
+    double borrow_rate_override{-1.0};
+    bool is_easy_to_borrow{true};
+    double short_locate_fee_per_trade{0.0};
 };
 
 /**
@@ -81,9 +112,16 @@ public:
     }  // $1 per point for stocks
 
     bool is_tradeable() const override;
+
+    // Legacy no-arg margin: 0.0 sentinel. Equity margin is account-mode and
+    // position-dependent; callers must use the price/quantity overload below.
+    // Returning 0 (rather than a stale 0.5) ensures any unmigrated caller
+    // surfaces an obvious bug instead of silently using nonsense margin.
     double get_margin_requirement() const override {
-        return spec_.margin_requirement;
+        return 0.0;
     }
+    double get_margin_requirement(double price, double quantity) const override;
+
     std::string get_trading_hours() const override {
         return spec_.trading_hours;
     }
@@ -111,6 +149,31 @@ public:
      */
     bool is_marginable() const {
         return spec_.is_marginable;
+    }
+
+    /**
+     * @brief Get the account mode (CASH or REG_T).
+     */
+    EquityAccountMode get_account_mode() const {
+        return spec_.account_mode;
+    }
+
+    /**
+     * @brief Whether shorting is permitted for this instrument.
+     *
+     * True only when account_mode is REG_T AND short_selling_allowed is set.
+     * Strategies must clamp short signals to zero when this returns false.
+     */
+    bool is_short_allowed() const {
+        return spec_.account_mode == EquityAccountMode::REG_T &&
+               spec_.short_selling_allowed;
+    }
+
+    /**
+     * @brief Access the underlying spec (for borrow-fee config etc.).
+     */
+    const EquitySpec& get_spec() const {
+        return spec_;
     }
 
     /**

--- a/include/trade_ngin/instruments/futures.hpp
+++ b/include/trade_ngin/instruments/futures.hpp
@@ -2,6 +2,7 @@
 #pragma once
 
 #include <chrono>
+#include <cmath>
 #include <string>
 #include "trade_ngin/instruments/instrument.hpp"
 
@@ -66,6 +67,14 @@ public:
     bool is_tradeable() const override;
     double get_margin_requirement() const override {
         return spec_.initial_margin;
+    }
+    // Override the price/qty overload so the base-class default (which forwards
+    // to the no-arg version returning per-contract margin) doesn't strip the
+    // contract-count multiplication. MarginManager calls this overload and
+    // expects total dollars, not per-contract.
+    double get_margin_requirement(double price, double quantity) const override {
+        (void)price;  // Futures margin is a fixed dollar amount per contract.
+        return std::abs(quantity) * spec_.initial_margin;
     }
     std::string get_trading_hours() const override {
         return spec_.trading_hours;

--- a/include/trade_ngin/instruments/instrument.hpp
+++ b/include/trade_ngin/instruments/instrument.hpp
@@ -62,9 +62,31 @@ public:
     virtual bool is_tradeable() const = 0;
 
     /**
-     * @brief Get margin requirement
+     * @brief Get margin requirement (legacy, no-context form).
+     *
+     * For futures this returns the contract's initial-margin dollar amount.
+     * For equities this is unreliable -- equity margin depends on price and
+     * signed quantity (cash account: full notional; Reg T long: 50%; Reg T
+     * short: 150%). Prefer the price/quantity overload below for equities.
      */
     virtual double get_margin_requirement() const = 0;
+
+    /**
+     * @brief Get margin requirement given price and signed quantity.
+     *
+     * Default body forwards to the no-arg version so futures and other
+     * legacy instruments don't need to override. Equities override this to
+     * compute account-mode-aware margin (cash vs Reg T, long vs short).
+     *
+     * @param price Reference price per unit (e.g. close)
+     * @param quantity Signed share/contract count (positive long, negative short)
+     * @return Margin requirement in dollars
+     */
+    virtual double get_margin_requirement(double price, double quantity) const {
+        (void)price;
+        (void)quantity;
+        return get_margin_requirement();
+    }
 
     /**
      * @brief Get trading hours

--- a/include/trade_ngin/live/margin_manager.hpp
+++ b/include/trade_ngin/live/margin_manager.hpp
@@ -159,15 +159,21 @@ private:
     Result<std::shared_ptr<Instrument>> get_instrument_safe(const std::string& symbol);
 
     /**
-     * Extract margin requirements from instrument
+     * Extract margin requirements from instrument.
+     *
+     * Equities need price+signed quantity to compute account-mode-aware
+     * margin (cash: full notional; Reg T long: 50%; Reg T short: 150%).
+     * Futures ignore price (their margin is fixed dollar amount per contract).
      *
      * @param instrument Instrument pointer
-     * @param quantity Position quantity
+     * @param quantity Position quantity (signed)
+     * @param market_price Reference price per unit; required for equities
      * @return Pair of (initial_margin, maintenance_margin)
      */
     std::pair<double, double> extract_margin_requirements(
         const std::shared_ptr<Instrument>& instrument,
-        double quantity) const;
+        double quantity,
+        double market_price) const;
 };
 
 } // namespace trade_ngin

--- a/include/trade_ngin/portfolio/portfolio_manager.hpp
+++ b/include/trade_ngin/portfolio/portfolio_manager.hpp
@@ -166,6 +166,19 @@ public:
     void clear_execution_history();
 
     /**
+     * @brief Append a synthetic ExecutionReport to a strategy's history.
+     *
+     * Used by carry-cost accrual (e.g., overnight borrow fees) to keep the
+     * per-execution audit trail in sync with the daily equity-curve cost
+     * roll-up. The exec is appended as-is; callers are responsible for
+     * setting symbol, filled_quantity (typically 0 for synthetic carry),
+     * timestamps, and cost fields. Idempotent at the per-call level; not
+     * deduped across calls.
+     */
+    void append_synthetic_execution(const std::string& strategy_id,
+                                    const ExecutionReport& exec);
+
+    /**
      * @brief Clear all executions including strategy-level (used during warmup)
      */
     void clear_all_executions();

--- a/include/trade_ngin/transaction_cost/spread_model.hpp
+++ b/include/trade_ngin/transaction_cost/spread_model.hpp
@@ -89,6 +89,18 @@ public:
     double get_volatility_multiplier(const std::string& symbol) const;
 
     /**
+     * @brief Get annualized volatility for a symbol from stored log returns.
+     *
+     * Computes sample std dev (n-1) of log returns, annualized by sqrt(252).
+     * Used by TransactionCostManager::calculate_overnight_borrow_fees for
+     * the borrow-rate volatility multiplier.
+     *
+     * @param symbol Instrument symbol
+     * @return Annualized volatility, or 0.25 (25%) if insufficient data
+     */
+    double get_annual_volatility(const std::string& symbol) const;
+
+    /**
      * @brief Clear stored data for a symbol
      */
     void clear_symbol_data(const std::string& symbol);

--- a/include/trade_ngin/transaction_cost/transaction_cost_manager.hpp
+++ b/include/trade_ngin/transaction_cost/transaction_cost_manager.hpp
@@ -11,6 +11,11 @@
 #include "trade_ngin/transaction_cost/spread_model.hpp"
 
 namespace trade_ngin {
+
+// Forward decl: borrow-fee path uses InstrumentRegistry to look up the
+// EquityInstrument per symbol. Full header included in the .cpp.
+class InstrumentRegistry;
+
 namespace transaction_cost {
 
 /**
@@ -137,6 +142,12 @@ public:
     double get_volatility_multiplier(const std::string& symbol) const;
 
     /**
+     * @brief Get annualized volatility for a symbol (used by borrow-fee model).
+     * Returns 0.25 (25%) fallback if no observations are available.
+     */
+    double get_annual_volatility(const std::string& symbol) const;
+
+    /**
      * @brief Get asset configuration for a symbol
      */
     AssetCostConfig get_asset_config(const std::string& symbol) const;
@@ -168,6 +179,33 @@ public:
         const std::vector<std::string>& symbols,
         const std::unordered_map<std::string, std::vector<Bar>>& bars_by_symbol,
         int adv_lookback_days = 20);
+
+    /**
+     * @brief Compute overnight borrow fees for short equity positions.
+     *
+     * For each short equity position, derives an annual borrow rate using
+     * multi-factor scoring per audit §3.2:
+     *   - Dollar volume (ADV × price) as a proxy for liquidity / lendable supply
+     *   - Price level (<$5 high risk, <$10 medium risk)
+     *   - is_easy_to_borrow flag (false forces HTB tier)
+     * Then scales by a volatility multiplier (clamp(annual_vol / 0.25, 1.0, 3.0)).
+     * Per-symbol `borrow_rate_override` on EquitySpec bypasses the formula.
+     *
+     * Daily fee = effective_annual_rate * |short_position_value| / 365.
+     *
+     * Caller (backtest daily loop or live EOD finalizer) sums the returned
+     * map and adds to total_transaction_costs for the day. Returns empty map
+     * if no shorts present. Long positions and non-equity positions are
+     * skipped.
+     *
+     * Market cap data isn't available in the system today; the dollar-volume
+     * fallback degrades precision but preserves directional correctness per
+     * audit §3.2.
+     */
+    std::unordered_map<std::string, double> calculate_overnight_borrow_fees(
+        const std::unordered_map<std::string, Position>& positions,
+        const std::unordered_map<std::string, double>& current_prices,
+        const InstrumentRegistry& registry) const;
 
     /**
      * @brief Clear all market data (for new backtest run)

--- a/include/trade_ngin/transaction_cost/transaction_cost_manager.hpp
+++ b/include/trade_ngin/transaction_cost/transaction_cost_manager.hpp
@@ -186,7 +186,7 @@ public:
      * For each short equity position, derives an annual borrow rate using
      * multi-factor scoring per audit §3.2:
      *   - Dollar volume (ADV × price) as a proxy for liquidity / lendable supply
-     *   - Price level (<$5 high risk, <$10 medium risk)
+     *   - Price level (<$5 high risk; no medium tier currently implemented)
      *   - is_easy_to_borrow flag (false forces HTB tier)
      * Then scales by a volatility multiplier (clamp(annual_vol / 0.25, 1.0, 3.0)).
      * Per-symbol `borrow_rate_override` on EquitySpec bypasses the formula.

--- a/src/backtest/backtest_coordinator.cpp
+++ b/src/backtest/backtest_coordinator.cpp
@@ -690,18 +690,43 @@ Result<void> BacktestCoordinator::process_portfolio_day(
         pnl_manager_->update_previous_closes(current_close_prices);
 
         // Phase 2 §3.2: accrue overnight borrow fees on open short equity
-        // positions. Adds to today's transaction costs so the equity curve
-        // reflects the cost of holding shorts overnight. No-op when no shorts
-        // are open (the common case in long-only backtests).
+        // positions. Per-strategy attribution: iterate strategy_positions,
+        // compute each strategy's borrow fee on its own shorts, both add to
+        // today's transaction costs (equity curve) AND emit a synthetic
+        // zero-quantity ExecutionReport so the DB / CSV / metrics audit
+        // trail stays in sync with the equity-curve drop.
+        // No-op when no shorts are open (the common case for long-only).
         if (execution_manager_ && registry_) {
-            auto portfolio_positions_for_borrow = portfolio->get_portfolio_positions();
-            auto borrow_fees = execution_manager_->get_transaction_cost_manager()
-                .calculate_overnight_borrow_fees(
-                    portfolio_positions_for_borrow,
-                    current_close_prices,
-                    *registry_);
-            for (const auto& [sym, fee] : borrow_fees) {
-                total_transaction_costs += fee;
+            auto& tcm = execution_manager_->get_transaction_cost_manager();
+            auto strategy_positions_for_borrow = portfolio->get_strategy_positions();
+            for (const auto& [strategy_id, strat_positions] : strategy_positions_for_borrow) {
+                auto strat_borrow_fees = tcm.calculate_overnight_borrow_fees(
+                    strat_positions, current_close_prices, *registry_);
+                for (const auto& [sym, fee] : strat_borrow_fees) {
+                    if (fee <= 0.0) continue;
+                    total_transaction_costs += fee;
+
+                    // Synthesize a zero-quantity exec so per-strategy and
+                    // per-symbol metrics (profit_factor, win_rate, symbol
+                    // PnL) include the borrow drag instead of silently
+                    // excluding it.
+                    ExecutionReport borrow_exec;
+                    borrow_exec.exec_id = "BORROW_" + strategy_id + "_" + sym;
+                    borrow_exec.order_id = borrow_exec.exec_id;
+                    borrow_exec.symbol = sym;
+                    borrow_exec.side = Side::SELL;
+                    borrow_exec.filled_quantity = Quantity(0.0);
+                    auto price_it = current_close_prices.find(sym);
+                    borrow_exec.fill_price = Price(
+                        price_it != current_close_prices.end() ? price_it->second : 0.0);
+                    borrow_exec.fill_time = timestamp;
+                    borrow_exec.commissions_fees = Decimal(fee);
+                    borrow_exec.implicit_price_impact = Decimal(0.0);
+                    borrow_exec.slippage_market_impact = Decimal(0.0);
+                    borrow_exec.total_transaction_costs = Decimal(fee);
+                    borrow_exec.is_partial = false;
+                    portfolio->append_synthetic_execution(strategy_id, borrow_exec);
+                }
             }
         }
 

--- a/src/backtest/backtest_coordinator.cpp
+++ b/src/backtest/backtest_coordinator.cpp
@@ -689,6 +689,22 @@ Result<void> BacktestCoordinator::process_portfolio_day(
         // Update previous closes for next iteration
         pnl_manager_->update_previous_closes(current_close_prices);
 
+        // Phase 2 §3.2: accrue overnight borrow fees on open short equity
+        // positions. Adds to today's transaction costs so the equity curve
+        // reflects the cost of holding shorts overnight. No-op when no shorts
+        // are open (the common case in long-only backtests).
+        if (execution_manager_ && registry_) {
+            auto portfolio_positions_for_borrow = portfolio->get_portfolio_positions();
+            auto borrow_fees = execution_manager_->get_transaction_cost_manager()
+                .calculate_overnight_borrow_fees(
+                    portfolio_positions_for_borrow,
+                    current_close_prices,
+                    *registry_);
+            for (const auto& [sym, fee] : borrow_fees) {
+                total_transaction_costs += fee;
+            }
+        }
+
         // Calculate portfolio value: previous value + daily PnL - transaction costs
         double portfolio_value =
             equity_curve.empty() ? initial_capital : equity_curve.back().second;

--- a/src/core/email_sender.cpp
+++ b/src/core/email_sender.cpp
@@ -1068,14 +1068,22 @@ std::string EmailSender::format_positions_table(
                     throw std::runtime_error("Invalid multiplier for: " + lookup_sym);
                 }
 
-                double contracts_abs = std::abs(position.quantity.as_double());
-                double initial_margin_per_contract = instrument->get_margin_requirement();
-                if (initial_margin_per_contract <= 0) {
+                // Use the price/quantity overload so equities get
+                // account-mode-aware margin (CASH = full notional, REG_T = 50%
+                // long / 150% short) and futures get total dollars (now
+                // multiplied internally by FuturesInstrument's new override).
+                const double signed_qty = position.quantity.as_double();
+                const double price_for_margin = position.average_price.as_double();
+                double total_initial_margin =
+                    instrument->get_margin_requirement(price_for_margin, signed_qty);
+                if (total_initial_margin <= 0) {
                     ERROR("CRITICAL: Invalid margin requirement " +
-                          std::to_string(initial_margin_per_contract) + " for " + lookup_sym);
+                          std::to_string(total_initial_margin) + " for " + lookup_sym +
+                          " (price=" + std::to_string(price_for_margin) +
+                          ", qty=" + std::to_string(signed_qty) + ")");
                     throw std::runtime_error("Invalid margin requirement for: " + lookup_sym);
                 }
-                total_margin_posted += contracts_abs * initial_margin_per_contract;
+                total_margin_posted += total_initial_margin;
 
             } catch (const std::exception& e) {
                 ERROR("CRITICAL: Failed to get instrument data for " + position.symbol + ": " +
@@ -3095,14 +3103,20 @@ std::string EmailSender::format_single_strategy_table(
                     throw std::runtime_error("Invalid multiplier for: " + lookup_sym);
                 }
 
-                double contracts_abs = std::abs(position.quantity.as_double());
-                double initial_margin_per_contract = instrument->get_margin_requirement();
-                if (initial_margin_per_contract <= 0) {
+                // Price/qty overload: returns total dollars for both equities
+                // (account-mode-aware notional fraction) and futures (|qty| ×
+                // per-contract margin, after the FuturesInstrument override).
+                const double signed_qty = position.quantity.as_double();
+                const double price_for_margin = position.average_price.as_double();
+                margin_for_position =
+                    instrument->get_margin_requirement(price_for_margin, signed_qty);
+                if (margin_for_position <= 0) {
                     ERROR("CRITICAL: Invalid margin requirement " +
-                          std::to_string(initial_margin_per_contract) + " for " + lookup_sym);
+                          std::to_string(margin_for_position) + " for " + lookup_sym +
+                          " (price=" + std::to_string(price_for_margin) +
+                          ", qty=" + std::to_string(signed_qty) + ")");
                     throw std::runtime_error("Invalid margin requirement for: " + lookup_sym);
                 }
-                margin_for_position = contracts_abs * initial_margin_per_contract;
                 total_margin_posted += margin_for_position;
 
             } catch (const std::exception& e) {
@@ -3243,9 +3257,13 @@ std::string EmailSender::format_strategy_positions_tables(
                                           position.average_price.as_double() * contract_multiplier;
                         portfolio_total_notional += std::abs(notional);
 
-                        double contracts_abs = std::abs(position.quantity.as_double());
-                        double initial_margin = instrument->get_margin_requirement();
-                        portfolio_total_margin += contracts_abs * initial_margin;
+                        // Use the price/qty overload (returns total dollars).
+                        // Required for equities to get account-mode-aware
+                        // margin instead of the legacy 0.0 sentinel.
+                        const double signed_qty = position.quantity.as_double();
+                        const double price_for_margin = position.average_price.as_double();
+                        portfolio_total_margin +=
+                            instrument->get_margin_requirement(price_for_margin, signed_qty);
                     }
                 } catch (...) {
                     // Already logged in format_single_strategy_table

--- a/src/instruments/equity.cpp
+++ b/src/instruments/equity.cpp
@@ -80,6 +80,23 @@ double EquityInstrument::calculate_commission(double quantity) const {
     return std::abs(quantity) * spec_.commission_per_share;
 }
 
+double EquityInstrument::get_margin_requirement(double price, double quantity) const {
+    // Closes audit §1.3: real Reg T-aware margin math, replacing the
+    // structurally broken margin_requirement{0.5} treated as $/share.
+    const double notional = std::abs(quantity) * price;
+    if (spec_.account_mode == EquityAccountMode::CASH) {
+        // Cash account: full position value tied up; no margin extension.
+        return notional;
+    }
+    // REG_T:
+    if (quantity >= 0.0) {
+        // Long: 50% initial margin under Reg T.
+        return notional * 0.50;
+    }
+    // Short: 100% proceeds collateral + 50% maintenance margin = 150% notional.
+    return notional * 1.50;
+}
+
 std::optional<DividendInfo> EquityInstrument::get_next_dividend(const Timestamp& from) const {
     auto it = std::find_if(spec_.dividends.begin(), spec_.dividends.end(),
                            [&from](const DividendInfo& div) { return div.ex_date > from; });

--- a/src/live/margin_manager.cpp
+++ b/src/live/margin_manager.cpp
@@ -90,7 +90,6 @@ Result<std::pair<double, double>> MarginManager::calculate_position_margin(
     double quantity,
     double market_price) {
 
-    (void)market_price;
     // Get instrument from registry
     auto instrument_result = get_instrument_safe(symbol);
     if (instrument_result.is_error()) {
@@ -102,8 +101,10 @@ Result<std::pair<double, double>> MarginManager::calculate_position_margin(
 
     auto instrument = instrument_result.value();
 
-    // Extract margin requirements
-    auto [initial_margin, maintenance_margin] = extract_margin_requirements(instrument, quantity);
+    // Extract margin requirements. market_price is now threaded through so
+    // equity margin can be computed correctly via the price/qty overload.
+    auto [initial_margin, maintenance_margin] = extract_margin_requirements(
+        instrument, quantity, market_price);
 
     return Result<std::pair<double, double>>(std::make_pair(initial_margin, maintenance_margin));
 }
@@ -280,32 +281,40 @@ Result<std::shared_ptr<Instrument>> MarginManager::get_instrument_safe(const std
 
 std::pair<double, double> MarginManager::extract_margin_requirements(
     const std::shared_ptr<Instrument>& instrument,
-    double quantity) const {
+    double quantity,
+    double market_price) const {
 
     double contracts_abs = std::abs(quantity);
 
-    // Get initial margin
-    double initial_margin_per_contract = instrument->get_margin_requirement();
-    if (initial_margin_per_contract <= 0) {
-        ERROR("Invalid initial margin " + std::to_string(initial_margin_per_contract) +
-              " for " + instrument->get_symbol());
+    // Equities: use the price/quantity overload to get account-mode-aware
+    // dollar margin (CASH = full notional, REG_T long = 50%, short = 150%).
+    // Futures: the base class default forwards to the no-arg version, so
+    // get_margin_requirement(price, qty) returns the same fixed dollar
+    // amount per contract that the legacy path used.
+    double total_initial_margin = instrument->get_margin_requirement(
+        market_price, quantity);
+    if (total_initial_margin <= 0) {
+        ERROR("Invalid initial margin " + std::to_string(total_initial_margin) +
+              " for " + instrument->get_symbol() +
+              " (price=" + std::to_string(market_price) +
+              ", qty=" + std::to_string(quantity) + ")");
         throw std::runtime_error("Invalid initial margin for: " + instrument->get_symbol());
     }
-    double total_initial_margin = contracts_abs * initial_margin_per_contract;
 
-    // Try to get maintenance margin if available (for futures)
-    double maintenance_margin_per_contract = initial_margin_per_contract;
+    // Maintenance margin: futures expose a distinct value; equities and
+    // others fall back to using initial margin as the maintenance figure.
+    double total_maintenance_margin = total_initial_margin;
     if (auto futures_ptr = std::dynamic_pointer_cast<FuturesInstrument>(instrument)) {
-        maintenance_margin_per_contract = futures_ptr->get_maintenance_margin();
+        double maintenance_margin_per_contract = futures_ptr->get_maintenance_margin();
         if (maintenance_margin_per_contract <= 0) {
             ERROR("Invalid maintenance margin " +
                   std::to_string(maintenance_margin_per_contract) +
                   " for " + instrument->get_symbol());
-            // Fall back to initial margin
-            maintenance_margin_per_contract = initial_margin_per_contract;
+            // Fall back to initial margin per contract.
+            maintenance_margin_per_contract = futures_ptr->get_margin_requirement();
         }
+        total_maintenance_margin = contracts_abs * maintenance_margin_per_contract;
     }
-    double total_maintenance_margin = contracts_abs * maintenance_margin_per_contract;
 
     return std::make_pair(total_initial_margin, total_maintenance_margin);
 }

--- a/src/portfolio/portfolio_manager.cpp
+++ b/src/portfolio/portfolio_manager.cpp
@@ -1332,6 +1332,12 @@ PortfolioManager::get_strategy_executions() const {
     return strategy_executions_;
 }
 
+void PortfolioManager::append_synthetic_execution(const std::string& strategy_id,
+                                                  const ExecutionReport& exec) {
+    std::lock_guard<std::mutex> lock(mutex_);
+    strategy_executions_[strategy_id].push_back(exec);
+}
+
 void PortfolioManager::clear_execution_history() {
     std::lock_guard<std::mutex> lock(mutex_);
     // Only clear portfolio-level executions (recent_executions_)

--- a/src/strategy/mean_reversion.cpp
+++ b/src/strategy/mean_reversion.cpp
@@ -138,6 +138,18 @@ Result<void> MeanReversionStrategy::on_data(const std::vector<Bar>& data) {
             if (std::abs(signal) > 0.01) {
                 double position_size = calculate_position_size(bar.symbol, bar.close.as_double(), inst_data.current_volatility);
                 double new_target = signal * position_size;
+                // Phase 2 short-selling gate (audit §3.2). If the instrument
+                // is an equity that isn't REG_T with short_selling_allowed,
+                // clamp the short to zero -- cash accounts can't short.
+                if (new_target < 0.0 && registry_) {
+                    auto equity = registry_->get_equity_instrument(bar.symbol);
+                    if (equity && !equity->is_short_allowed()) {
+                        WARN("Shorting disallowed for " + bar.symbol +
+                             " (account_mode=CASH or short_selling_allowed=false). "
+                             "Clamping short target " + std::to_string(new_target) + " to 0.");
+                        new_target = 0.0;
+                    }
+                }
                 inst_data.target_position = new_target;
             } else {
                 inst_data.target_position = 0.0;

--- a/src/transaction_cost/spread_model.cpp
+++ b/src/transaction_cost/spread_model.cpp
@@ -1,5 +1,6 @@
 #include "trade_ngin/transaction_cost/spread_model.hpp"
 
+#include <cmath>
 #include <numeric>
 #include <stdexcept>
 
@@ -92,6 +93,22 @@ double SpreadModel::get_volatility_multiplier(const std::string& symbol) const {
     // Convert deque to vector for calculation
     std::vector<double> returns(it->second.begin(), it->second.end());
     return calculate_volatility_multiplier(returns);
+}
+
+double SpreadModel::get_annual_volatility(const std::string& symbol) const {
+    auto it = symbol_log_returns_.find(symbol);
+    if (it == symbol_log_returns_.end() || it->second.size() < 2) {
+        // 25% fallback matches the borrow-fee baseline divisor in
+        // TransactionCostManager::calculate_overnight_borrow_fees, so an
+        // unobserved symbol yields vol_multiplier of exactly 1.0.
+        return 0.25;
+    }
+
+    std::vector<double> returns(it->second.begin(), it->second.end());
+    const double mean = compute_mean(returns);
+    const double sigma = compute_stdev(returns, mean);
+    // Annualize assuming daily log returns (252 trading days).
+    return sigma * std::sqrt(252.0);
 }
 
 void SpreadModel::clear_symbol_data(const std::string& symbol) {

--- a/src/transaction_cost/transaction_cost_manager.cpp
+++ b/src/transaction_cost/transaction_cost_manager.cpp
@@ -4,6 +4,8 @@
 #include <cmath>
 
 #include "trade_ngin/core/logger.hpp"
+#include "trade_ngin/instruments/equity.hpp"
+#include "trade_ngin/instruments/instrument_registry.hpp"
 
 namespace trade_ngin {
 namespace transaction_cost {
@@ -137,6 +139,10 @@ double TransactionCostManager::get_volatility_multiplier(const std::string& symb
     return spread_model_.get_volatility_multiplier(symbol);
 }
 
+double TransactionCostManager::get_annual_volatility(const std::string& symbol) const {
+    return spread_model_.get_annual_volatility(symbol);
+}
+
 AssetCostConfig TransactionCostManager::get_asset_config(const std::string& symbol) const {
     return asset_configs_.get_config(symbol);
 }
@@ -194,6 +200,102 @@ int TransactionCostManager::register_equity_costs_from_bars(
 void TransactionCostManager::clear_all_data() {
     spread_model_.clear_all();
     impact_model_.clear_all();
+}
+
+namespace {
+
+// Audit §3.2 risk scoring: count high-risk flags and map to annual base
+// borrow rate. Dollar-volume substitutes for market cap (audit fallback).
+double base_rate_from_flags(int flag_count) {
+    if (flag_count <= 0) return 0.0025;   //  25 bps -- ETB / liquid stocks
+    if (flag_count == 1) return 0.0050;   //  50 bps -- one tilt away from clean
+    if (flag_count == 2) return 0.0150;   // 150 bps -- borderline HTB
+    return 0.0500;                        // 500 bps -- HTB+ proxy
+}
+
+}  // namespace
+
+std::unordered_map<std::string, double>
+TransactionCostManager::calculate_overnight_borrow_fees(
+    const std::unordered_map<std::string, Position>& positions,
+    const std::unordered_map<std::string, double>& current_prices,
+    const InstrumentRegistry& registry) const {
+
+    std::unordered_map<std::string, double> fees;
+
+    for (const auto& [symbol, position] : positions) {
+        const double qty = position.quantity.as_double();
+        if (qty >= 0.0) {
+            continue;  // Only shorts accrue borrow fees.
+        }
+
+        auto equity = registry.get_equity_instrument(symbol);
+        if (!equity) {
+            // Non-equity (e.g., short futures) doesn't pay equity borrow fees.
+            continue;
+        }
+
+        // Resolve current price.
+        double price = 0.0;
+        auto price_it = current_prices.find(symbol);
+        if (price_it != current_prices.end()) {
+            price = price_it->second;
+        } else {
+            price = position.average_price.as_double();
+            WARN("calculate_overnight_borrow_fees: no current price for " +
+                 symbol + ", using avg_price " + std::to_string(price));
+        }
+        if (price <= 0.0) {
+            WARN("calculate_overnight_borrow_fees: non-positive price for " +
+                 symbol + ", skipping");
+            continue;
+        }
+
+        const double short_position_value = std::abs(qty) * price;
+        const auto& spec = equity->get_spec();
+        double annual_rate;
+
+        if (spec.borrow_rate_override >= 0.0) {
+            // Broker-provided rate or test override; formula bypassed.
+            annual_rate = spec.borrow_rate_override;
+        } else {
+            // Multi-factor scoring per audit §3.2.
+            int flag_count = 0;
+
+            // Dollar-volume signal: ADV × price. <$5M/day flags as high risk.
+            const double adv = impact_model_.get_adv(symbol);
+            const double dollar_volume = adv * price;
+            if (dollar_volume > 0.0 && dollar_volume < 5'000'000.0) {
+                ++flag_count;
+            }
+
+            // Price-level signal: penny / micro-cap risk.
+            if (price < 5.0) {
+                ++flag_count;
+            }
+
+            // HTB override: explicit is_easy_to_borrow=false forces high tier.
+            if (!spec.is_easy_to_borrow) {
+                ++flag_count;
+            }
+
+            const double base = base_rate_from_flags(flag_count);
+
+            // Volatility multiplier: clamp(annual_vol / 0.25, 1.0, 3.0).
+            const double annual_vol = spread_model_.get_annual_volatility(symbol);
+            double vol_mult = annual_vol / 0.25;
+            if (vol_mult < 1.0) vol_mult = 1.0;
+            if (vol_mult > 3.0) vol_mult = 3.0;
+
+            annual_rate = base * vol_mult;
+        }
+
+        // Daily fee charged per overnight position held.
+        const double daily_fee = annual_rate * short_position_value / 365.0;
+        fees[symbol] = daily_fee;
+    }
+
+    return fees;
 }
 
 }  // namespace transaction_cost

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -28,6 +28,7 @@ set(TEST_SOURCES
     instruments/test_exchange_json_wireup.cpp
     instruments/test_equity_margin_cash_regt.cpp
     instruments/test_equity_leverage_guardrail.cpp
+    instruments/test_futures_margin_overload.cpp
     strategy/test_base_strategy.cpp
     strategy/test_trend_following.cpp
     strategy/test_mean_reversion_backtest.cpp

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -20,11 +20,14 @@ set(TEST_SOURCES
     backtesting/test_transaction_cost_analysis.cpp
     transaction_cost/test_adv_classifier_wireup.cpp
     transaction_cost/test_unknown_equity_costs_dispatch.cpp
+    transaction_cost/test_equity_borrow_fees.cpp
     # backtesting/test_engine.cpp  # Deprecated - BacktestEngine replaced by BacktestCoordinator
     execution/test_execution_engine.cpp
     portfolio/test_portfolio_manager.cpp
     instruments/test_equity_instrument_holiday_check_wired.cpp
     instruments/test_exchange_json_wireup.cpp
+    instruments/test_equity_margin_cash_regt.cpp
+    instruments/test_equity_leverage_guardrail.cpp
     strategy/test_base_strategy.cpp
     strategy/test_trend_following.cpp
     strategy/test_mean_reversion_backtest.cpp

--- a/tests/instruments/test_equity_leverage_guardrail.cpp
+++ b/tests/instruments/test_equity_leverage_guardrail.cpp
@@ -1,0 +1,93 @@
+#include <gtest/gtest.h>
+#include <memory>
+#include "../core/test_base.hpp"
+#include "../data/test_db_utils.hpp"
+#include "trade_ngin/instruments/equity.hpp"
+#include "trade_ngin/instruments/instrument_registry.hpp"
+
+using namespace trade_ngin;
+using namespace trade_ngin::testing;
+
+// Audit test T2.4 -- leverage guardrail (audit §3.3). The equity apps refuse
+// to start if max_gross_leverage > 1.0 and any CASH-mode equity is in the
+// symbol list. Cash accounts can't borrow, so a leverage cap above 1.0 is
+// structurally invalid.
+//
+// The guard logic lives inline in the apps' main(); this test verifies the
+// building blocks (instrument account_mode + registry lookup) the guard
+// depends on, plus reproduces the same check pattern the apps execute.
+
+namespace {
+
+// Mimic the exact check the equity apps perform after load_equity_instruments.
+// Returns true if the guardrail should refuse startup.
+bool would_refuse_startup(const std::vector<std::string>& symbols,
+                          const InstrumentRegistry& registry,
+                          double max_gross_leverage) {
+    if (max_gross_leverage <= 1.0) return false;
+    for (const auto& symbol : symbols) {
+        auto inst = registry.get_equity_instrument(symbol);
+        if (inst && inst->get_account_mode() == EquityAccountMode::CASH) {
+            return true;
+        }
+    }
+    return false;
+}
+
+class LeverageGuardrailTest : public TestBase {
+protected:
+    void SetUp() override {
+        TestBase::SetUp();
+        auto& registry = InstrumentRegistry::instance();
+        auto db = std::make_shared<MockPostgresDatabase>("mock://leverage_guardrail_test");
+        ASSERT_TRUE(db->connect().is_ok());
+        (void)registry.initialize(db);  // Idempotent.
+    }
+};
+
+}  // namespace
+
+TEST_F(LeverageGuardrailTest, CashEquityWithLeverageAboveOneRefuses) {
+    auto& registry = InstrumentRegistry::instance();
+    const std::string sym = "PHASE2_T24_CASH_AAPL";
+
+    EquitySpec spec;
+    spec.exchange = "NASDAQ";
+    spec.currency = "USD";
+    spec.tick_size = 0.01;
+    spec.account_mode = EquityAccountMode::CASH;
+    registry.register_instrument(sym, std::make_shared<EquityInstrument>(sym, spec));
+
+    EXPECT_TRUE(would_refuse_startup({sym}, registry, 2.0))
+        << "Cash equity with max_gross_leverage=2.0 must trip the guardrail.";
+}
+
+TEST_F(LeverageGuardrailTest, CashEquityWithLeverageOneAccepts) {
+    auto& registry = InstrumentRegistry::instance();
+    const std::string sym = "PHASE2_T24_CASH_AAPL_LEV1";
+
+    EquitySpec spec;
+    spec.exchange = "NASDAQ";
+    spec.currency = "USD";
+    spec.tick_size = 0.01;
+    spec.account_mode = EquityAccountMode::CASH;
+    registry.register_instrument(sym, std::make_shared<EquityInstrument>(sym, spec));
+
+    EXPECT_FALSE(would_refuse_startup({sym}, registry, 1.0))
+        << "Cash equity at max_gross_leverage=1.0 (the valid cap) must NOT trip the guardrail.";
+}
+
+TEST_F(LeverageGuardrailTest, RegTEquityWithLeverageAboveOneAccepts) {
+    auto& registry = InstrumentRegistry::instance();
+    const std::string sym = "PHASE2_T24_REGT_MSFT";
+
+    EquitySpec spec;
+    spec.exchange = "NASDAQ";
+    spec.currency = "USD";
+    spec.tick_size = 0.01;
+    spec.account_mode = EquityAccountMode::REG_T;
+    registry.register_instrument(sym, std::make_shared<EquityInstrument>(sym, spec));
+
+    EXPECT_FALSE(would_refuse_startup({sym}, registry, 2.0))
+        << "REG_T equities permit leverage > 1.0; guardrail must not fire.";
+}

--- a/tests/instruments/test_equity_margin_cash_regt.cpp
+++ b/tests/instruments/test_equity_margin_cash_regt.cpp
@@ -1,0 +1,89 @@
+#include <gtest/gtest.h>
+#include "trade_ngin/instruments/equity.hpp"
+
+using namespace trade_ngin;
+
+// Audit tests T2.1-T2.3 + T2.5 -- exercise the new
+// EquityInstrument::get_margin_requirement(price, qty) overload and the
+// short-selling gate. Closes audit §1.3 + §3.1 + §3.2 verification surface.
+
+namespace {
+
+EquitySpec make_cash_spec() {
+    EquitySpec spec;
+    spec.exchange = "NASDAQ";
+    spec.currency = "USD";
+    spec.tick_size = 0.01;
+    spec.account_mode = EquityAccountMode::CASH;
+    spec.short_selling_allowed = false;
+    return spec;
+}
+
+EquitySpec make_regt_spec(bool shorts_allowed) {
+    EquitySpec spec;
+    spec.exchange = "NASDAQ";
+    spec.currency = "USD";
+    spec.tick_size = 0.01;
+    spec.account_mode = EquityAccountMode::REG_T;
+    spec.short_selling_allowed = shorts_allowed;
+    return spec;
+}
+
+}  // namespace
+
+// T2.1: Cash account, long 100 AAPL @ $150 -> full notional posted.
+TEST(EquityCashAccountLongTest, FullNotionalIsPosted) {
+    EquityInstrument aapl("AAPL", make_cash_spec());
+    EXPECT_DOUBLE_EQ(aapl.get_margin_requirement(150.0, 100.0), 15000.0);
+}
+
+// T2.2: Reg T account, long 100 AAPL @ $150 -> 50% notional posted.
+TEST(EquityRegTLongTest, FiftyPercentNotionalIsPosted) {
+    EquityInstrument aapl("AAPL", make_regt_spec(false));
+    EXPECT_DOUBLE_EQ(aapl.get_margin_requirement(150.0, 100.0), 7500.0);
+}
+
+// T2.3: Reg T account with shorts allowed, short 100 AAPL @ $150 ->
+// 150% notional (100% proceeds + 50% maintenance).
+TEST(EquityRegTShortTest, OneHundredFiftyPercentNotionalIsPosted) {
+    EquityInstrument aapl("AAPL", make_regt_spec(true));
+    EXPECT_DOUBLE_EQ(aapl.get_margin_requirement(150.0, -100.0), 22500.0);
+}
+
+// T2.5: Cash account rejects shorts via is_short_allowed.
+// Strategy clamps when this is false; verifying the accessor pins the gate.
+TEST(EquityShortDisabledInCashTest, CashAccountRejectsShorts) {
+    EquityInstrument aapl("AAPL", make_cash_spec());
+    EXPECT_FALSE(aapl.is_short_allowed())
+        << "Cash account must always reject shorts regardless of short_selling_allowed flag.";
+}
+
+TEST(EquityShortDisabledInCashTest, RegTWithoutFlagRejectsShorts) {
+    EquityInstrument aapl("AAPL", make_regt_spec(false));
+    EXPECT_FALSE(aapl.is_short_allowed())
+        << "Reg T without short_selling_allowed should still reject shorts.";
+}
+
+TEST(EquityShortDisabledInCashTest, RegTWithFlagAllowsShorts) {
+    EquityInstrument aapl("AAPL", make_regt_spec(true));
+    EXPECT_TRUE(aapl.is_short_allowed())
+        << "Reg T with short_selling_allowed=true must allow shorts.";
+}
+
+// Account-mode accessor sanity.
+TEST(EquityAccountModeTest, GetAccountModeReturnsConfigured) {
+    EquityInstrument cash_inst("AAPL", make_cash_spec());
+    EquityInstrument regt_inst("MSFT", make_regt_spec(true));
+    EXPECT_EQ(cash_inst.get_account_mode(), EquityAccountMode::CASH);
+    EXPECT_EQ(regt_inst.get_account_mode(), EquityAccountMode::REG_T);
+}
+
+// Legacy no-arg overload returns 0.0 (sentinel) for equities -- forces
+// migration to the price/qty overload. Documents the contract for any
+// caller that hasn't migrated yet.
+TEST(EquityMarginLegacyApiTest, NoArgOverloadReturnsZeroSentinel) {
+    EquityInstrument aapl("AAPL", make_cash_spec());
+    EXPECT_DOUBLE_EQ(aapl.get_margin_requirement(), 0.0)
+        << "Legacy no-arg margin must return 0 sentinel; callers must use "
+           "get_margin_requirement(price, quantity).";
+}

--- a/tests/instruments/test_futures_margin_overload.cpp
+++ b/tests/instruments/test_futures_margin_overload.cpp
@@ -1,0 +1,72 @@
+#include <gtest/gtest.h>
+#include "trade_ngin/instruments/futures.hpp"
+
+using namespace trade_ngin;
+
+// Regression test for the post-Phase-2 ultrareview bug_001.
+//
+// Phase 2 changed MarginManager::extract_margin_requirements to call
+// instrument->get_margin_requirement(price, quantity) directly without
+// multiplying by |quantity|, on the assumption the overload returned total
+// dollars. EquityInstrument's override does multiply; but FuturesInstrument
+// originally only overrode the no-arg version, so the base-class default
+// forwarded to per-contract margin -- under-reporting total margin by the
+// contract count and producing impossible initial < maintenance states.
+//
+// This test pins the contract: the price/qty overload must return total
+// dollars across the position (|qty| * initial_margin).
+
+namespace {
+
+FuturesSpec make_es_spec() {
+    FuturesSpec spec;
+    spec.root_symbol = "ES";
+    spec.exchange = "CME";
+    spec.currency = "USD";
+    spec.tick_size = 0.25;
+    spec.multiplier = 50.0;
+    spec.initial_margin = 12000.0;
+    spec.maintenance_margin = 10000.0;
+    spec.trading_hours = "00:00-23:59";
+    return spec;
+}
+
+}  // namespace
+
+// 100-contract ES position should report total initial margin = 100 × $12K = $1.2M.
+TEST(FuturesMarginOverloadTest, OneHundredContractsReportsTotalDollars) {
+    FuturesInstrument es("ES", make_es_spec());
+    EXPECT_DOUBLE_EQ(es.get_margin_requirement(4500.0, 100.0), 1'200'000.0);
+}
+
+// Shorts must also report positive total margin (absolute value of quantity).
+TEST(FuturesMarginOverloadTest, ShortPositionReportsTotalDollars) {
+    FuturesInstrument es("ES", make_es_spec());
+    EXPECT_DOUBLE_EQ(es.get_margin_requirement(4500.0, -50.0), 600'000.0);
+}
+
+// Single contract sanity check.
+TEST(FuturesMarginOverloadTest, SingleContractMatchesPerContractAmount) {
+    FuturesInstrument es("ES", make_es_spec());
+    EXPECT_DOUBLE_EQ(es.get_margin_requirement(4500.0, 1.0), 12'000.0);
+}
+
+// Total initial margin must be >= total maintenance margin for N>1 positions
+// (basic FCM contract that the pre-fix code violated). This pins the
+// invariant by computing both via the same paths MarginManager uses.
+TEST(FuturesMarginOverloadTest, InitialMarginCoversMaintenanceMargin) {
+    FuturesInstrument es("ES", make_es_spec());
+    const double qty = 100.0;
+    const double price = 4500.0;
+    const double total_initial = es.get_margin_requirement(price, qty);
+    const double total_maintenance = std::abs(qty) * es.get_maintenance_margin();
+    EXPECT_GE(total_initial, total_maintenance)
+        << "Initial margin (" << total_initial << ") must cover maintenance ("
+        << total_maintenance << "). FCM rules require initial >= maintenance.";
+}
+
+// Legacy no-arg overload still returns per-contract margin (unchanged).
+TEST(FuturesMarginOverloadTest, NoArgOverloadStillReturnsPerContract) {
+    FuturesInstrument es("ES", make_es_spec());
+    EXPECT_DOUBLE_EQ(es.get_margin_requirement(), 12'000.0);
+}

--- a/tests/transaction_cost/test_equity_borrow_fees.cpp
+++ b/tests/transaction_cost/test_equity_borrow_fees.cpp
@@ -1,0 +1,211 @@
+#include <gtest/gtest.h>
+#include <chrono>
+#include <cmath>
+#include <memory>
+#include <string>
+#include <unordered_map>
+#include <vector>
+#include "../core/test_base.hpp"
+#include "../data/test_db_utils.hpp"
+#include "trade_ngin/core/types.hpp"
+#include "trade_ngin/instruments/equity.hpp"
+#include "trade_ngin/instruments/instrument_registry.hpp"
+#include "trade_ngin/transaction_cost/transaction_cost_manager.hpp"
+
+using namespace trade_ngin;
+using namespace trade_ngin::transaction_cost;
+using namespace trade_ngin::testing;
+
+// Audit tests T2.6, T2.7, T2.8 -- borrow fee model on TCM (§3.2).
+// Multi-factor risk scoring (dollar-volume + price + is_easy_to_borrow flag)
+// × volatility multiplier × short notional / 365. Per-symbol
+// borrow_rate_override bypasses the formula.
+
+namespace {
+
+// Synthesize bars at constant price/volume so ADV is exactly `volume`.
+std::vector<Bar> bars_for(const std::string& symbol, int days, double price, double volume) {
+    std::vector<Bar> bars;
+    bars.reserve(days);
+    auto now = std::chrono::system_clock::now();
+    for (int i = 0; i < days; ++i) {
+        Bar b;
+        b.symbol = symbol;
+        b.timestamp = now - std::chrono::hours(24 * (days - i));
+        b.open = price;
+        b.high = price * 1.001;
+        b.low = price * 0.999;
+        b.close = price;
+        b.volume = volume;
+        bars.push_back(b);
+    }
+    return bars;
+}
+
+EquitySpec regt_spec(bool shorts = true) {
+    EquitySpec spec;
+    spec.exchange = "NASDAQ";
+    spec.currency = "USD";
+    spec.tick_size = 0.01;
+    spec.account_mode = EquityAccountMode::REG_T;
+    spec.short_selling_allowed = shorts;
+    return spec;
+}
+
+class BorrowFeesTest : public TestBase {
+protected:
+    void SetUp() override {
+        TestBase::SetUp();
+        auto& registry = InstrumentRegistry::instance();
+        auto db = std::make_shared<MockPostgresDatabase>("mock://borrow_fees_test");
+        ASSERT_TRUE(db->connect().is_ok());
+        (void)registry.initialize(db);  // Idempotent.
+    }
+};
+
+}  // namespace
+
+// T2.6: REG_T short 100 AAPL @ $150, mega-cap (ADV >10M -> dollar volume
+// >$1.5B/day, no flag), price > $10 (no flag), default is_easy_to_borrow=true
+// (no flag) -> 0 flags -> 25 bps base. Annual vol 25% -> multiplier 1.0.
+// Daily fee = 0.0025 * $15,000 / 365 ~= $0.1027.
+TEST_F(BorrowFeesTest, MegaCapShortYieldsLowFee) {
+    TransactionCostManager::Config tcm_config;
+    TransactionCostManager tcm(tcm_config);
+    auto& registry = InstrumentRegistry::instance();
+
+    const std::string sym = "PHASE2_T26_AAPL";
+    registry.register_instrument(sym, std::make_shared<EquityInstrument>(sym, regt_spec()));
+
+    // Register equity cost config so impact_model knows the ADV.
+    std::unordered_map<std::string, std::vector<Bar>> bars;
+    bars[sym] = bars_for(sym, 30, 150.0, 50'000'000.0);
+    tcm.register_equity_costs_from_bars({sym}, bars);
+
+    // Feed log returns to seed the vol estimate at 25% annualized.
+    // daily_log_return for 25% annual vol = 0.25/sqrt(252) ~ 0.01575.
+    const double daily_ret = 0.25 / std::sqrt(252.0);
+    for (int i = 0; i < 22; ++i) {
+        const double r = (i % 2 == 0) ? daily_ret : -daily_ret;
+        tcm.update_market_data(sym, 50'000'000.0, 150.0 + r * 150.0, 150.0);
+    }
+
+    // Short 100 shares.
+    std::unordered_map<std::string, Position> positions;
+    Position p;
+    p.symbol = sym;
+    p.quantity = -100.0;
+    p.average_price = 150.0;
+    positions[sym] = p;
+
+    std::unordered_map<std::string, double> prices;
+    prices[sym] = 150.0;
+
+    auto fees = tcm.calculate_overnight_borrow_fees(positions, prices, registry);
+    ASSERT_EQ(fees.size(), 1u);
+
+    const double expected = 0.0025 * 15000.0 / 365.0;  // ~0.1027
+    EXPECT_NEAR(fees.at(sym), expected, 0.05)
+        << "Mega-cap short fee should be ~$0.10/day (25 bps × $15K / 365); "
+           "got " << fees.at(sym);
+}
+
+// T2.7: short 100 of small-cap @ $4. ADV 80K -> dollar volume $320K/day -> 1 flag.
+// Price < $5 -> 1 flag. is_easy_to_borrow=true so no extra flag. Total 2 flags
+// -> 150 bps base. Annual vol set to 75% -> raw multiplier 3.0 (capped).
+// Annual rate = 0.015 × 3.0 = 0.045 (4.5%). Daily fee = 0.045 × $400 / 365 ~= $0.0493.
+TEST_F(BorrowFeesTest, SmallCapHighVolYieldsScaledFee) {
+    TransactionCostManager::Config tcm_config;
+    TransactionCostManager tcm(tcm_config);
+    auto& registry = InstrumentRegistry::instance();
+
+    const std::string sym = "PHASE2_T27_SMALLCAP";
+    registry.register_instrument(sym, std::make_shared<EquityInstrument>(sym, regt_spec()));
+
+    std::unordered_map<std::string, std::vector<Bar>> bars;
+    bars[sym] = bars_for(sym, 30, 4.0, 80'000.0);
+    tcm.register_equity_costs_from_bars({sym}, bars);
+
+    // Seed 75% annual vol via daily log returns.
+    const double daily_ret = 0.75 / std::sqrt(252.0);
+    for (int i = 0; i < 22; ++i) {
+        const double r = (i % 2 == 0) ? daily_ret : -daily_ret;
+        tcm.update_market_data(sym, 80'000.0, 4.0 + r * 4.0, 4.0);
+    }
+
+    std::unordered_map<std::string, Position> positions;
+    Position p;
+    p.symbol = sym;
+    p.quantity = -100.0;
+    p.average_price = 4.0;
+    positions[sym] = p;
+
+    std::unordered_map<std::string, double> prices;
+    prices[sym] = 4.0;
+
+    auto fees = tcm.calculate_overnight_borrow_fees(positions, prices, registry);
+    ASSERT_EQ(fees.size(), 1u);
+
+    // 2 flags -> 150 bps base. 75% vol -> 3× cap. Annual rate = 0.045.
+    // Daily fee = 0.045 × $400 / 365 ~= $0.0493
+    const double expected = 0.045 * 400.0 / 365.0;
+    EXPECT_NEAR(fees.at(sym), expected, 0.02)
+        << "Small-cap high-vol short should scale via 2-flag base × 3× vol mult; "
+           "got " << fees.at(sym);
+}
+
+// T2.8: borrow_rate_override = 0.50 (50% annual). Formula is bypassed entirely.
+// Daily fee = 0.50 × $15,000 / 365 ~= $20.55.
+TEST_F(BorrowFeesTest, OverrideBypassesFormula) {
+    TransactionCostManager::Config tcm_config;
+    TransactionCostManager tcm(tcm_config);
+    auto& registry = InstrumentRegistry::instance();
+
+    const std::string sym = "PHASE2_T28_OVERRIDE";
+    EquitySpec spec = regt_spec();
+    spec.borrow_rate_override = 0.50;
+    registry.register_instrument(sym, std::make_shared<EquityInstrument>(sym, spec));
+
+    // No ADV / vol seeding -- override means formula isn't consulted.
+
+    std::unordered_map<std::string, Position> positions;
+    Position p;
+    p.symbol = sym;
+    p.quantity = -100.0;
+    p.average_price = 150.0;
+    positions[sym] = p;
+
+    std::unordered_map<std::string, double> prices;
+    prices[sym] = 150.0;
+
+    auto fees = tcm.calculate_overnight_borrow_fees(positions, prices, registry);
+    ASSERT_EQ(fees.size(), 1u);
+
+    const double expected = 0.50 * 15000.0 / 365.0;  // ~$20.55
+    EXPECT_NEAR(fees.at(sym), expected, 0.05)
+        << "Override should bypass formula; expected " << expected
+        << ", got " << fees.at(sym);
+}
+
+// Longs and non-equities should be skipped (no borrow fee).
+TEST_F(BorrowFeesTest, LongsAndNonEquitiesAreSkipped) {
+    TransactionCostManager::Config tcm_config;
+    TransactionCostManager tcm(tcm_config);
+    auto& registry = InstrumentRegistry::instance();
+
+    const std::string sym = "PHASE2_T28_LONG";
+    registry.register_instrument(sym, std::make_shared<EquityInstrument>(sym, regt_spec()));
+
+    std::unordered_map<std::string, Position> positions;
+    Position p;
+    p.symbol = sym;
+    p.quantity = 100.0;  // Long.
+    p.average_price = 150.0;
+    positions[sym] = p;
+
+    std::unordered_map<std::string, double> prices;
+    prices[sym] = 150.0;
+
+    auto fees = tcm.calculate_overnight_borrow_fees(positions, prices, registry);
+    EXPECT_TRUE(fees.empty()) << "Long positions must not accrue borrow fees.";
+}


### PR DESCRIPTION
## Summary
Addresses 1 HIGH structural finding (§1.3) and locked design decisions §3.1, §3.2, §3.3 from the 2026-05-03 equities integration audit. Largest blast-radius phase in the work.

| Area | What changed |
|---|---|
| Margin model | New `EquityAccountMode {CASH, REG_T}` on EquitySpec; new `Instrument::get_margin_requirement(price, qty)` overload; EquityInstrument computes real CASH / Reg T long (50%) / Reg T short (150%) math; MarginManager threads price + signed qty through. Futures unchanged via base-class default. |
| Short-selling | `EquityInstrument::is_short_allowed()` gate. MeanReversionStrategy clamps shorts to 0 with WARN log when disallowed. CASH equities reject shorts unconditionally. |
| Leverage guardrail | Both equity apps refuse to start if `max_gross_leverage > 1.0` and any CASH-mode equity is in the portfolio. |
| Borrow fees | New `TransactionCostManager::calculate_overnight_borrow_fees`. Multi-factor scoring (dollar volume + price + is_easy_to_borrow) × volatility multiplier × short notional / 365. Per-symbol `borrow_rate_override` bypasses formula. Backtest accrues into daily transaction costs. |
| Tests | 15 new (T2.1–T2.8 + supporting). Full suite 385/385. |

## Test plan
- [x] Full build clean: `cmake --build build -j`
- [x] New tests pass: `trade_ngin_tests --gtest_filter='Equity*:LeverageGuardrail*:BorrowFees*'`
- [x] No regression to Phase 3 or Phase 1 tests
- [x] Full suite: 385/385 pass (was 370 + 15 new = 385)
- [ ] Smoke-run `bt_equity_mr` and compare PnL trajectory to a pre-Phase-2 baseline (current equity bt is long-only and CASH, so behavior change is in margin reporting only -- realized/unrealized PnL should be identical)
- [ ] Smoke-run `live_equity_mr` (manual) -- confirms startup guard fires when misconfigured

## Notable design calls (scoped intentionally)
- **RiskManager runtime guardrail deferred.** Defense-in-depth check inside `process_positions()` would cross-couple RiskManager with EquityInstrument internals. App-level startup check covers production exposure.
- **Live EOD borrow fee accrual deferred.** Backtest accrual is wired (where the cost matters for strategy P&L modeling). Live mode is paper-trading per audit §7; the live EOD hook location wasn't pinned without additional surgery.
- **Market cap unavailable.** Dollar volume (ADV × price) substitutes per audit §3.2 fallback. Real market cap is a future enhancement.
- **Per-symbol account_mode JSON config deferred.** Phase 2 uses EquitySpec defaults globally (CASH, no shorts, no override). Per-symbol JSON override is a Phase 2.5 follow-on if needed.

## Behavior change
- `margin_posted` for cash-equity portfolios reports full notional ($15,000 for 100 AAPL @ $150) instead of the prior nonsense ~\$50.
- Strategy clamps shorts to 0 for any equity that isn't REG_T with shorts explicitly allowed. Existing long-only equity portfolios unaffected.
- Risk manager refuses to start CASH-equity portfolios with `max_gross_leverage > 1.0`.
- Backtests of REG_T short positions accrue daily borrow fees into `transaction_costs`.
- **Futures behavior unchanged** -- the new margin overload's default body forwards to the no-arg version that futures already implement.

## Out of scope (deferred per audit §7)
Phases 4, 5, 6 -- follow-on PRs. Phase 7 permanently deferred.

Source audit: `docs/equities_review_2026-05-03.md`