### PR TITLE
Phase 4 + 4.5: Live corp-action handling + cumulative dividend income

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -122,6 +122,8 @@ set(TRADE_NGIN_SOURCES
     src/live/execution_manager.cpp
     src/live/margin_manager.cpp
     src/live/csv_exporter.cpp
+    src/live/corporate_actions_applier.cpp
+    src/live/corporate_actions_audit_log.cpp
     src/statistics/utils/statistics_utils.cpp
     src/statistics/transformers/normalizer.cpp
     src/statistics/transformers/pca.cpp

--- a/apps/strategies/live_equity_mean_reversion.cpp
+++ b/apps/strategies/live_equity_mean_reversion.cpp
@@ -1,6 +1,9 @@
+#include <cstdlib>
+#include <filesystem>
 #include <fstream>
 #include <iomanip>
 #include <iostream>
+#include <map>
 #include <sstream>
 #include <chrono>
 #include <ctime>
@@ -32,6 +35,20 @@
 #include "trade_ngin/live/csv_exporter.hpp"
 
 using namespace trade_ngin;
+
+// Resolve the on-disk dedup state directory for the live equity app.
+// Honors TRADE_NGIN_STATE_DIR (treated as the parent directory) when set;
+// otherwise roots an absolute path at the current working directory. Always
+// returns an absolute path so cron-triggered runs from a different CWD cannot
+// silently relocate state and reset dedup (ultrareview bug_013). The directory
+// itself is created on first save() by CorporateActionsAuditLog.
+static std::string resolve_corp_actions_state_dir(const std::string& strategy_id) {
+    namespace fs = std::filesystem;
+    if (const char* env = std::getenv("TRADE_NGIN_STATE_DIR")) {
+        return (fs::path(env) / strategy_id).string();
+    }
+    return (fs::current_path() / "state" / strategy_id).string();
+}
 
 // Locale-independent date formatting for SQL queries.
 // Uses std::put_time with %Y-%m-%d, always producing YYYY-MM-DD.
@@ -164,6 +181,13 @@ int main(int argc, char* argv[]) {
             WARN("Could not load instruments from DB (may not have futures metadata): " +
                  std::string(load_result.error()->what()));
         }
+
+        // Resolve the corp-actions state directory once (absolute path) so all
+        // three call sites (daily corp-action apply, metrics build, email body)
+        // see the same on-disk store regardless of CWD.
+        const std::string ca_state_dir =
+            resolve_corp_actions_state_dir("LIVE_EQUITY_MEAN_REVERSION");
+        INFO("Corp-actions state directory: " + ca_state_dir);
 
         // Get current date for daily processing (or use override date)
         auto now = use_override_date ? target_date : std::chrono::system_clock::now();
@@ -552,17 +576,77 @@ int main(int argc, char* argv[]) {
                 INFO("Fetched " + std::to_string(rows.size()) +
                      " corp-action rows in window [" + start_buf + ", " + today_buf + "]");
 
-                CorporateActionsAuditLog audit_log(
-                    "state/LIVE_EQUITY_MEAN_REVERSION");
+                CorporateActionsAuditLog audit_log(ca_state_dir);
                 audit_log.load();
+
+                // Historical close lookup keyed by (symbol, YYYY-MM-DD) so
+                // the dividend rescale denominator uses close at THIS event's
+                // ex_date - 1, not today's T-1 close (ultrareview bug_002).
+                // Built once from the same `all_bars` we already loaded.
+                std::unordered_map<std::string, std::map<std::string, double>>
+                    close_by_symbol_date;
+                for (const auto& bar : all_bars) {
+                    auto bt = std::chrono::system_clock::to_time_t(bar.timestamp);
+                    std::tm btm = *std::localtime(&bt);
+                    char dbuf[11];
+                    std::strftime(dbuf, sizeof(dbuf), "%Y-%m-%d", &btm);
+                    close_by_symbol_date[bar.symbol][std::string(dbuf)] =
+                        bar.close.as_double();
+                }
+                // Last close strictly BEFORE ex_date (walks back over
+                // weekends/holidays via the map's ordering). 0.0 if no bar.
+                auto close_before = [&](const std::string& symbol,
+                                        const std::string& ex_date) -> double {
+                    auto sym_it = close_by_symbol_date.find(symbol);
+                    if (sym_it == close_by_symbol_date.end()) return 0.0;
+                    const auto& by_date = sym_it->second;
+                    auto it = by_date.lower_bound(ex_date);
+                    if (it == by_date.begin()) return 0.0;
+                    --it;
+                    return it->second;
+                };
+
+                // Per-unique-ex_date positions cache for qty_at_ex_date
+                // lookup (ultrareview bug_021). Queries positions at
+                // ex_date - 1 (eligibility cutoff for cash dividends).
+                std::unordered_map<std::string, std::unordered_map<std::string, Position>>
+                    positions_at_date_cache;
+                auto qty_at_ex_date = [&](const std::string& symbol,
+                                          const std::string& ex_date) -> double {
+                    auto cached = positions_at_date_cache.find(ex_date);
+                    if (cached == positions_at_date_cache.end()) {
+                        std::tm tm{};
+                        std::istringstream ss(ex_date);
+                        ss >> std::get_time(&tm, "%Y-%m-%d");
+                        if (ss.fail()) return 0.0;
+                        auto tt = std::mktime(&tm) - 24 * 60 * 60;  // ex_date - 1 day
+                        auto tp = std::chrono::system_clock::from_time_t(tt);
+                        auto r = db->load_positions_by_date(
+                            "LIVE_EQUITY_MEAN_REVERSION", "EQUITY_MEAN_REVERSION",
+                            "BASE_PORTFOLIO", tp, "trading.positions");
+                        auto& slot = positions_at_date_cache[ex_date];
+                        if (r.is_ok()) slot = r.value();
+                        cached = positions_at_date_cache.find(ex_date);
+                    }
+                    auto p = cached->second.find(symbol);
+                    if (p == cached->second.end()) return 0.0;
+                    return p->second.quantity.as_double();
+                };
 
                 std::vector<CorpActionEvent> events;
                 events.reserve(rows.size());
+                // Intra-batch dedup (ultrareview bug_037): if the same
+                // (ticker, ex_date, action) tuple appears twice in this fetch
+                // (data-quality dupe), the persisted audit-log check above
+                // wouldn't see the duplicate within the same batch yet -- we
+                // must guard locally so we don't double-apply within one run.
+                std::set<std::tuple<std::string, std::string, CorpActionType>> seen_in_batch;
                 for (const auto& row : rows) {
                     CorpActionType type = CorporateActionsApplier::type_from_action_string(row.action);
                     if (type == CorpActionType::UNKNOWN) continue;
                     if (audit_log.is_applied(row.ticker, row.date_str, type)) continue;
                     if (previous_positions.find(row.ticker) == previous_positions.end()) continue;
+                    if (!seen_in_batch.emplace(row.ticker, row.date_str, type).second) continue;
 
                     CorpActionEvent ev;
                     ev.symbol = row.ticker;
@@ -570,10 +654,26 @@ int main(int argc, char* argv[]) {
                     ev.type = type;
                     ev.value = row.value;
                     if (type == CorpActionType::DIVIDEND) {
-                        auto p_it = previous_day_close_prices.find(row.ticker);
-                        ev.close_t_minus_1 = (p_it != previous_day_close_prices.end())
-                                                 ? p_it->second
-                                                 : 0.0;
+                        // bug_002: use close at THIS event's ex_date - 1.
+                        // Fall back to today's T-1 with a warning if not in
+                        // the loaded bar window (rare; the strategy's
+                        // historical_days window should cover the 14-day
+                        // catch-up easily).
+                        double c = close_before(row.ticker, row.date_str);
+                        if (c <= 0.0) {
+                            auto p_it = previous_day_close_prices.find(row.ticker);
+                            c = (p_it != previous_day_close_prices.end()) ? p_it->second : 0.0;
+                            if (c > 0.0) {
+                                WARN("No historical close for " + row.ticker +
+                                     " before ex_date " + row.date_str +
+                                     " -- using today's T-1 close as a fallback");
+                            }
+                        }
+                        ev.close_t_minus_1 = c;
+                        // bug_021: prefer qty at ex_date - 1; fall back to
+                        // current qty if the historical positions row is
+                        // missing (e.g. first-week catch-up runs).
+                        ev.qty_at_ex_date = qty_at_ex_date(row.ticker, row.date_str);
                     }
                     events.push_back(std::move(ev));
                 }
@@ -590,15 +690,24 @@ int main(int argc, char* argv[]) {
                              ", ratio " + std::to_string(adj.ratio_change));
                         audit_log.record(adj);
                     }
-                    audit_log.save();
 
                     // Persist corrected positions back so future runs (and
                     // tomorrow's load_positions_by_date) pick up the adjusted state.
+                    // Stamp last_update = now (ultrareview bug_007): the date-keyed
+                    // load filters on last_update, so without re-stamping the rows
+                    // we'd write at yesterday's effective date and tomorrow's
+                    // load_positions_by_date(today) would silently skip them.
                     std::vector<Position> positions_to_store;
                     positions_to_store.reserve(previous_positions.size());
                     for (const auto& [sym, pos] : previous_positions) {
-                        positions_to_store.push_back(pos);
+                        Position p = pos;
+                        p.last_update = now;
+                        positions_to_store.push_back(std::move(p));
                     }
+                    // Persist DB first, THEN save the dedup state file
+                    // (ultrareview merged_bug_001): if DB write fails, the state
+                    // file must NOT claim "applied" -- otherwise the next run
+                    // skips the event and positions drift permanently.
                     auto store_result = db->store_positions(
                         positions_to_store,
                         "LIVE_EQUITY_MEAN_REVERSION", "EQUITY_MEAN_REVERSION",
@@ -606,6 +715,11 @@ int main(int argc, char* argv[]) {
                     if (store_result.is_error()) {
                         ERROR("Failed to persist corp-action-adjusted positions: " +
                               std::string(store_result.error()->what()));
+                        return 1;
+                    }
+                    if (!audit_log.save()) {
+                        ERROR("Failed to persist corp-actions audit log -- "
+                              "next run may double-apply events");
                         return 1;
                     }
                     INFO("Persisted " + std::to_string(adjustments.size()) +
@@ -1664,7 +1778,7 @@ int main(int argc, char* argv[]) {
             // total-return via Phase 4's avg_price frame-alignment fix).
             double total_dividend_income = 0.0;
             {
-                CorporateActionsAuditLog div_log("state/LIVE_EQUITY_MEAN_REVERSION");
+                CorporateActionsAuditLog div_log(ca_state_dir);
                 div_log.load();
                 total_dividend_income = div_log.total_cumulative_dividend_income();
             }
@@ -1954,7 +2068,7 @@ int main(int argc, char* argv[]) {
                 // Phase 4.5: cumulative dividend income from the corp-action
                 // state file (informational ONLY; not in any PnL total).
                 {
-                    CorporateActionsAuditLog div_log_email("state/LIVE_EQUITY_MEAN_REVERSION");
+                    CorporateActionsAuditLog div_log_email(ca_state_dir);
                     div_log_email.load();
                     strategy_metrics["Dividend Income (cumulative, informational)"] =
                         div_log_email.total_cumulative_dividend_income();

--- a/apps/strategies/live_equity_mean_reversion.cpp
+++ b/apps/strategies/live_equity_mean_reversion.cpp
@@ -16,6 +16,8 @@
 #include "trade_ngin/data/conversion_utils.hpp"
 #include "trade_ngin/instruments/instrument_registry.hpp"
 #include "trade_ngin/instruments/equity.hpp"
+#include "trade_ngin/live/corporate_actions_applier.hpp"
+#include "trade_ngin/live/corporate_actions_audit_log.hpp"
 #include "trade_ngin/portfolio/portfolio_manager.hpp"
 #include "trade_ngin/strategy/mean_reversion.hpp"
 #include "trade_ngin/core/email_sender.hpp"
@@ -520,6 +522,97 @@ int main(int argc, char* argv[]) {
         INFO("Retrieved prices from PriceManager: " +
              std::to_string(previous_day_close_prices.size()) + " Day T-1, " +
              std::to_string(two_days_ago_close_prices.size()) + " Day T-2");
+
+        // ========================================
+        // PHASE 4: APPLY CORPORATE ACTIONS
+        // Read events from equities_data.corporate_action between yesterday's
+        // run window and today, dedup against state file, adjust position
+        // quantities + cost basis, persist corrected positions BEFORE the
+        // strategy generates today's targets. Closes audit §1.12, §1.15.
+        // ========================================
+        if (!previous_positions.empty()) {
+            // 14-day lookback covers weekend / holiday gaps; the audit log
+            // dedups any event seen on a prior run.
+            auto today_t = std::chrono::system_clock::to_time_t(now);
+            auto window_start_t = today_t - 14 * 24 * 60 * 60;
+            std::tm today_tm = *std::localtime(&today_t);
+            std::tm start_tm = *std::localtime(&window_start_t);
+            char today_buf[11], start_buf[11];
+            std::strftime(today_buf, sizeof(today_buf), "%Y-%m-%d", &today_tm);
+            std::strftime(start_buf, sizeof(start_buf), "%Y-%m-%d", &start_tm);
+
+            auto ca_result = db->get_corporate_actions(
+                symbols, std::string(start_buf), std::string(today_buf));
+            if (ca_result.is_error()) {
+                WARN("Failed to fetch corporate actions: " +
+                     std::string(ca_result.error()->what()) +
+                     " -- continuing without corp-action adjustments");
+            } else {
+                const auto& rows = ca_result.value();
+                INFO("Fetched " + std::to_string(rows.size()) +
+                     " corp-action rows in window [" + start_buf + ", " + today_buf + "]");
+
+                CorporateActionsAuditLog audit_log(
+                    "state/LIVE_EQUITY_MEAN_REVERSION");
+                audit_log.load();
+
+                std::vector<CorpActionEvent> events;
+                events.reserve(rows.size());
+                for (const auto& row : rows) {
+                    CorpActionType type = CorporateActionsApplier::type_from_action_string(row.action);
+                    if (type == CorpActionType::UNKNOWN) continue;
+                    if (audit_log.is_applied(row.ticker, row.date_str, type)) continue;
+                    if (previous_positions.find(row.ticker) == previous_positions.end()) continue;
+
+                    CorpActionEvent ev;
+                    ev.symbol = row.ticker;
+                    ev.ex_date = row.date_str;
+                    ev.type = type;
+                    ev.value = row.value;
+                    if (type == CorpActionType::DIVIDEND) {
+                        auto p_it = previous_day_close_prices.find(row.ticker);
+                        ev.close_t_minus_1 = (p_it != previous_day_close_prices.end())
+                                                 ? p_it->second
+                                                 : 0.0;
+                    }
+                    events.push_back(std::move(ev));
+                }
+
+                if (!events.empty()) {
+                    auto adjustments = CorporateActionsApplier::apply(previous_positions, events);
+                    for (const auto& adj : adjustments) {
+                        INFO("Applied " + std::string(CorporateActionsApplier::type_to_string(adj.type)) +
+                             " for " + adj.symbol + " (ex_date " + adj.event_date +
+                             "): qty " + std::to_string(adj.quantity_before) + " -> " +
+                             std::to_string(adj.quantity_after) +
+                             ", avg_price " + std::to_string(adj.avg_price_before) + " -> " +
+                             std::to_string(adj.avg_price_after) +
+                             ", ratio " + std::to_string(adj.ratio_change));
+                        audit_log.record(adj);
+                    }
+                    audit_log.save();
+
+                    // Persist corrected positions back so future runs (and
+                    // tomorrow's load_positions_by_date) pick up the adjusted state.
+                    std::vector<Position> positions_to_store;
+                    positions_to_store.reserve(previous_positions.size());
+                    for (const auto& [sym, pos] : previous_positions) {
+                        positions_to_store.push_back(pos);
+                    }
+                    auto store_result = db->store_positions(
+                        positions_to_store,
+                        "LIVE_EQUITY_MEAN_REVERSION", "EQUITY_MEAN_REVERSION",
+                        "BASE_PORTFOLIO", "trading.positions");
+                    if (store_result.is_error()) {
+                        ERROR("Failed to persist corp-action-adjusted positions: " +
+                              std::string(store_result.error()->what()));
+                        return 1;
+                    }
+                    INFO("Persisted " + std::to_string(adjustments.size()) +
+                         " corp-action adjustments to trading.positions");
+                }
+            }
+        }
 
         // Verify we have prices for all required symbols
         std::set<std::string> all_symbols;
@@ -1565,6 +1658,17 @@ int main(int argc, char* argv[]) {
             // Use the LiveResultsManager
             INFO("Setting metrics in LiveResultsManager...");
 
+            // Phase 4.5: cumulative dividend income, sourced from the
+            // Phase 4 corp-action state file. Informational ONLY -- NOT
+            // added to total_pnl (closeadj already captures dividend
+            // total-return via Phase 4's avg_price frame-alignment fix).
+            double total_dividend_income = 0.0;
+            {
+                CorporateActionsAuditLog div_log("state/LIVE_EQUITY_MEAN_REVERSION");
+                div_log.load();
+                total_dividend_income = div_log.total_cumulative_dividend_income();
+            }
+
             // Prepare metrics maps
             std::unordered_map<std::string, double> double_metrics = {
                 {"total_cumulative_return", total_cumulative_return_pct},
@@ -1592,7 +1696,8 @@ int main(int argc, char* argv[]) {
                 {"daily_unrealized_pnl", daily_unrealized_pnl},
                 {"daily_commissions", total_daily_commissions},
                 {"margin_posted", total_posted_margin},
-                {"cash_available", current_portfolio_value - total_posted_margin}
+                {"cash_available", current_portfolio_value - total_posted_margin},
+                {"total_dividend_income", total_dividend_income}
             };
 
             std::unordered_map<std::string, int> int_metrics = {
@@ -1753,9 +1858,13 @@ int main(int argc, char* argv[]) {
                     }
                     INFO("Loaded " + std::to_string(yesterday_positions_finalized.size()) + " finalized positions for email");
 
-                    // Load yesterday's daily metrics from database for accurate display
+                    // Load yesterday's daily metrics from database for accurate display.
+                    // Phase 4.5: total_dividend_income (informational; cumulative for the
+                    // strategy as of that date) added to the SELECT and surfaced in the
+                    // email body alongside Daily Total PnL.
                     std::string yesterday_metrics_query =
-                        "SELECT daily_return, daily_unrealized_pnl, daily_realized_pnl, daily_pnl, daily_commissions "
+                        "SELECT daily_return, daily_unrealized_pnl, daily_realized_pnl, daily_pnl, "
+                        "daily_commissions, total_dividend_income "
                         "FROM trading.live_results "
                         "WHERE strategy_id = 'LIVE_EQUITY_MEAN_REVERSION' AND date = '" + yesterday_date_for_email + "' "
                         "ORDER BY date DESC LIMIT 1";
@@ -1772,6 +1881,7 @@ int main(int argc, char* argv[]) {
                         auto daily_realized_arr = std::static_pointer_cast<arrow::StringArray>(metrics_table->column(2)->chunk(0));
                         auto daily_total_arr = std::static_pointer_cast<arrow::StringArray>(metrics_table->column(3)->chunk(0));
                         auto daily_commissions_arr = std::static_pointer_cast<arrow::StringArray>(metrics_table->column(4)->chunk(0));
+                        auto dividend_income_arr = std::static_pointer_cast<arrow::StringArray>(metrics_table->column(5)->chunk(0));
 
                         if (!daily_return_arr->IsNull(0)) {
                             yesterday_daily_metrics_final["Daily Return"] = std::stod(daily_return_arr->GetString(0));
@@ -1793,6 +1903,13 @@ int main(int argc, char* argv[]) {
                         if (!daily_commissions_arr->IsNull(0)) {
                             yesterday_daily_metrics_final["Daily Commissions"] = std::stod(daily_commissions_arr->GetString(0));
                             INFO("Daily Commissions: " + daily_commissions_arr->GetString(0));
+                        }
+                        if (!dividend_income_arr->IsNull(0)) {
+                            // Phase 4.5: informational only -- NOT in any PnL total.
+                            yesterday_daily_metrics_final["Dividend Income (cumulative)"] =
+                                std::stod(dividend_income_arr->GetString(0));
+                            INFO("Total Dividend Income (cumulative): " +
+                                 dividend_income_arr->GetString(0));
                         }
 
                         INFO("Successfully loaded yesterday's daily metrics from live_results");
@@ -1833,6 +1950,15 @@ int main(int argc, char* argv[]) {
                 }
                 strategy_metrics["Total Commissions"] = total_commissions_cumulative;
                 strategy_metrics["Current Portfolio Value"] = current_portfolio_value;
+
+                // Phase 4.5: cumulative dividend income from the corp-action
+                // state file (informational ONLY; not in any PnL total).
+                {
+                    CorporateActionsAuditLog div_log_email("state/LIVE_EQUITY_MEAN_REVERSION");
+                    div_log_email.load();
+                    strategy_metrics["Dividend Income (cumulative, informational)"] =
+                        div_log_email.total_cumulative_dividend_income();
+                }
 
                 // Leverage Metrics - Calculate values from position analysis
                 double gross_leverage_calc = (current_portfolio_value != 0.0) ? (gross_notional / current_portfolio_value) : 0.0;

--- a/include/trade_ngin/data/postgres_database.hpp
+++ b/include/trade_ngin/data/postgres_database.hpp
@@ -485,6 +485,38 @@ public:
     Result<std::shared_ptr<arrow::Table>> get_contract_metadata() const;
 
     /**
+     * @brief Corporate action row from equities_data.corporate_action.
+     *
+     * The `value` field is parsed from the source table's text column:
+     *   - SPLIT / ADR_SPLIT: split factor (e.g. 4.0 for a 4-for-1)
+     *   - DIVIDEND: cash amount per share in trading currency
+     */
+    struct CorpActionRow {
+        std::string ticker;
+        std::string date_str;  // YYYY-MM-DD
+        std::string action;    // "split" | "dividend" | "adrratiosplit"
+        double value;
+    };
+
+    /**
+     * @brief Read corporate actions for a ticker list between two dates.
+     *
+     * Reads from equities_data.corporate_action (existing schema; no DDL).
+     * Filters to splits and dividends only -- spinoffs/mergers/ticker
+     * changes need basis-cost reallocation logic out of scope for Phase 4.
+     *
+     * @param tickers      Symbols to query (typically the live portfolio's
+     *                     equity universe).
+     * @param start_date   Inclusive YYYY-MM-DD.
+     * @param end_date     Inclusive YYYY-MM-DD.
+     * @return Sorted by (date, ticker, action); empty result is not an error.
+     */
+    Result<std::vector<CorpActionRow>> get_corporate_actions(
+        const std::vector<std::string>& tickers,
+        const std::string& start_date,
+        const std::string& end_date);
+
+    /**
      * @brief Convert asset class to string for database queries
      * @param asset_class Asset class to convert
      * @return String representation for database queries

--- a/include/trade_ngin/live/corporate_actions_applier.hpp
+++ b/include/trade_ngin/live/corporate_actions_applier.hpp
@@ -1,0 +1,93 @@
+#pragma once
+
+#include <string>
+#include <unordered_map>
+#include <vector>
+
+#include "trade_ngin/core/types.hpp"
+
+namespace trade_ngin {
+
+/**
+ * @brief Type of equity corporate action this applier knows how to adjust.
+ *
+ * Phase 4 covers ordinary splits, ADR-ratio splits, and ordinary cash
+ * dividends. Spinoffs / mergers / ticker changes are out of scope per the
+ * Phase 4 plan -- those need basis-cost reallocation logic beyond per-symbol
+ * scalar adjustment.
+ */
+enum class CorpActionType { SPLIT, ADR_SPLIT, DIVIDEND, UNKNOWN };
+
+/**
+ * @brief One corporate-action event to apply.
+ *
+ * `value` carries the event's primary parameter (split factor for SPLIT /
+ * ADR_SPLIT, cash $/share for DIVIDEND). `close_t_minus_1` is required for
+ * dividends to compute the closeadj ratio change; ignored for splits.
+ */
+struct CorpActionEvent {
+    std::string symbol;
+    std::string ex_date;          // YYYY-MM-DD
+    CorpActionType type{CorpActionType::UNKNOWN};
+    double value{0.0};            // split factor OR dividend $/share
+    double close_t_minus_1{0.0};  // required for DIVIDEND only
+};
+
+/**
+ * @brief Auditable record of a position adjustment.
+ *
+ * Returned from CorporateActionsApplier::apply for logging, state-file
+ * persistence (idempotency dedup), and operator audit trails.
+ */
+struct PositionAdjustment {
+    std::string symbol;
+    std::string event_date;
+    CorpActionType type;
+    double quantity_before{0.0};
+    double quantity_after{0.0};
+    double avg_price_before{0.0};
+    double avg_price_after{0.0};
+    double event_value{0.0};       // split factor or $/share
+    double ratio_change{1.0};      // for dividends: 1 + d/close_t_minus_1
+};
+
+/**
+ * @brief Pure-logic applier that mutates a position map in place.
+ *
+ * No DB dependency, no file I/O -- the caller (live equity app) is
+ * responsible for sourcing events (PostgresDatabase::get_corporate_actions),
+ * passing close[T-1] prices on dividends, and persisting the adjusted
+ * positions afterward. Designed for direct unit testing.
+ *
+ * Adjustment math (audit §1.12, §1.15):
+ *   - SPLIT (factor F):      qty *= F; avg_price /= F
+ *   - ADR_SPLIT (factor F):  same as SPLIT
+ *   - DIVIDEND (d, close_t_minus_1):
+ *         ratio = 1 + d / close_t_minus_1
+ *         avg_price /= ratio  (keeps avg_price in the post-rescale closeadj frame)
+ *
+ * Positions with zero quantity are skipped (no adjustment, no record).
+ * Events targeting symbols absent from the positions map are skipped.
+ * Stacked events on the same symbol apply in the input order.
+ */
+class CorporateActionsApplier {
+public:
+    /**
+     * @brief Apply events to positions in place; return the audit log.
+     *
+     * @param positions Map to mutate. Keys are symbols; values are Position.
+     * @param events    Events to apply (in order).
+     * @return Vector of PositionAdjustment records, one per applied event.
+     */
+    static std::vector<PositionAdjustment> apply(
+        std::unordered_map<std::string, Position>& positions,
+        const std::vector<CorpActionEvent>& events);
+
+    // Stringify the type for logs / audit files.
+    static const char* type_to_string(CorpActionType t);
+
+    // Parse the action text from equities_data.corporate_action into the enum.
+    static CorpActionType type_from_action_string(const std::string& action);
+};
+
+}  // namespace trade_ngin

--- a/include/trade_ngin/live/corporate_actions_applier.hpp
+++ b/include/trade_ngin/live/corporate_actions_applier.hpp
@@ -30,7 +30,15 @@ struct CorpActionEvent {
     std::string ex_date;          // YYYY-MM-DD
     CorpActionType type{CorpActionType::UNKNOWN};
     double value{0.0};            // split factor OR dividend $/share
-    double close_t_minus_1{0.0};  // required for DIVIDEND only
+    double close_t_minus_1{0.0};  // required for DIVIDEND only; close at ex_date-1
+    // Quantity held at end of business on ex_date - 1 (the eligibility cutoff
+    // for cash dividends). Optional: when > 0, the applier records this on
+    // PositionAdjustment.quantity_before/after for DIVIDEND events instead of
+    // today's live qty, so the audit log's cash-flow figure reflects the
+    // ex-date holding even when running a catch-up apply days later
+    // (ultrareview bug_021). Has NO effect on the actual position quantity
+    // (dividends never change qty), nor on splits.
+    double qty_at_ex_date{0.0};
 };
 
 /**

--- a/include/trade_ngin/live/corporate_actions_audit_log.hpp
+++ b/include/trade_ngin/live/corporate_actions_audit_log.hpp
@@ -1,0 +1,112 @@
+#pragma once
+
+#include <set>
+#include <string>
+#include <tuple>
+#include <vector>
+
+#include "trade_ngin/live/corporate_actions_applier.hpp"
+
+namespace trade_ngin {
+
+/**
+ * @brief On-disk dedup record for corp-action events applied to a strategy.
+ *
+ * Persists to `<state_dir>/applied_corp_actions.json` per strategy. Each
+ * entry pins one (symbol, ex_date, action) tuple as "already applied" so
+ * the daily live app can re-run safely without double-adjusting positions.
+ *
+ * No DB dependency by design -- the Phase 4 scope constraint forbids new
+ * schema. The audit's original dividend_ledger DB table is the natural
+ * future home; this state file is a stand-in until that constraint lifts.
+ *
+ * File format:
+ * {
+ *   "applied": [
+ *     {"symbol": "AAPL", "ex_date": "2024-08-12", "action": "DIVIDEND"},
+ *     {"symbol": "NVDA", "ex_date": "2024-06-10", "action": "SPLIT"}
+ *   ],
+ *   "dividend_events": [
+ *     {"symbol": "AAPL", "ex_date": "2024-08-12",
+ *      "qty_held": 100.0, "dividend_per_share": 0.25, "total_cash": 25.0}
+ *   ]
+ * }
+ *
+ * Concurrency: single-process semantics. The live equity app runs as a
+ * cron-triggered batch; concurrent invocations on the same state_dir are
+ * not supported (would race on save).
+ */
+class CorporateActionsAuditLog {
+public:
+    explicit CorporateActionsAuditLog(std::string state_dir);
+
+    /**
+     * @brief Load existing dedup records from disk.
+     * @return true if the file existed and parsed; false if first-run.
+     *         Either way, the in-memory state is initialized.
+     */
+    bool load();
+
+    /**
+     * @brief Has this (symbol, ex_date, action) tuple already been applied?
+     */
+    bool is_applied(const std::string& symbol,
+                    const std::string& ex_date,
+                    CorpActionType action) const;
+
+    /**
+     * @brief Record an adjustment as applied (idempotency dedup).
+     *        Also captures dividend cash-flow detail when type is DIVIDEND.
+     */
+    void record(const PositionAdjustment& adjustment);
+
+    /**
+     * @brief Write current state to disk. Creates parent directory if needed.
+     * @return true on successful write, false on filesystem error.
+     */
+    bool save() const;
+
+    /**
+     * @brief Sum of total_cash across all recorded dividend events.
+     *
+     * Cumulative across the lifetime of the state file (no date filter --
+     * the file is per-strategy and grows monotonically, so "all events" IS
+     * "cumulative for this strategy"). Returns 0 if no dividends recorded.
+     *
+     * Used by the live equity app to populate
+     * trading.live_results.total_dividend_income at daily finalization
+     * (Phase 4.5). Splits do not contribute (only DIVIDEND events are
+     * captured in dividend_events_).
+     *
+     * Informational ONLY: closeadj already captures dividend total-return
+     * via price continuity (Phase 4 avg_price frame-alignment fix). Do NOT
+     * add this value to P&L totals -- it would double-count.
+     */
+    double total_cumulative_dividend_income() const;
+
+    /** Test helper: clear in-memory state (does not touch disk). */
+    void clear_in_memory() {
+        applied_.clear();
+        dividend_events_.clear();
+    }
+
+    const std::string& state_dir() const { return state_dir_; }
+
+private:
+    using AppliedKey = std::tuple<std::string, std::string, CorpActionType>;
+    struct DividendEvent {
+        std::string symbol;
+        std::string ex_date;
+        double qty_held{0.0};
+        double dividend_per_share{0.0};
+        double total_cash{0.0};
+    };
+
+    std::string state_dir_;
+    std::set<AppliedKey> applied_;
+    std::vector<DividendEvent> dividend_events_;
+
+    std::string file_path() const;
+};
+
+}  // namespace trade_ngin

--- a/include/trade_ngin/live/execution_manager.hpp
+++ b/include/trade_ngin/live/execution_manager.hpp
@@ -12,13 +12,23 @@
 namespace trade_ngin {
 
 /**
- * ExecutionManager - Handles execution generation for live trading
+ * ExecutionManager - Offline execution synthesizer for the live trading flow.
  *
- * This class encapsulates the logic for:
- * - Generating execution reports from position changes
- * - Calculating commissions and transaction costs via TransactionCostManager
+ * Despite "live" in the path, this class is NOT a real broker adapter.
+ * It generates synthetic ExecutionReports from position deltas
+ * (target - current) priced at T-1 close, and computes commissions /
+ * transaction costs via TransactionCostManager. There is no order routing,
+ * no broker network call, no partial-fill handling.
  *
- * Extracted from live_trend.cpp lines 717-833 as part of Phase 3 refactoring
+ * This is paper-trading by design per the 2026-05-03 audit §7. A real
+ * broker adapter (and the broker-reconciliation work in audit §1.13) lands
+ * in a separate phase if and when live brokerage integration ships.
+ *
+ * For historical simulation, see backtest::BacktestExecutionManager.
+ *
+ * History: extracted from live_trend.cpp lines 717-833 during the Phase 3
+ * refactor. The "live" prefix is preserved for path stability; this
+ * docstring is the authoritative description of the role.
  */
 class ExecutionManager {
 private:

--- a/scripts/2026-05-18_phase4.5_dividend_income_column.sql
+++ b/scripts/2026-05-18_phase4.5_dividend_income_column.sql
@@ -1,0 +1,19 @@
+-- Phase 4.5: cumulative dividend income column on trading.live_results.
+--
+-- Run once before deploying the corresponding C++ code. Safe to re-run
+-- (IF NOT EXISTS guard).
+--
+-- Usage:
+--   PGPASSWORD=algogators psql -h <host> -U postgres -d new_algo_data \
+--       -f scripts/2026-05-18_phase4.5_dividend_income_column.sql
+
+ALTER TABLE trading.live_results
+    ADD COLUMN IF NOT EXISTS total_dividend_income DECIMAL(18,8) DEFAULT 0;
+
+COMMENT ON COLUMN trading.live_results.total_dividend_income IS
+    'Cumulative dividend cash income for (strategy, portfolio) as of this date. '
+    'Informational ONLY -- NOT added to total_pnl. closeadj captures dividend '
+    'total-return via price continuity (Phase 4 avg_price frame-alignment fix); '
+    'adding dividend cash on top would double-count. '
+    'Source: in-process sum of CorporateActionsAuditLog dividend_events at daily finalization. '
+    'Decomposition view: total_return = capital_appreciation + total_dividend_income.';

--- a/src/backtest/backtest_coordinator.cpp
+++ b/src/backtest/backtest_coordinator.cpp
@@ -7,8 +7,10 @@
 #include "trade_ngin/core/time_utils.hpp"
 #include "trade_ngin/data/market_data_bus.hpp"
 #include "trade_ngin/storage/backtest_results_manager.hpp"
+#include "trade_ngin/strategy/base_strategy.hpp"
 #include "trade_ngin/strategy/trend_following.hpp"
 #include "trade_ngin/strategy/trend_following_fast.hpp"
+#include "trade_ngin/strategy/types.hpp"
 
 namespace trade_ngin {
 namespace backtest {
@@ -636,6 +638,18 @@ Result<void> BacktestCoordinator::process_portfolio_day(
         // Calculate PnL for each strategy using its individual quantities
         auto strategy_positions = portfolio->get_strategy_positions();
 
+        // Phase 4 §1.14: build per-strategy PnL accounting method lookup so
+        // we can branch on REALIZED_ONLY (futures: daily MTM IS realized) vs
+        // MIXED/UNREALIZED_ONLY (equities: realized_pnl only on actual close,
+        // written by on_execution -- coordinator must NOT stamp realized_pnl
+        // here for equities).
+        std::unordered_map<std::string, PnLAccountingMethod> pnl_method_by_strategy;
+        for (const auto& s : portfolio->get_strategies()) {
+            if (auto bs = std::dynamic_pointer_cast<BaseStrategy>(s)) {
+                pnl_method_by_strategy[bs->get_metadata().id] = bs->get_pnl_accounting().method;
+            }
+        }
+
         for (const auto& [strategy_id, positions_map] : strategy_positions) {
             for (const auto& [symbol, pos] : positions_map) {
                 double qty = static_cast<double>(pos.quantity);
@@ -666,7 +680,20 @@ Result<void> BacktestCoordinator::process_portfolio_day(
                 if (pnl_result.valid) {
                     // Update this strategy's position with calculated PnL
                     Position updated_pos = pos;
-                    updated_pos.realized_pnl = Decimal(pnl_result.daily_pnl);
+                    // Phase 4 §1.14: only stamp realized_pnl with daily MTM
+                    // when the strategy uses REALIZED_ONLY accounting
+                    // (futures). For equities (MIXED / UNREALIZED_ONLY),
+                    // leave realized_pnl untouched -- on_execution writes
+                    // realized when positions actually close. total_portfolio_pnl
+                    // below still aggregates daily_pnl independently so equity
+                    // curve totals are unchanged.
+                    auto pnl_method_it = pnl_method_by_strategy.find(strategy_id);
+                    PnLAccountingMethod method = (pnl_method_it != pnl_method_by_strategy.end())
+                                                     ? pnl_method_it->second
+                                                     : PnLAccountingMethod::REALIZED_ONLY;
+                    if (method == PnLAccountingMethod::REALIZED_ONLY) {
+                        updated_pos.realized_pnl = Decimal(pnl_result.daily_pnl);
+                    }
                     // For equities: unrealized = (current_price - cost_basis) * qty
                     // For futures: unrealized = 0 (mark-to-market settles daily)
                     double avg_price = static_cast<double>(pos.average_price);

--- a/src/data/postgres_database.cpp
+++ b/src/data/postgres_database.cpp
@@ -2381,4 +2381,71 @@ Result<std::shared_ptr<arrow::Table>> PostgresDatabase::convert_generic_to_arrow
     }
 }
 
+Result<std::vector<PostgresDatabase::CorpActionRow>>
+PostgresDatabase::get_corporate_actions(
+    const std::vector<std::string>& tickers,
+    const std::string& start_date,
+    const std::string& end_date) {
+
+    auto validation = validate_connection();
+    if (validation.is_error()) {
+        return make_error<std::vector<CorpActionRow>>(
+            validation.error()->code(), validation.error()->what());
+    }
+    if (tickers.empty()) {
+        return Result<std::vector<CorpActionRow>>(std::vector<CorpActionRow>{});
+    }
+
+    try {
+        pqxx::work txn(*connection_);
+
+        // Build the IN list with txn.quote for safety. equities_data.corporate_action
+        // stores dates as text; cast to date for the BETWEEN comparison.
+        std::string in_list;
+        for (size_t i = 0; i < tickers.size(); ++i) {
+            if (i > 0) in_list += ",";
+            in_list += txn.quote(tickers[i]);
+        }
+
+        const std::string query =
+            "SELECT date, action, ticker, value "
+            "FROM equities_data.corporate_action "
+            "WHERE ticker IN (" + in_list + ") "
+            "  AND action IN ('split','dividend','adrratiosplit') "
+            "  AND date::date BETWEEN " + txn.quote(start_date) +
+            "::date AND " + txn.quote(end_date) + "::date "
+            "ORDER BY date, ticker, action";
+
+        auto result = txn.exec(query);
+        std::vector<CorpActionRow> rows;
+        rows.reserve(result.size());
+
+        for (const auto& row : result) {
+            CorpActionRow ca;
+            ca.date_str = row["date"].c_str();
+            ca.action = row["action"].c_str();
+            ca.ticker = row["ticker"].c_str();
+            // value is stored as text in the source schema; parse defensively.
+            const std::string val_str = row["value"].is_null() ? "" : row["value"].c_str();
+            try {
+                ca.value = val_str.empty() ? 0.0 : std::stod(val_str);
+            } catch (const std::exception&) {
+                WARN("get_corporate_actions: unparseable value '" + val_str +
+                     "' for " + ca.ticker + " on " + ca.date_str + " -- skipping");
+                continue;
+            }
+            rows.push_back(std::move(ca));
+        }
+
+        txn.commit();
+        return Result<std::vector<CorpActionRow>>(std::move(rows));
+
+    } catch (const std::exception& e) {
+        return make_error<std::vector<CorpActionRow>>(
+            ErrorCode::DATABASE_ERROR,
+            "Failed to fetch corporate actions: " + std::string(e.what()),
+            "PostgresDatabase");
+    }
+}
+
 }  // namespace trade_ngin

--- a/src/live/corporate_actions_applier.cpp
+++ b/src/live/corporate_actions_applier.cpp
@@ -103,7 +103,16 @@ std::vector<PositionAdjustment> CorporateActionsApplier::apply(
                 if (avg_before > 0.0) {
                     pos.average_price = Decimal(avg_after);
                 }
-                adj.quantity_after = qty_before;  // unchanged
+                // For the audit log's cash-flow figure, the basis is the
+                // qty held on ex_date - 1 (ultrareview bug_021). When the
+                // caller supplied that, record it; otherwise fall back to
+                // the live position qty (same as before).
+                const double basis_qty =
+                    (ev.qty_at_ex_date > 0.0 && std::isfinite(ev.qty_at_ex_date))
+                        ? ev.qty_at_ex_date
+                        : qty_before;
+                adj.quantity_before = basis_qty;
+                adj.quantity_after = basis_qty;  // unchanged
                 adj.avg_price_after = avg_after;
                 adj.ratio_change = ratio;
                 break;

--- a/src/live/corporate_actions_applier.cpp
+++ b/src/live/corporate_actions_applier.cpp
@@ -1,0 +1,121 @@
+#include "trade_ngin/live/corporate_actions_applier.hpp"
+
+#include <cmath>
+
+#include "trade_ngin/core/logger.hpp"
+
+namespace trade_ngin {
+
+const char* CorporateActionsApplier::type_to_string(CorpActionType t) {
+    switch (t) {
+        case CorpActionType::SPLIT:     return "SPLIT";
+        case CorpActionType::ADR_SPLIT: return "ADR_SPLIT";
+        case CorpActionType::DIVIDEND:  return "DIVIDEND";
+        case CorpActionType::UNKNOWN:   return "UNKNOWN";
+    }
+    return "UNKNOWN";
+}
+
+CorpActionType CorporateActionsApplier::type_from_action_string(const std::string& action) {
+    if (action == "split") return CorpActionType::SPLIT;
+    if (action == "adrratiosplit") return CorpActionType::ADR_SPLIT;
+    if (action == "dividend") return CorpActionType::DIVIDEND;
+    return CorpActionType::UNKNOWN;
+}
+
+std::vector<PositionAdjustment> CorporateActionsApplier::apply(
+    std::unordered_map<std::string, Position>& positions,
+    const std::vector<CorpActionEvent>& events) {
+
+    std::vector<PositionAdjustment> log;
+    log.reserve(events.size());
+
+    for (const auto& ev : events) {
+        if (ev.type == CorpActionType::UNKNOWN) {
+            WARN("CorporateActionsApplier: UNKNOWN event type for " + ev.symbol +
+                 " on " + ev.ex_date + " -- skipping");
+            continue;
+        }
+
+        auto it = positions.find(ev.symbol);
+        if (it == positions.end()) {
+            // No held position; nothing to adjust. Not an error.
+            continue;
+        }
+
+        Position& pos = it->second;
+        const double qty_before = pos.quantity.as_double();
+        const double avg_before = pos.average_price.as_double();
+
+        if (std::abs(qty_before) < 1e-9) {
+            // Zero position; no adjustment needed.
+            continue;
+        }
+
+        PositionAdjustment adj;
+        adj.symbol = ev.symbol;
+        adj.event_date = ev.ex_date;
+        adj.type = ev.type;
+        adj.quantity_before = qty_before;
+        adj.avg_price_before = avg_before;
+        adj.event_value = ev.value;
+        adj.ratio_change = 1.0;
+
+        switch (ev.type) {
+            case CorpActionType::SPLIT:
+            case CorpActionType::ADR_SPLIT: {
+                if (ev.value <= 0.0 || !std::isfinite(ev.value)) {
+                    WARN("CorporateActionsApplier: bad split factor " +
+                         std::to_string(ev.value) + " for " + ev.symbol +
+                         " on " + ev.ex_date + " -- skipping");
+                    continue;
+                }
+                const double factor = ev.value;
+                const double qty_after = qty_before * factor;
+                const double avg_after = avg_before > 0.0 ? avg_before / factor : 0.0;
+                pos.quantity = Quantity(qty_after);
+                if (avg_before > 0.0) {
+                    pos.average_price = Decimal(avg_after);
+                }
+                adj.quantity_after = qty_after;
+                adj.avg_price_after = avg_after;
+                adj.ratio_change = factor;
+                break;
+            }
+            case CorpActionType::DIVIDEND: {
+                // ratio_change = 1 + dividend_per_share / close[T-1]
+                if (ev.close_t_minus_1 <= 0.0 || !std::isfinite(ev.close_t_minus_1)) {
+                    WARN("CorporateActionsApplier: dividend for " + ev.symbol +
+                         " on " + ev.ex_date + " has invalid close[T-1]=" +
+                         std::to_string(ev.close_t_minus_1) + " -- skipping");
+                    continue;
+                }
+                if (ev.value <= 0.0 || !std::isfinite(ev.value)) {
+                    WARN("CorporateActionsApplier: dividend for " + ev.symbol +
+                         " on " + ev.ex_date + " has invalid amount=" +
+                         std::to_string(ev.value) + " -- skipping");
+                    continue;
+                }
+                const double ratio = 1.0 + ev.value / ev.close_t_minus_1;
+                const double avg_after = avg_before > 0.0 ? avg_before / ratio : 0.0;
+                // Dividend doesn't change quantity; only rescales avg_price into
+                // the post-dividend closeadj frame (audit §1.15).
+                if (avg_before > 0.0) {
+                    pos.average_price = Decimal(avg_after);
+                }
+                adj.quantity_after = qty_before;  // unchanged
+                adj.avg_price_after = avg_after;
+                adj.ratio_change = ratio;
+                break;
+            }
+            case CorpActionType::UNKNOWN:
+                continue;  // handled above
+        }
+
+        log.push_back(std::move(adj));
+    }
+
+    return log;
+}
+
+}  // namespace trade_ngin

--- a/src/live/corporate_actions_audit_log.cpp
+++ b/src/live/corporate_actions_audit_log.cpp
@@ -134,13 +134,37 @@ bool CorporateActionsAuditLog::save() const {
         out["dividend_events"].push_back(std::move(entry));
     }
 
+    // Atomic write (ultrareview bug_003): writing directly to `path` leaves a
+    // corrupt half-file if the process is killed mid-write, which makes the
+    // next load() fail and silently zeroes the dedup state. Write to a temp
+    // sibling, flush, then rename -- rename is atomic on the same filesystem,
+    // so a reader either sees the old file or the new file but never a
+    // partial one.
     const std::string path = file_path();
-    std::ofstream f(path);
-    if (!f.is_open()) {
-        ERROR("CorporateActionsAuditLog: cannot open " + path + " for writing");
+    const std::string tmp_path = path + ".tmp";
+    {
+        std::ofstream f(tmp_path, std::ios::out | std::ios::trunc);
+        if (!f.is_open()) {
+            ERROR("CorporateActionsAuditLog: cannot open " + tmp_path + " for writing");
+            return false;
+        }
+        f << out.dump(2);
+        f.flush();
+        if (!f.good()) {
+            ERROR("CorporateActionsAuditLog: write to " + tmp_path + " failed");
+            std::error_code ec;
+            std::filesystem::remove(tmp_path, ec);
+            return false;
+        }
+    }
+    std::error_code ec;
+    std::filesystem::rename(tmp_path, path, ec);
+    if (ec) {
+        ERROR("CorporateActionsAuditLog: atomic rename " + tmp_path + " -> " +
+              path + " failed: " + ec.message());
+        std::filesystem::remove(tmp_path, ec);
         return false;
     }
-    f << out.dump(2);
     return true;
 }
 

--- a/src/live/corporate_actions_audit_log.cpp
+++ b/src/live/corporate_actions_audit_log.cpp
@@ -1,0 +1,147 @@
+#include "trade_ngin/live/corporate_actions_audit_log.hpp"
+
+#include <filesystem>
+#include <fstream>
+#include <sstream>
+#include <utility>
+
+#include <nlohmann/json.hpp>
+
+#include "trade_ngin/core/logger.hpp"
+
+namespace trade_ngin {
+
+namespace {
+
+CorpActionType parse_type(const std::string& s) {
+    if (s == "SPLIT") return CorpActionType::SPLIT;
+    if (s == "ADR_SPLIT") return CorpActionType::ADR_SPLIT;
+    if (s == "DIVIDEND") return CorpActionType::DIVIDEND;
+    return CorpActionType::UNKNOWN;
+}
+
+}  // namespace
+
+CorporateActionsAuditLog::CorporateActionsAuditLog(std::string state_dir)
+    : state_dir_(std::move(state_dir)) {}
+
+std::string CorporateActionsAuditLog::file_path() const {
+    return state_dir_ + "/applied_corp_actions.json";
+}
+
+bool CorporateActionsAuditLog::load() {
+    applied_.clear();
+    dividend_events_.clear();
+
+    const std::string path = file_path();
+    std::ifstream f(path);
+    if (!f.is_open()) {
+        // First run for this strategy. Not an error.
+        return false;
+    }
+
+    try {
+        nlohmann::json j;
+        f >> j;
+
+        if (j.contains("applied") && j["applied"].is_array()) {
+            for (const auto& entry : j["applied"]) {
+                if (!entry.contains("symbol") || !entry.contains("ex_date") ||
+                    !entry.contains("action")) {
+                    continue;
+                }
+                applied_.emplace(
+                    entry["symbol"].get<std::string>(),
+                    entry["ex_date"].get<std::string>(),
+                    parse_type(entry["action"].get<std::string>()));
+            }
+        }
+        if (j.contains("dividend_events") && j["dividend_events"].is_array()) {
+            for (const auto& entry : j["dividend_events"]) {
+                DividendEvent de;
+                de.symbol = entry.value("symbol", "");
+                de.ex_date = entry.value("ex_date", "");
+                de.qty_held = entry.value("qty_held", 0.0);
+                de.dividend_per_share = entry.value("dividend_per_share", 0.0);
+                de.total_cash = entry.value("total_cash", 0.0);
+                dividend_events_.push_back(std::move(de));
+            }
+        }
+    } catch (const std::exception& e) {
+        WARN("CorporateActionsAuditLog: failed to parse " + path + ": " + e.what() +
+             " -- treating as empty");
+        applied_.clear();
+        dividend_events_.clear();
+        return false;
+    }
+    return true;
+}
+
+bool CorporateActionsAuditLog::is_applied(const std::string& symbol,
+                                          const std::string& ex_date,
+                                          CorpActionType action) const {
+    return applied_.find(AppliedKey{symbol, ex_date, action}) != applied_.end();
+}
+
+void CorporateActionsAuditLog::record(const PositionAdjustment& adj) {
+    applied_.emplace(adj.symbol, adj.event_date, adj.type);
+
+    if (adj.type == CorpActionType::DIVIDEND) {
+        DividendEvent de;
+        de.symbol = adj.symbol;
+        de.ex_date = adj.event_date;
+        de.qty_held = adj.quantity_after;  // unchanged for dividends
+        de.dividend_per_share = adj.event_value;
+        de.total_cash = de.qty_held * de.dividend_per_share;
+        dividend_events_.push_back(std::move(de));
+    }
+}
+
+double CorporateActionsAuditLog::total_cumulative_dividend_income() const {
+    double sum = 0.0;
+    for (const auto& de : dividend_events_) {
+        sum += de.total_cash;
+    }
+    return sum;
+}
+
+bool CorporateActionsAuditLog::save() const {
+    try {
+        std::filesystem::create_directories(state_dir_);
+    } catch (const std::exception& e) {
+        ERROR("CorporateActionsAuditLog: cannot create state dir " + state_dir_ +
+              ": " + e.what());
+        return false;
+    }
+
+    nlohmann::json out;
+    out["applied"] = nlohmann::json::array();
+    for (const auto& [sym, date, type] : applied_) {
+        nlohmann::json entry;
+        entry["symbol"] = sym;
+        entry["ex_date"] = date;
+        entry["action"] = CorporateActionsApplier::type_to_string(type);
+        out["applied"].push_back(std::move(entry));
+    }
+    out["dividend_events"] = nlohmann::json::array();
+    for (const auto& de : dividend_events_) {
+        nlohmann::json entry;
+        entry["symbol"] = de.symbol;
+        entry["ex_date"] = de.ex_date;
+        entry["qty_held"] = de.qty_held;
+        entry["dividend_per_share"] = de.dividend_per_share;
+        entry["total_cash"] = de.total_cash;
+        out["dividend_events"].push_back(std::move(entry));
+    }
+
+    const std::string path = file_path();
+    std::ofstream f(path);
+    if (!f.is_open()) {
+        ERROR("CorporateActionsAuditLog: cannot open " + path + " for writing");
+        return false;
+    }
+    f << out.dump(2);
+    return true;
+}
+
+}  // namespace trade_ngin

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -26,6 +26,7 @@ set(TEST_SOURCES
     live/test_corp_actions_long_hold_total_return.cpp
     live/test_audit_log_cumulative_dividend.cpp
     live/test_live_metrics_includes_dividend_income.cpp
+    live/test_corp_actions_ultrareview_fixes.cpp
     backtest/test_pnl_accounting_branch.cpp
     # backtesting/test_engine.cpp  # Deprecated - BacktestEngine replaced by BacktestCoordinator
     execution/test_execution_engine.cpp

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -21,6 +21,12 @@ set(TEST_SOURCES
     transaction_cost/test_adv_classifier_wireup.cpp
     transaction_cost/test_unknown_equity_costs_dispatch.cpp
     transaction_cost/test_equity_borrow_fees.cpp
+    live/test_corp_actions_applier.cpp
+    live/test_corp_actions_audit_log.cpp
+    live/test_corp_actions_long_hold_total_return.cpp
+    live/test_audit_log_cumulative_dividend.cpp
+    live/test_live_metrics_includes_dividend_income.cpp
+    backtest/test_pnl_accounting_branch.cpp
     # backtesting/test_engine.cpp  # Deprecated - BacktestEngine replaced by BacktestCoordinator
     execution/test_execution_engine.cpp
     portfolio/test_portfolio_manager.cpp

--- a/tests/backtest/test_pnl_accounting_branch.cpp
+++ b/tests/backtest/test_pnl_accounting_branch.cpp
@@ -1,0 +1,109 @@
+#include <gtest/gtest.h>
+#include <memory>
+#include "../core/test_base.hpp"
+#include "../data/test_db_utils.hpp"
+#include "trade_ngin/strategy/mean_reversion.hpp"
+#include "trade_ngin/strategy/trend_following.hpp"
+#include "trade_ngin/strategy/types.hpp"
+
+using namespace trade_ngin;
+using namespace trade_ngin::testing;
+
+// Phase 4 audit test T4.6 — §1.14 backtest coordinator P&L semantics.
+//
+// Contract test: the coordinator's branch reads strategy->get_pnl_accounting().method
+// and only stamps realized_pnl when REALIZED_ONLY (futures: settled daily).
+// MIXED / UNREALIZED_ONLY (equities) leaves realized_pnl untouched at the
+// coordinator level -- on_execution writes realized when positions actually close.
+//
+// This test pins the contract by verifying:
+// 1. Each strategy's accounting method is what the coordinator expects.
+// 2. The PnL accounting accessor returns the same value over successive calls.
+//
+// A true integration test of the coordinator's branch requires the full bar
+// loop, portfolio, and execution path -- captured by the broader smoke runs
+// rather than a unit test. This contract test catches regressions in the
+// accessor / setter contract that the coordinator's branch depends on.
+
+namespace {
+
+class PnLAccountingBranchTest : public TestBase {
+protected:
+    void SetUp() override {
+        TestBase::SetUp();
+        StateManager::reset_instance();
+        db_ = std::make_shared<MockPostgresDatabase>("mock://pnl_branch_test");
+        ASSERT_TRUE(db_->connect().is_ok());
+    }
+
+    std::shared_ptr<MockPostgresDatabase> db_;
+};
+
+}  // namespace
+
+TEST_F(PnLAccountingBranchTest, MeanReversionUsesMixed) {
+    StrategyConfig cfg;
+    cfg.capital_allocation = 100000.0;
+    cfg.max_leverage = 2.0;
+    cfg.max_drawdown = 0.3;
+    cfg.asset_classes = {AssetClass::EQUITIES};
+    cfg.frequencies = {DataFrequency::DAILY};
+    cfg.trading_params["AAPL"] = 1.0;
+    cfg.position_limits["AAPL"] = 1000.0;
+
+    MeanReversionConfig mr;
+    mr.lookback_period = 20;
+    mr.vol_lookback = 20;
+    mr.entry_threshold = 2.0;
+    mr.exit_threshold = 0.5;
+    mr.risk_target = 0.15;
+    mr.position_size = 0.1;
+
+    MeanReversionStrategy strat("TEST_MR_PNL", cfg, mr, db_);
+    ASSERT_TRUE(strat.initialize().is_ok());
+
+    EXPECT_EQ(strat.get_pnl_accounting().method, PnLAccountingMethod::MIXED)
+        << "Equity mean reversion must declare MIXED accounting so the "
+           "backtest coordinator skips daily realized_pnl writes (Phase 4 §1.14).";
+}
+
+TEST_F(PnLAccountingBranchTest, TrendFollowingUsesRealizedOnly) {
+    StrategyConfig cfg;
+    cfg.capital_allocation = 100000.0;
+    cfg.max_leverage = 2.0;
+    cfg.max_drawdown = 0.3;
+    cfg.asset_classes = {AssetClass::FUTURES};
+    cfg.frequencies = {DataFrequency::DAILY};
+    cfg.trading_params["ES"] = 1.0;
+    cfg.position_limits["ES"] = 10.0;
+
+    TrendFollowingConfig tfc;
+
+    TrendFollowingStrategy strat("TEST_TF_PNL", cfg, tfc, db_);
+    ASSERT_TRUE(strat.initialize().is_ok());
+
+    EXPECT_EQ(strat.get_pnl_accounting().method, PnLAccountingMethod::REALIZED_ONLY)
+        << "Futures trend following must declare REALIZED_ONLY accounting so "
+           "the backtest coordinator writes daily MTM into realized_pnl "
+           "(futures settle daily) per Phase 4 §1.14.";
+}
+
+TEST_F(PnLAccountingBranchTest, AccessorIsStableAcrossCalls) {
+    StrategyConfig cfg;
+    cfg.capital_allocation = 100000.0;
+    cfg.max_leverage = 2.0;
+    cfg.max_drawdown = 0.3;
+    cfg.asset_classes = {AssetClass::EQUITIES};
+    cfg.frequencies = {DataFrequency::DAILY};
+    cfg.trading_params["AAPL"] = 1.0;
+    cfg.position_limits["AAPL"] = 1000.0;
+
+    MeanReversionStrategy strat("TEST_MR_STABLE", cfg, MeanReversionConfig{}, db_);
+    ASSERT_TRUE(strat.initialize().is_ok());
+
+    auto method_a = strat.get_pnl_accounting().method;
+    auto method_b = strat.get_pnl_accounting().method;
+    auto method_c = strat.get_pnl_accounting().method;
+    EXPECT_EQ(method_a, method_b);
+    EXPECT_EQ(method_b, method_c);
+}

--- a/tests/live/test_audit_log_cumulative_dividend.cpp
+++ b/tests/live/test_audit_log_cumulative_dividend.cpp
@@ -1,0 +1,123 @@
+#include <gtest/gtest.h>
+#include <cstdlib>
+#include <filesystem>
+#include <string>
+#include "trade_ngin/live/corporate_actions_applier.hpp"
+#include "trade_ngin/live/corporate_actions_audit_log.hpp"
+
+using namespace trade_ngin;
+
+// Phase 4.5 test TDI.1 — total_cumulative_dividend_income() accessor.
+// Sums total_cash across all recorded DIVIDEND events; SPLITs are not
+// included. Persisted to disk via save() and reloadable via load().
+
+namespace {
+
+class AuditLogCumulativeDividendTest : public ::testing::Test {
+protected:
+    void SetUp() override {
+        state_dir_ = (std::filesystem::temp_directory_path() /
+                      ("ca_cum_div_" + std::to_string(std::rand())))
+                         .string();
+    }
+    void TearDown() override {
+        std::error_code ec;
+        std::filesystem::remove_all(state_dir_, ec);
+    }
+    std::string state_dir_;
+};
+
+PositionAdjustment dividend_adj(const std::string& symbol,
+                                const std::string& date,
+                                double qty_after,
+                                double per_share) {
+    PositionAdjustment adj;
+    adj.symbol = symbol;
+    adj.event_date = date;
+    adj.type = CorpActionType::DIVIDEND;
+    adj.quantity_before = qty_after;
+    adj.quantity_after = qty_after;
+    adj.avg_price_before = 100.0;
+    adj.avg_price_after = 99.75;
+    adj.event_value = per_share;
+    adj.ratio_change = 1.0 + per_share / 100.0;
+    return adj;
+}
+
+PositionAdjustment split_adj(const std::string& symbol,
+                             const std::string& date,
+                             double factor) {
+    PositionAdjustment adj;
+    adj.symbol = symbol;
+    adj.event_date = date;
+    adj.type = CorpActionType::SPLIT;
+    adj.quantity_before = 100.0;
+    adj.quantity_after = 100.0 * factor;
+    adj.avg_price_before = 400.0;
+    adj.avg_price_after = 400.0 / factor;
+    adj.event_value = factor;
+    adj.ratio_change = factor;
+    return adj;
+}
+
+}  // namespace
+
+// Empty log returns 0.
+TEST_F(AuditLogCumulativeDividendTest, EmptyLogReturnsZero) {
+    CorporateActionsAuditLog log(state_dir_);
+    log.load();
+    EXPECT_DOUBLE_EQ(log.total_cumulative_dividend_income(), 0.0);
+}
+
+// Three dividends sum correctly.
+TEST_F(AuditLogCumulativeDividendTest, ThreeDividendsSumTotalCash) {
+    CorporateActionsAuditLog log(state_dir_);
+    log.load();
+    // qty 100 * $0.25 = $25
+    log.record(dividend_adj("AAPL", "2024-08-12", 100.0, 0.25));
+    // qty 100 * $0.30 = $30
+    log.record(dividend_adj("MSFT", "2024-08-15", 100.0, 0.30));
+    // qty 100 * $0.50 = $50
+    log.record(dividend_adj("NSC", "2024-09-01", 100.0, 0.50));
+
+    EXPECT_DOUBLE_EQ(log.total_cumulative_dividend_income(), 105.0);
+}
+
+// Splits are NOT included in the cumulative sum.
+TEST_F(AuditLogCumulativeDividendTest, SplitsDoNotContribute) {
+    CorporateActionsAuditLog log(state_dir_);
+    log.load();
+    log.record(dividend_adj("AAPL", "2024-08-12", 100.0, 0.25));   // $25
+    log.record(split_adj("NVDA", "2024-06-10", 10.0));             // $0 (split)
+    log.record(dividend_adj("MSFT", "2024-08-15", 100.0, 0.30));   // $30
+    log.record(split_adj("TSLA", "2022-08-25", 3.0));              // $0 (split)
+    EXPECT_DOUBLE_EQ(log.total_cumulative_dividend_income(), 55.0);
+}
+
+// Sum survives save/reload round-trip.
+TEST_F(AuditLogCumulativeDividendTest, SumPersistsAcrossReload) {
+    {
+        CorporateActionsAuditLog log(state_dir_);
+        log.load();
+        log.record(dividend_adj("AAPL", "2024-08-12", 100.0, 0.25));
+        log.record(dividend_adj("MSFT", "2024-08-15", 100.0, 0.30));
+        ASSERT_TRUE(log.save());
+    }
+    CorporateActionsAuditLog log2(state_dir_);
+    ASSERT_TRUE(log2.load());
+    EXPECT_DOUBLE_EQ(log2.total_cumulative_dividend_income(), 55.0);
+}
+
+// Fractional quantities and fractional dividends (after stacked dividends
+// scale avg_price, qty_held is what's reported pre-rescale -- but the
+// accessor just sums whatever is in the file).
+TEST_F(AuditLogCumulativeDividendTest, FractionalSumsExactly) {
+    CorporateActionsAuditLog log(state_dir_);
+    log.load();
+    // 50 shares * $0.1234 = $6.17
+    log.record(dividend_adj("FOO", "2024-01-01", 50.0, 0.1234));
+    // 25 shares * $0.0500 = $1.25
+    log.record(dividend_adj("BAR", "2024-02-01", 25.0, 0.05));
+    // Total: 6.17 + 1.25 = 7.42
+    EXPECT_NEAR(log.total_cumulative_dividend_income(), 7.42, 1e-9);
+}

--- a/tests/live/test_corp_actions_applier.cpp
+++ b/tests/live/test_corp_actions_applier.cpp
@@ -1,0 +1,184 @@
+#include <gtest/gtest.h>
+#include <cmath>
+#include <unordered_map>
+#include <vector>
+#include "trade_ngin/core/types.hpp"
+#include "trade_ngin/live/corporate_actions_applier.hpp"
+
+using namespace trade_ngin;
+
+// Phase 4 audit tests T4.1, T4.2, T4.5 (applier unit semantics).
+
+namespace {
+
+Position make_position(const std::string& symbol, double qty, double avg_price) {
+    Position p;
+    p.symbol = symbol;
+    p.quantity = Quantity(qty);
+    p.average_price = Decimal(avg_price);
+    return p;
+}
+
+CorpActionEvent split_event(const std::string& symbol, const std::string& date, double factor) {
+    CorpActionEvent ev;
+    ev.symbol = symbol;
+    ev.ex_date = date;
+    ev.type = CorpActionType::SPLIT;
+    ev.value = factor;
+    return ev;
+}
+
+CorpActionEvent dividend_event(const std::string& symbol, const std::string& date,
+                               double per_share, double close_tm1) {
+    CorpActionEvent ev;
+    ev.symbol = symbol;
+    ev.ex_date = date;
+    ev.type = CorpActionType::DIVIDEND;
+    ev.value = per_share;
+    ev.close_t_minus_1 = close_tm1;
+    return ev;
+}
+
+}  // namespace
+
+// T4.1: 4-for-1 split moves 100 AAPL @ $400 -> 400 @ $100. Notional preserved.
+TEST(CorpActionsApplierTest, SplitFourForOne) {
+    std::unordered_map<std::string, Position> positions;
+    positions["AAPL"] = make_position("AAPL", 100.0, 400.0);
+
+    auto log = CorporateActionsApplier::apply(
+        positions, {split_event("AAPL", "2020-08-31", 4.0)});
+
+    ASSERT_EQ(log.size(), 1u);
+    EXPECT_EQ(log[0].type, CorpActionType::SPLIT);
+    EXPECT_DOUBLE_EQ(positions["AAPL"].quantity.as_double(), 400.0);
+    EXPECT_DOUBLE_EQ(positions["AAPL"].average_price.as_double(), 100.0);
+
+    // Notional invariant (qty × avg_price) preserved.
+    const double notional_before = 100.0 * 400.0;
+    const double notional_after = positions["AAPL"].quantity.as_double() *
+                                  positions["AAPL"].average_price.as_double();
+    EXPECT_DOUBLE_EQ(notional_after, notional_before);
+}
+
+// T4.2: dividend rescales avg_price into the post-rescale closeadj frame.
+// Position 100 AAPL bought at $100. $0.25 dividend, close[T-1]=$100.
+// Expected ratio = 1 + 0.25/100 = 1.0025. Expected new avg_price = 100/1.0025 ≈ 99.751.
+TEST(CorpActionsApplierTest, DividendRescaleAvgPrice) {
+    std::unordered_map<std::string, Position> positions;
+    positions["AAPL"] = make_position("AAPL", 100.0, 100.0);
+
+    auto log = CorporateActionsApplier::apply(
+        positions, {dividend_event("AAPL", "2024-08-12", 0.25, 100.0)});
+
+    ASSERT_EQ(log.size(), 1u);
+    EXPECT_EQ(log[0].type, CorpActionType::DIVIDEND);
+    EXPECT_DOUBLE_EQ(positions["AAPL"].quantity.as_double(), 100.0);  // unchanged
+    EXPECT_NEAR(positions["AAPL"].average_price.as_double(), 99.7506234, 1e-6);
+    EXPECT_NEAR(log[0].ratio_change, 1.0025, 1e-6);
+}
+
+// Stacked events on the same symbol apply in input order.
+// 100 AAPL @ $400 -> 4-for-1 split -> 400 @ $100 -> $0.25 div on $100 close ->
+// 400 @ ~$99.7506.
+TEST(CorpActionsApplierTest, StackedSplitThenDividend) {
+    std::unordered_map<std::string, Position> positions;
+    positions["AAPL"] = make_position("AAPL", 100.0, 400.0);
+
+    auto log = CorporateActionsApplier::apply(
+        positions,
+        {split_event("AAPL", "2020-08-31", 4.0),
+         dividend_event("AAPL", "2024-08-12", 0.25, 100.0)});
+
+    ASSERT_EQ(log.size(), 2u);
+    EXPECT_DOUBLE_EQ(positions["AAPL"].quantity.as_double(), 400.0);
+    EXPECT_NEAR(positions["AAPL"].average_price.as_double(), 99.7506234, 1e-6);
+}
+
+// ADR_SPLIT behaves identically to SPLIT.
+TEST(CorpActionsApplierTest, AdrSplitMatchesSplit) {
+    std::unordered_map<std::string, Position> positions;
+    positions["FOO"] = make_position("FOO", 200.0, 50.0);
+
+    CorpActionEvent ev;
+    ev.symbol = "FOO";
+    ev.ex_date = "2023-01-01";
+    ev.type = CorpActionType::ADR_SPLIT;
+    ev.value = 2.0;
+
+    auto log = CorporateActionsApplier::apply(positions, {ev});
+
+    ASSERT_EQ(log.size(), 1u);
+    EXPECT_DOUBLE_EQ(positions["FOO"].quantity.as_double(), 400.0);
+    EXPECT_DOUBLE_EQ(positions["FOO"].average_price.as_double(), 25.0);
+}
+
+// Events for symbols absent from positions map are no-ops.
+TEST(CorpActionsApplierTest, MissingSymbolIsSkipped) {
+    std::unordered_map<std::string, Position> positions;
+    positions["MSFT"] = make_position("MSFT", 100.0, 400.0);
+
+    auto log = CorporateActionsApplier::apply(
+        positions, {split_event("AAPL", "2020-08-31", 4.0)});
+
+    EXPECT_TRUE(log.empty());
+    EXPECT_DOUBLE_EQ(positions["MSFT"].quantity.as_double(), 100.0);
+    EXPECT_TRUE(positions.find("AAPL") == positions.end());
+}
+
+// Zero-quantity positions are skipped.
+TEST(CorpActionsApplierTest, ZeroQuantityIsSkipped) {
+    std::unordered_map<std::string, Position> positions;
+    positions["AAPL"] = make_position("AAPL", 0.0, 100.0);
+
+    auto log = CorporateActionsApplier::apply(
+        positions, {split_event("AAPL", "2020-08-31", 4.0)});
+
+    EXPECT_TRUE(log.empty());
+    EXPECT_DOUBLE_EQ(positions["AAPL"].quantity.as_double(), 0.0);
+    EXPECT_DOUBLE_EQ(positions["AAPL"].average_price.as_double(), 100.0);
+}
+
+// Invalid split factors are skipped with a log warning (not a crash).
+TEST(CorpActionsApplierTest, InvalidSplitFactorSkipped) {
+    std::unordered_map<std::string, Position> positions;
+    positions["AAPL"] = make_position("AAPL", 100.0, 400.0);
+
+    auto log = CorporateActionsApplier::apply(
+        positions, {split_event("AAPL", "2020-08-31", 0.0)});
+    EXPECT_TRUE(log.empty());
+    EXPECT_DOUBLE_EQ(positions["AAPL"].quantity.as_double(), 100.0);
+}
+
+// Invalid dividend inputs (zero close[T-1] or zero amount) are skipped.
+TEST(CorpActionsApplierTest, InvalidDividendInputsSkipped) {
+    std::unordered_map<std::string, Position> positions;
+    positions["AAPL"] = make_position("AAPL", 100.0, 100.0);
+
+    // close[T-1] == 0
+    auto log1 = CorporateActionsApplier::apply(
+        positions, {dividend_event("AAPL", "2024-08-12", 0.25, 0.0)});
+    EXPECT_TRUE(log1.empty());
+
+    // amount == 0
+    auto log2 = CorporateActionsApplier::apply(
+        positions, {dividend_event("AAPL", "2024-08-12", 0.0, 100.0)});
+    EXPECT_TRUE(log2.empty());
+
+    EXPECT_DOUBLE_EQ(positions["AAPL"].average_price.as_double(), 100.0);
+}
+
+// type_from_action_string parses the equities_data.corporate_action.action
+// text values that the live app passes in.
+TEST(CorpActionsApplierTest, TypeFromActionString) {
+    EXPECT_EQ(CorporateActionsApplier::type_from_action_string("split"),
+              CorpActionType::SPLIT);
+    EXPECT_EQ(CorporateActionsApplier::type_from_action_string("adrratiosplit"),
+              CorpActionType::ADR_SPLIT);
+    EXPECT_EQ(CorporateActionsApplier::type_from_action_string("dividend"),
+              CorpActionType::DIVIDEND);
+    EXPECT_EQ(CorporateActionsApplier::type_from_action_string("spinoff"),
+              CorpActionType::UNKNOWN);
+    EXPECT_EQ(CorporateActionsApplier::type_from_action_string(""),
+              CorpActionType::UNKNOWN);
+}

--- a/tests/live/test_corp_actions_audit_log.cpp
+++ b/tests/live/test_corp_actions_audit_log.cpp
@@ -1,0 +1,128 @@
+#include <gtest/gtest.h>
+#include <cstdlib>
+#include <filesystem>
+#include <fstream>
+#include <iterator>
+#include <string>
+#include "trade_ngin/live/corporate_actions_applier.hpp"
+#include "trade_ngin/live/corporate_actions_audit_log.hpp"
+
+using namespace trade_ngin;
+
+// Phase 4 audit test T4.4 — idempotency via the on-disk dedup state file.
+
+namespace {
+
+class CorpActionsAuditLogTest : public ::testing::Test {
+protected:
+    void SetUp() override {
+        state_dir_ = (std::filesystem::temp_directory_path() /
+                      ("ca_audit_log_" + std::to_string(std::rand())))
+                         .string();
+    }
+    void TearDown() override {
+        std::error_code ec;
+        std::filesystem::remove_all(state_dir_, ec);
+    }
+    std::string state_dir_;
+};
+
+PositionAdjustment make_split_adj(const std::string& symbol,
+                                  const std::string& date) {
+    PositionAdjustment adj;
+    adj.symbol = symbol;
+    adj.event_date = date;
+    adj.type = CorpActionType::SPLIT;
+    adj.quantity_before = 100.0;
+    adj.quantity_after = 400.0;
+    adj.avg_price_before = 400.0;
+    adj.avg_price_after = 100.0;
+    adj.event_value = 4.0;
+    adj.ratio_change = 4.0;
+    return adj;
+}
+
+PositionAdjustment make_div_adj(const std::string& symbol,
+                                const std::string& date,
+                                double qty_held,
+                                double per_share) {
+    PositionAdjustment adj;
+    adj.symbol = symbol;
+    adj.event_date = date;
+    adj.type = CorpActionType::DIVIDEND;
+    adj.quantity_before = qty_held;
+    adj.quantity_after = qty_held;  // dividend doesn't change qty
+    adj.avg_price_before = 100.0;
+    adj.avg_price_after = 99.75;
+    adj.event_value = per_share;
+    adj.ratio_change = 1.0 + per_share / 100.0;
+    return adj;
+}
+
+}  // namespace
+
+// First-run: load returns false, in-memory state is empty.
+TEST_F(CorpActionsAuditLogTest, FirstRunLoadReturnsFalseEmpty) {
+    CorporateActionsAuditLog log(state_dir_);
+    EXPECT_FALSE(log.load());
+    EXPECT_FALSE(log.is_applied("AAPL", "2020-08-31", CorpActionType::SPLIT));
+}
+
+// Record, save, reload, verify the dedup record persists.
+TEST_F(CorpActionsAuditLogTest, RecordSaveReloadDedupesFutureRuns) {
+    {
+        CorporateActionsAuditLog log(state_dir_);
+        log.load();
+        log.record(make_split_adj("AAPL", "2020-08-31"));
+        EXPECT_TRUE(log.save());
+    }
+    // Fresh instance loads from disk.
+    CorporateActionsAuditLog log2(state_dir_);
+    EXPECT_TRUE(log2.load());
+    EXPECT_TRUE(log2.is_applied("AAPL", "2020-08-31", CorpActionType::SPLIT));
+    EXPECT_FALSE(log2.is_applied("AAPL", "2020-08-31", CorpActionType::DIVIDEND));
+    EXPECT_FALSE(log2.is_applied("NVDA", "2024-06-10", CorpActionType::SPLIT));
+}
+
+// Dividend records also capture cash-flow detail in the dividend_events
+// section of the JSON file -- this is the audit-trail substitute for the
+// deferred trading.dividend_ledger table.
+TEST_F(CorpActionsAuditLogTest, DividendCashFlowCapturedInState) {
+    {
+        CorporateActionsAuditLog log(state_dir_);
+        log.load();
+        log.record(make_div_adj("AAPL", "2024-08-12", 100.0, 0.25));
+        ASSERT_TRUE(log.save());
+    }
+    // Read the file directly and confirm dividend_events has the entry.
+    std::ifstream f(state_dir_ + "/applied_corp_actions.json");
+    ASSERT_TRUE(f.is_open());
+    std::string content((std::istreambuf_iterator<char>(f)),
+                        std::istreambuf_iterator<char>());
+    EXPECT_NE(content.find("dividend_events"), std::string::npos);
+    EXPECT_NE(content.find("AAPL"), std::string::npos);
+    EXPECT_NE(content.find("2024-08-12"), std::string::npos);
+    // total_cash = qty_held (100) * per_share (0.25) = 25.0
+    EXPECT_NE(content.find("25.0"), std::string::npos);
+}
+
+// Idempotency: applying the same event twice via the audit-log dedup
+// pattern must result in only one record in state. Mimics what the live
+// equity app's filter_unapplied + record loop produces across two daily runs.
+TEST_F(CorpActionsAuditLogTest, IdempotencyAcrossTwoRuns) {
+    const auto adj = make_split_adj("NVDA", "2024-06-10");
+
+    // Run 1: not yet applied -> record + save.
+    {
+        CorporateActionsAuditLog log(state_dir_);
+        log.load();
+        ASSERT_FALSE(log.is_applied(adj.symbol, adj.event_date, adj.type));
+        log.record(adj);
+        ASSERT_TRUE(log.save());
+    }
+    // Run 2: load -> already applied -> caller would skip.
+    CorporateActionsAuditLog log2(state_dir_);
+    log2.load();
+    EXPECT_TRUE(log2.is_applied(adj.symbol, adj.event_date, adj.type));
+    // Caller filter_unapplied would drop this event; positions stay unchanged.
+}

--- a/tests/live/test_corp_actions_long_hold_total_return.cpp
+++ b/tests/live/test_corp_actions_long_hold_total_return.cpp
@@ -1,0 +1,71 @@
+#include <gtest/gtest.h>
+#include <cmath>
+#include <string>
+#include <unordered_map>
+#include <vector>
+#include "trade_ngin/core/types.hpp"
+#include "trade_ngin/live/corporate_actions_applier.hpp"
+
+using namespace trade_ngin;
+
+// Phase 4 audit test T4.3 — long-hold total-return regression guard for §1.15.
+//
+// Scenario: held 100 shares of a 4%-annual-yield equity for 1 year with no
+// net price change. Provider uses backward (retroactive) closeadj
+// adjustment, so each dividend rescales the closeadj curve. Pre-fix, the
+// stored avg_price never updated, accumulating ~4% understatement of return.
+// Post-fix, the avg_price /= (1 + d/close_t_minus_1) rescaling per
+// dividend keeps the avg_price in the same closeadj frame as bar.close,
+// so MTM correctly reflects total return.
+//
+// We simulate 4 quarterly dividends of $1 (total $4) on a $100 stock held
+// at 100 shares for the year. End-of-year closeadj = $100 (provider has
+// retroactively rescaled the original purchase price down by the same
+// cumulative factor). Pre-fix: avg_price still $100, MTM = (100-100)*100 = $0
+// (silently dropping the $400 of return). Post-fix: avg_price /= each
+// quarter's ratio, ends ≈ $96.117, MTM = (100-96.117)*100 ≈ $388 ≈ 4%.
+
+TEST(CorpActionsLongHoldTotalReturnTest, FourQuarterlyDividendsCaptureTotalReturn) {
+    std::unordered_map<std::string, Position> positions;
+    Position p;
+    p.symbol = "DIVCO";
+    p.quantity = Quantity(100.0);
+    p.average_price = Decimal(100.0);
+    positions["DIVCO"] = p;
+
+    // 4 quarterly dividends of $1.00 each, close[T-1] = $100 each quarter
+    // (no net price change over the year).
+    std::vector<CorpActionEvent> events;
+    for (int q = 0; q < 4; ++q) {
+        CorpActionEvent ev;
+        ev.symbol = "DIVCO";
+        ev.ex_date = "2025-" + std::to_string(3 * (q + 1)) + "-15";
+        ev.type = CorpActionType::DIVIDEND;
+        ev.value = 1.00;
+        ev.close_t_minus_1 = 100.0;
+        events.push_back(ev);
+    }
+
+    auto log = CorporateActionsApplier::apply(positions, events);
+    ASSERT_EQ(log.size(), 4u);
+
+    // Each dividend scales avg_price by 1/(1 + 1/100) = 1/1.01.
+    // After 4 quarters: avg_price = 100 / 1.01^4 = 100 / 1.04060401 ≈ 96.0980
+    const double expected_avg = 100.0 / std::pow(1.01, 4);
+    EXPECT_NEAR(positions["DIVCO"].average_price.as_double(), expected_avg, 1e-6);
+
+    // MTM at year-end close $100 reflects the accumulated total return.
+    const double mtm = (100.0 - positions["DIVCO"].average_price.as_double()) *
+                       positions["DIVCO"].quantity.as_double();
+    // 4% annual yield on 100 shares × $100 = $400 nominal, but the
+    // compound-rescale formula gives slightly less than nominal:
+    // mtm = (100 - 100/1.01^4) * 100 ≈ 100 - 96.0980) * 100 ≈ 390.20
+    EXPECT_NEAR(mtm, 100.0 * (100.0 - expected_avg), 1e-6);
+    EXPECT_GT(mtm, 380.0)
+        << "Total return should be ~$390 (close to nominal 4% on $10K). "
+           "Pre-fix MTM would be exactly $0 -- §1.15 silent understatement.";
+    EXPECT_LT(mtm, 400.0);
+
+    // Sanity: quantity is unchanged (dividends don't change share count).
+    EXPECT_DOUBLE_EQ(positions["DIVCO"].quantity.as_double(), 100.0);
+}

--- a/tests/live/test_corp_actions_ultrareview_fixes.cpp
+++ b/tests/live/test_corp_actions_ultrareview_fixes.cpp
@@ -1,0 +1,201 @@
+#include <gtest/gtest.h>
+
+#include <cstdlib>
+#include <filesystem>
+#include <fstream>
+#include <string>
+#include <unordered_map>
+#include <vector>
+
+#include "trade_ngin/core/types.hpp"
+#include "trade_ngin/live/corporate_actions_applier.hpp"
+#include "trade_ngin/live/corporate_actions_audit_log.hpp"
+
+using namespace trade_ngin;
+
+// Ultrareview PR #38 fix verification.
+// Pins the three behaviors that ultrareview flagged as real correctness or
+// durability gaps and we resolved in this PR:
+//   - bug_021 (cash-basis qty): the audit log records ex_date qty, not today's.
+//   - bug_003 (atomic save):    the on-disk state file is written via tmp+rename.
+// bug_007, merged_bug_001, bug_013, bug_037, bug_002 are wire-up concerns in
+// the live equity app's main() and are exercised via integration / manual
+// verification (the unit-test surface here is just the pure-logic layer).
+
+namespace {
+
+Position make_position(const std::string& symbol, double qty, double avg_price) {
+    Position p;
+    p.symbol = symbol;
+    p.quantity = Quantity(qty);
+    p.average_price = Decimal(avg_price);
+    return p;
+}
+
+CorpActionEvent dividend_event(const std::string& symbol,
+                               const std::string& date,
+                               double per_share,
+                               double close_tm1,
+                               double qty_at_ex = 0.0) {
+    CorpActionEvent ev;
+    ev.symbol = symbol;
+    ev.ex_date = date;
+    ev.type = CorpActionType::DIVIDEND;
+    ev.value = per_share;
+    ev.close_t_minus_1 = close_tm1;
+    ev.qty_at_ex_date = qty_at_ex;
+    return ev;
+}
+
+}  // namespace
+
+// bug_021: cash-flow figure uses ex_date qty (not today's), so a catch-up
+// run days after the ex_date still records the correct dividend cash.
+//
+// Setup: position is 100 today, but on ex_date the operator was holding 200.
+// $0.50 dividend per share. The cash recorded should be 200*0.50 = $100,
+// NOT 100*0.50 = $50.
+TEST(CorpActionsUltrareviewFixes, DividendUsesQtyAtExDateForCashBasis) {
+    std::unordered_map<std::string, Position> positions;
+    positions["AAPL"] = make_position("AAPL", 100.0, 100.0);
+
+    auto log = CorporateActionsApplier::apply(
+        positions,
+        {dividend_event("AAPL", "2024-08-12", 0.50, 100.0, /*qty_at_ex=*/200.0)});
+
+    ASSERT_EQ(log.size(), 1u);
+    // The recorded adjustment's quantity reflects ex_date holding (200), not
+    // today's live position (100). avg_price math still uses the live position
+    // (dividends don't change qty, only rescale avg_price into closeadj frame).
+    EXPECT_DOUBLE_EQ(log[0].quantity_before, 200.0);
+    EXPECT_DOUBLE_EQ(log[0].quantity_after, 200.0);
+    // Position quantity in-memory is unchanged (qty doesn't change on dividend).
+    EXPECT_DOUBLE_EQ(positions["AAPL"].quantity.as_double(), 100.0);
+}
+
+// bug_021 regression guard: when the live app couldn't reconstruct ex_date qty
+// (first-week catch-up, missing historical row, etc.) and leaves qty_at_ex_date
+// at 0.0, the applier falls back to the live position quantity -- preserving
+// pre-fix behavior so no audit log diff for the common same-day path.
+TEST(CorpActionsUltrareviewFixes, DividendFallsBackToCurrentQtyWhenExDateQtyUnset) {
+    std::unordered_map<std::string, Position> positions;
+    positions["AAPL"] = make_position("AAPL", 100.0, 100.0);
+
+    auto log = CorporateActionsApplier::apply(
+        positions,
+        {dividend_event("AAPL", "2024-08-12", 0.50, 100.0, /*qty_at_ex=*/0.0)});
+
+    ASSERT_EQ(log.size(), 1u);
+    EXPECT_DOUBLE_EQ(log[0].quantity_before, 100.0);
+    EXPECT_DOUBLE_EQ(log[0].quantity_after, 100.0);
+}
+
+// bug_021 cash-flow round-trip: the audit log uses the applier's recorded
+// quantity_after as the dividend basis when computing total_cash for
+// total_cumulative_dividend_income(). With qty_at_ex_date=200 and
+// $0.50/share, total_cash should be $100, not $50.
+TEST(CorpActionsUltrareviewFixes, AuditLogTotalCashHonorsExDateQty) {
+    const std::string state_dir =
+        (std::filesystem::temp_directory_path() /
+         ("ca_ultrareview_div_basis_" + std::to_string(std::rand()))).string();
+
+    std::unordered_map<std::string, Position> positions;
+    positions["AAPL"] = make_position("AAPL", 100.0, 100.0);
+
+    auto log_records = CorporateActionsApplier::apply(
+        positions,
+        {dividend_event("AAPL", "2024-08-12", 0.50, 100.0, /*qty_at_ex=*/200.0)});
+
+    CorporateActionsAuditLog audit(state_dir);
+    audit.load();
+    for (const auto& r : log_records) audit.record(r);
+    EXPECT_DOUBLE_EQ(audit.total_cumulative_dividend_income(), 100.0);
+
+    std::error_code ec;
+    std::filesystem::remove_all(state_dir, ec);
+}
+
+// bug_003: save() must be atomic -- write to a sibling .tmp and rename
+// into place. After a successful save, the .tmp must not linger.
+TEST(CorpActionsUltrareviewFixes, AtomicSaveLeavesNoTempFile) {
+    const std::string state_dir =
+        (std::filesystem::temp_directory_path() /
+         ("ca_ultrareview_atomic_" + std::to_string(std::rand()))).string();
+
+    {
+        CorporateActionsAuditLog audit(state_dir);
+        audit.load();
+        PositionAdjustment adj;
+        adj.symbol = "AAPL";
+        adj.event_date = "2024-08-12";
+        adj.type = CorpActionType::DIVIDEND;
+        adj.quantity_before = 100.0;
+        adj.quantity_after = 100.0;
+        adj.avg_price_before = 100.0;
+        adj.avg_price_after = 99.75;
+        adj.event_value = 0.25;
+        adj.ratio_change = 1.0025;
+        audit.record(adj);
+        ASSERT_TRUE(audit.save());
+    }
+
+    const std::string final_path = state_dir + "/applied_corp_actions.json";
+    const std::string tmp_path = final_path + ".tmp";
+    EXPECT_TRUE(std::filesystem::exists(final_path));
+    EXPECT_FALSE(std::filesystem::exists(tmp_path))
+        << "Atomic save must not leave a .tmp sibling after success";
+
+    // Reload from disk and verify the JSON parsed (i.e. the file is not
+    // corrupted from a half-write).
+    CorporateActionsAuditLog reload(state_dir);
+    ASSERT_TRUE(reload.load());
+    EXPECT_DOUBLE_EQ(reload.total_cumulative_dividend_income(), 25.0);
+
+    std::error_code ec;
+    std::filesystem::remove_all(state_dir, ec);
+}
+
+// bug_003 regression: a stale .tmp from an earlier crash is harmless --
+// the next save() overwrites it via the rename, leaving the final file
+// valid and the .tmp gone.
+TEST(CorpActionsUltrareviewFixes, AtomicSaveOverwritesStaleTempFile) {
+    const std::string state_dir =
+        (std::filesystem::temp_directory_path() /
+         ("ca_ultrareview_stale_tmp_" + std::to_string(std::rand()))).string();
+    std::filesystem::create_directories(state_dir);
+    const std::string final_path = state_dir + "/applied_corp_actions.json";
+    const std::string tmp_path = final_path + ".tmp";
+
+    // Simulate stale tmp from a prior crash (corrupt half-JSON).
+    {
+        std::ofstream stale(tmp_path);
+        stale << "{ \"applied\": [ corrupt";
+    }
+    ASSERT_TRUE(std::filesystem::exists(tmp_path));
+
+    CorporateActionsAuditLog audit(state_dir);
+    audit.load();
+    PositionAdjustment adj;
+    adj.symbol = "MSFT";
+    adj.event_date = "2024-08-15";
+    adj.type = CorpActionType::DIVIDEND;
+    adj.quantity_before = 100.0;
+    adj.quantity_after = 100.0;
+    adj.avg_price_before = 200.0;
+    adj.avg_price_after = 199.70;
+    adj.event_value = 0.30;
+    adj.ratio_change = 1.0015;
+    audit.record(adj);
+    ASSERT_TRUE(audit.save());
+
+    EXPECT_TRUE(std::filesystem::exists(final_path));
+    EXPECT_FALSE(std::filesystem::exists(tmp_path))
+        << "Atomic save must clean up its tmp after rename";
+
+    CorporateActionsAuditLog reload(state_dir);
+    ASSERT_TRUE(reload.load());
+    EXPECT_DOUBLE_EQ(reload.total_cumulative_dividend_income(), 30.0);
+
+    std::error_code ec;
+    std::filesystem::remove_all(state_dir, ec);
+}

--- a/tests/live/test_live_metrics_includes_dividend_income.cpp
+++ b/tests/live/test_live_metrics_includes_dividend_income.cpp
@@ -1,0 +1,96 @@
+#include <gtest/gtest.h>
+#include <cstdlib>
+#include <filesystem>
+#include <string>
+#include <unordered_map>
+#include "trade_ngin/live/corporate_actions_applier.hpp"
+#include "trade_ngin/live/corporate_actions_audit_log.hpp"
+
+using namespace trade_ngin;
+
+// Phase 4.5 test TDI.2 — wire-up contract.
+//
+// The live equity app builds its metrics map at daily finalization with a
+// "total_dividend_income" key whose value comes from
+// CorporateActionsAuditLog::total_cumulative_dividend_income(). This test
+// reproduces that exact call pattern against a state file with a known
+// cumulative total, and asserts the metric lands at the expected key with
+// the expected value. Pins the contract the live app depends on.
+
+namespace {
+
+class LiveMetricsIncludesDividendIncomeTest : public ::testing::Test {
+protected:
+    void SetUp() override {
+        state_dir_ = (std::filesystem::temp_directory_path() /
+                      ("ca_metric_wireup_" + std::to_string(std::rand())))
+                         .string();
+    }
+    void TearDown() override {
+        std::error_code ec;
+        std::filesystem::remove_all(state_dir_, ec);
+    }
+    std::string state_dir_;
+};
+
+PositionAdjustment dividend_adj(const std::string& symbol,
+                                const std::string& date,
+                                double qty_after,
+                                double per_share) {
+    PositionAdjustment adj;
+    adj.symbol = symbol;
+    adj.event_date = date;
+    adj.type = CorpActionType::DIVIDEND;
+    adj.quantity_before = qty_after;
+    adj.quantity_after = qty_after;
+    adj.avg_price_before = 100.0;
+    adj.avg_price_after = 99.75;
+    adj.event_value = per_share;
+    adj.ratio_change = 1.0 + per_share / 100.0;
+    return adj;
+}
+
+}  // namespace
+
+// Set up a state file with $75 in cumulative dividend income, then build a
+// metrics map the same way the live app does and assert the key/value.
+TEST_F(LiveMetricsIncludesDividendIncomeTest, MetricsMapPicksUpCumulativeFromAuditLog) {
+    // Arrange: write a state file with two dividends totaling $75.
+    {
+        CorporateActionsAuditLog log(state_dir_);
+        log.load();
+        // 100 shares * $0.25 = $25
+        log.record(dividend_adj("AAPL", "2024-08-12", 100.0, 0.25));
+        // 100 shares * $0.50 = $50
+        log.record(dividend_adj("MSFT", "2024-08-15", 100.0, 0.50));
+        ASSERT_TRUE(log.save());
+    }
+
+    // Act: mirror the live app's wire-up at the metrics-build site.
+    double total_dividend_income = 0.0;
+    {
+        CorporateActionsAuditLog div_log(state_dir_);
+        div_log.load();
+        total_dividend_income = div_log.total_cumulative_dividend_income();
+    }
+    std::unordered_map<std::string, double> double_metrics = {
+        {"total_pnl", 1234.5},               // placeholder for other metrics
+        {"total_dividend_income", total_dividend_income},
+    };
+
+    // Assert: the metric is exactly the cumulative sum, under the right key.
+    ASSERT_TRUE(double_metrics.count("total_dividend_income"));
+    EXPECT_DOUBLE_EQ(double_metrics["total_dividend_income"], 75.0);
+
+    // Sanity: total_pnl is independent (we did NOT add dividend income to it,
+    // per the audit's locked decision #8).
+    EXPECT_DOUBLE_EQ(double_metrics["total_pnl"], 1234.5);
+}
+
+// First-run / missing-state-file: metric is 0 (file absent → load returns
+// false → in-memory state empty → cumulative is 0).
+TEST_F(LiveMetricsIncludesDividendIncomeTest, MissingStateFileYieldsZeroMetric) {
+    CorporateActionsAuditLog div_log(state_dir_);
+    div_log.load();  // returns false; we ignore the return per the live app
+    EXPECT_DOUBLE_EQ(div_log.total_cumulative_dividend_income(), 0.0);
+}


### PR DESCRIPTION
## Summary
Combined PR closes 3 HIGH + 1 MED + 1 LOW audit finding (§1.12, §1.14, §1.15, §1.16) plus adds the deferred cumulative dividend income reporting column. Two logically distinct phases shipped together because 4.5 is a thin extension of 4 (one accessor + one column + wire-up).

| Phase | Finding | Severity | What changed |
|---|---|---|---|
| 4 | §1.12a/b Position qty + cost basis on splits | HIGH | New CorporateActionsApplier; wired into daily startup after position load |
| 4 | §1.15 closeadj frame-drift on dividends | HIGH | avg_price /= (1 + d/close[T-1]) keeps avg_price in same closeadj frame as bar.close |
| 4 | §1.14 backtest coordinator P&L semantics | MED | Branch on strategy.get_pnl_accounting().method -- equities no longer get daily MTM stamped into realized_pnl |
| 4 | §1.16 ExecutionManager naming | LOW | Header doc now explicit about offline-synthesizer role |
| 4.5 | Cumulative dividend income reporting | (audit §1.12c-revised, deferred) | ALTER TABLE live_results ADD total_dividend_income; sourced from CorporateActionsAuditLog state file |

## Phase 4 — Live corp-action handling

**Key discovery:** \`equities_data.corporate_action\` already exists in the DB (627k rows, 15,924 tickers, direct event feed). Replaced the audit's "derive from closeadj/close ratio" design with direct SELECT -- simpler, more reliable, no changes to \`get_bars()\` contract.

- New \`CorporateActionsApplier\` (pure logic, fully unit-testable): SPLIT/ADR_SPLIT (qty *= F, avg_price /= F), DIVIDEND (avg_price /= ratio_change for the §1.15 frame-alignment fix).
- New \`CorporateActionsAuditLog\` (file-based idempotency): state file at \`state/<strategy_id>/applied_corp_actions.json\` dedups (symbol, ex_date, action) tuples across runs.
- Daily flow wire-up: after position load (~line 495), fetch 14-day window of corp actions, filter via audit log, apply, persist corrected positions back to \`trading.positions\` before strategy generates targets.
- New \`PostgresDatabase::get_corporate_actions()\` (SELECT-only on existing schema, no DDL).
- §1.14 fix in backtest_coordinator: branch on PnLAccountingMethod -- REALIZED_ONLY (futures) writes daily MTM to realized_pnl; MIXED/UNREALIZED_ONLY (equities) leaves it for on_execution to set on actual closes.
- §1.16 ExecutionManager header doc rewritten to make the offline-synthesizer role explicit.

## Phase 4.5 — Cumulative dividend income column

- \`scripts/2026-05-18_phase4.5_dividend_income_column.sql\`: ALTER TABLE \`trading.live_results\` ADD COLUMN \`total_dividend_income DECIMAL(18,8) DEFAULT 0\`. **Operator runs once before deploy.**
- New \`CorporateActionsAuditLog::total_cumulative_dividend_income()\` accessor sums total_cash across recorded DIVIDEND events.
- Live equity app metrics map at finalization picks up \`total_dividend_income\`; \`store_live_results_complete\` (dynamic column-map pattern) writes it automatically.
- Email body SELECT extended to surface the cumulative as a "Dividend Income (cumulative, informational)" row.

**Critical contract (audit §7 decision #8 unchanged):** \`total_dividend_income\` is **informational ONLY -- NOT added to total_pnl**. \`closeadj\` already captures dividend total-return via price continuity (Phase 4 frame-alignment fix). Adding dividend cash on top would double-count.

## Test plan
- [x] Full build clean: \`cmake --build build -j\`
- [x] New Phase 4 tests pass: 17 tests covering applier semantics, audit log persistence, long-hold total return regression guard, P&L accounting branch
- [x] New Phase 4.5 tests pass: 7 tests covering cumulative accessor + metrics wire-up contract
- [x] No regressions on prior phases: full suite 414/414 pass (was 390 pre-Phase-4)
- [ ] Operator runs DDL before deploying: \`psql -f scripts/2026-05-18_phase4.5_dividend_income_column.sql\`
- [ ] Live smoke (manual) -- after DDL: confirm daily log shows "Applied SPLIT/DIVIDEND for ..." when corp actions exist, and \`trading.live_results.total_dividend_income\` populates on the next finalization.
- [ ] Backtest smoke -- equity bt: PnL trajectory should be identical pre/post (Phase 4 affects LIVE path; §1.14 changes how realized_pnl is reported per-row but totals unchanged).

## Notable design calls
- **State file for idempotency, DB for reporting.** Phase 4 uses a JSON state file to dedup events (no schema change needed). Phase 4.5 derives the reporting column from the same state file. The full \`trading.dividend_ledger\` table (audit §1.12c-revised) is deferred -- the state file is the natural backfill source if/when it ships.
- **Splits don't write to DB.** State file remains canonical for both splits and dividend dedup. Only the dividend cumulative is mirrored to DB for reporting.
- **Spinoff / merger / ticker-change events out of scope.** \`equities_data.corporate_action\` has them; adjustment logic is more involved (basis reallocation across spun-off entities). SELECT filter excludes; logged as INFO.
- **14-day lookback window** on corp-action fetch covers weekend/holiday gaps. Audit log prevents re-applies.

## ⚠️ Operational caveat
Dev DB \`equities_data.*\` tables are stale to ~2025-08-29 (today is 2026-05-18, ~9-month gap). Live equity trading on this DB is operating on 9-month-old data already, independent of Phase 4. Code is correct; needs a fresh data feed before production use.

## Out of scope (deferred or permanent)
- \`trading.dividend_ledger\` per-event table (can be added later; state file is the backfill source)
- Per-event DB persistence for dividends (state file canonical)
- Splits in DB (state file canonical)
- Backfill of pre-PR \`live_results\` rows (default 0; not retroactively patched)
- Phase 5 -- loader hardening (separate PR)
- Phase 6 -- cleanup + §1.18 fractional rounding (separate PR)
- §1.13 broker reconciliation -- permanently deferred per audit §7 (paper-trading by design)
- Phase 7a/b/c -- permanently deferred per audit §7

Source audit: \`docs/equities_review_2026-05-03.md\`