### PR TITLE
Fix equity PnL accounting, execution sizing, and build rpath

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -34,6 +34,13 @@ set(CMAKE_LIBRARY_OUTPUT_DIRECTORY_RELEASE "${CMAKE_BINARY_DIR}/bin/Release")
 set(CMAKE_ARCHIVE_OUTPUT_DIRECTORY_DEBUG "${CMAKE_BINARY_DIR}/bin/Debug")
 set(CMAKE_ARCHIVE_OUTPUT_DIRECTORY_RELEASE "${CMAKE_BINARY_DIR}/bin/Release")
 
+# RPATH: executables and libtrade_ngin.dylib share an output directory, so
+# resolve @rpath next to the loading binary. Without this, the build picks up
+# whatever rpath leaks from the environment (e.g. an active conda env's lib
+# dir) and binaries fail to find libtrade_ngin.dylib at launch.
+set(CMAKE_BUILD_RPATH "@loader_path")
+set(CMAKE_BUILD_WITH_INSTALL_RPATH OFF)
+
 # Find packages
 #set(GTest_DIR "C:/vcpkg/installed/x64-windows/share/gtest")
 find_package(GTest CONFIG REQUIRED)

--- a/include/trade_ngin/portfolio/portfolio_manager.hpp
+++ b/include/trade_ngin/portfolio/portfolio_manager.hpp
@@ -266,6 +266,10 @@ private:
     std::unordered_map<std::string, StrategyInfo> strategies_;
     std::vector<ExecutionReport> recent_executions_;  // Portfolio-level (aggregated)
     std::unordered_map<std::string, std::vector<ExecutionReport>> strategy_executions_;  // Per-strategy executions
+    // Per-strategy filled position (symbol -> net qty) accumulated from the
+    // executions this manager generates; baseline for sizing the next order as
+    // (target - filled). Strategy-agnostic -- does not read strategy positions_.
+    std::unordered_map<std::string, std::unordered_map<std::string, double>> filled_positions_;
     
     // Track previous day close prices for PnL Lag Model (prevents lookahead bias)
     std::unordered_map<std::string, double> previous_day_close_prices_;

--- a/include/trade_ngin/strategy/mean_reversion.hpp
+++ b/include/trade_ngin/strategy/mean_reversion.hpp
@@ -76,6 +76,11 @@ public:
     Result<void> on_data(const std::vector<Bar>& data) override;
     Result<void> initialize() override;
 
+    // Surfaces target positions from instrument_data_.target_position. positions_
+    // is left to BaseStrategy::on_execution() as the actual-holdings record, so
+    // on_data() must not write it (doing so made on_execution double-apply fills).
+    std::unordered_map<std::string, Position> get_target_positions() const override;
+
     std::unordered_map<std::string, std::vector<double>> get_price_history() const override {
         std::unordered_map<std::string, std::vector<double>> history;
         for (const auto& [symbol, data] : instrument_data_) {

--- a/src/data/postgres_database_extensions.cpp
+++ b/src/data/postgres_database_extensions.cpp
@@ -432,8 +432,9 @@ Result<void> PostgresDatabase::store_backtest_positions_with_strategy(
                      txn.quote(pos.symbol) + ", " +
                      std::to_string(static_cast<double>(pos.quantity)) + ", " +
                      std::to_string(static_cast<double>(pos.average_price)) + ", " +
-                     std::to_string(static_cast<double>(pos.realized_pnl)) + ", " +
-                     std::to_string(static_cast<double>(pos.unrealized_pnl)) + ", " + "'" +
+                     // Column order is (unrealized_pnl, realized_pnl) -- emit values to match.
+                     std::to_string(static_cast<double>(pos.unrealized_pnl)) + ", " +
+                     std::to_string(static_cast<double>(pos.realized_pnl)) + ", " + "'" +
                      last_update_str + "', " +      // last_update
                      "'" + last_update_str + "'" +  // updated_at (same as last_update)
                      ")";

--- a/src/portfolio/portfolio_manager.cpp
+++ b/src/portfolio/portfolio_manager.cpp
@@ -160,7 +160,6 @@ Result<void> PortfolioManager::process_market_data(const std::vector<Bar>& data,
     std::vector<std::string> processed_strategies;
 
     try {
-        std::unordered_map<std::string, std::unordered_map<std::string, Position>> prev_positions;
         std::unordered_map<std::string, Position> prev_portfolio_positions;
         {
             std::lock_guard<std::mutex> lock(mutex_);
@@ -174,11 +173,6 @@ Result<void> PortfolioManager::process_market_data(const std::vector<Bar>& data,
 
             // Update historical returns for all symbols
             update_historical_returns(data);
-
-            // Store current positions for each strategy to detect changes
-            for (const auto& [id, info] : strategies_) {
-                prev_positions[id] = info.current_positions;
-            }
 
             // Store current portfolio positions to detect changes
             prev_portfolio_positions = get_positions_internal();
@@ -425,45 +419,34 @@ Result<void> PortfolioManager::process_market_data(const std::vector<Bar>& data,
                         ", target_positions size: " + std::to_string(info.target_positions.size()) +
                         ", existing executions: " + std::to_string(exec_counter));
 
-                    // Get previous positions for this strategy
-                    const auto& prev_strategy_positions = prev_positions[strategy_id];
-                    INFO("Previous positions for strategy " + strategy_id +
-                         " size: " + std::to_string(prev_strategy_positions.size()));
-
-                    // OPTION 3 ENHANCEMENT: Detect first post-warmup day by checking if no
-                    // executions have been generated yet (exec_counter == 0). On the first
-                    // post-warmup day, generate "establishment executions" for all non-zero
-                    // positions, even if they match previous positions. This ensures executions
-                    // show how we got to the positions, not just changes. With Option 3, positions
-                    // accumulate during warmup but executions are cleared, so exec_counter == 0
-                    // indicates first post-warmup day.
-                    bool is_first_post_warmup_day = (exec_counter == 0);
-                    bool should_generate_establishment_execs = is_first_post_warmup_day;
+                    // Per-strategy filled-position ledger: the net position this
+                    // manager has actually traded into, accumulated from the
+                    // executions it generates. Sizing the next order as
+                    // (target - filled) is self-correcting -- a position that ever
+                    // desyncs from its target (e.g. a target the warmup left
+                    // unexecuted) gets traded back rather than stranded. Deliberately
+                    // NOT sourced from strategy get_positions(): that is not a
+                    // reliable actual-holdings record across strategy types
+                    // (trend-following never maintains its positions_ map).
+                    auto& strategy_filled = filled_positions_[strategy_id];
+                    INFO("Filled-position ledger for strategy " + strategy_id +
+                         " size: " + std::to_string(strategy_filled.size()));
 
                     // Generate executions based on individual strategy position changes
                     for (const auto& [symbol, new_pos] : info.target_positions) {
                         double current_qty = 0.0;
-                        auto prev_pos_it = prev_strategy_positions.find(symbol);
-                        if (prev_pos_it != prev_strategy_positions.end()) {
-                            current_qty = static_cast<double>(prev_pos_it->second.quantity);
+                        auto filled_it = strategy_filled.find(symbol);
+                        if (filled_it != strategy_filled.end()) {
+                            current_qty = filled_it->second;
                         }
 
                         double new_qty = static_cast<double>(new_pos.quantity);
+                        double trade_size = new_qty - current_qty;
 
-                        // Generate execution if:
-                        // 1. Position changed (normal case), OR
-                        // 2. This is first post-warmup day and position is non-zero (establishment
-                        // execution)
-                        bool position_changed = (std::abs(new_qty - current_qty) > 1e-6);
-                        bool is_establishment_exec =
-                            should_generate_establishment_execs && (std::abs(new_qty) > 1e-6);
-
-                        if (position_changed || is_establishment_exec) {
-                            // Calculate trade size
-                            // For establishment executions, use the full new_qty (we're
-                            // establishing the position) For normal changes, use the difference
-                            double trade_size =
-                                is_establishment_exec ? new_qty : (new_qty - current_qty);
+                        // Trade whenever the target differs from what has actually
+                        // been filled. Establishing a position from flat is simply
+                        // current_qty == 0 and needs no special case.
+                        if (std::abs(trade_size) > 1e-6) {
                             Side side = trade_size > 0 ? Side::BUY : Side::SELL;
 
                             // Find latest price for symbol
@@ -511,10 +494,11 @@ Result<void> PortfolioManager::process_market_data(const std::vector<Bar>& data,
                             // Add to strategy-specific executions
                             strategy_execs.push_back(exec);
                             exec_counter++;
-                            std::string exec_type = is_establishment_exec ? " [ESTABLISHMENT]" : "";
+                            // Ledger now reflects the position we just traded into.
+                            strategy_filled[symbol] = new_qty;
                             INFO("Generated execution for strategy " + strategy_id + ": " + symbol +
                                  " " + (side == Side::BUY ? "BUY" : "SELL") +
-                                 " qty=" + std::to_string(exec.filled_quantity) + exec_type);
+                                 " qty=" + std::to_string(exec.filled_quantity));
                         }
                     }
                     INFO("Total executions generated for strategy " + strategy_id + ": " +
@@ -1353,6 +1337,8 @@ void PortfolioManager::clear_all_executions() {
     // Used during warmup to ensure no executions from warmup period persist
     recent_executions_.clear();
     strategy_executions_.clear();
+    // Keep the filled-position ledger in lockstep with strategy_executions_.
+    filled_positions_.clear();
 }
 
 void PortfolioManager::update_cost_manager_market_data(const std::string& symbol, double volume,

--- a/src/strategy/mean_reversion.cpp
+++ b/src/strategy/mean_reversion.cpp
@@ -155,22 +155,13 @@ Result<void> MeanReversionStrategy::on_data(const std::vector<Bar>& data) {
                 inst_data.target_position = 0.0;
             }
 
-            // Update position quantity in base class
-            // DO NOT set average_price here -- on_execution() manages cost basis
-            Position pos = positions_[bar.symbol];
-
-            // Defensive guard: reset cost basis on direction flip so on_execution()
-            // treats it as a fresh entry. generate_signal() prevents single-bar flips,
-            // but this protects against future signal logic changes.
-            double old_qty = pos.quantity.as_double();
-            double new_qty = inst_data.target_position;
-            if ((old_qty > 0 && new_qty < 0) || (old_qty < 0 && new_qty > 0)) {
-                pos.average_price = Decimal(0.0);
-            }
-
-            pos.quantity = Quantity(new_qty);
-            pos.last_update = bar.timestamp;
-            positions_[bar.symbol] = pos;
+            // The target position lives in inst_data.target_position and is
+            // surfaced to the portfolio via get_target_positions(). on_data() must
+            // NOT write positions_ -- that map reflects ACTUAL holdings and is
+            // maintained solely by BaseStrategy::on_execution(). Writing the target
+            // here made on_execution() treat the already-moved quantity as the
+            // pre-trade holding and double-apply each fill, collapsing average_price
+            // toward zero and inflating realized_pnl.
 
             DEBUG("Symbol: " + bar.symbol +
                   " | Price: " + std::to_string(bar.close) +
@@ -207,6 +198,32 @@ Result<void> MeanReversionStrategy::on_data(const std::vector<Bar>& data) {
                                 "Failed to process market data: " + std::string(e.what()),
                                 "MeanReversionStrategy");
     }
+}
+
+std::unordered_map<std::string, Position> MeanReversionStrategy::get_target_positions() const {
+    std::unordered_map<std::string, Position> target_positions;
+
+    // Build target positions from instrument_data_.target_position. positions_ is
+    // deliberately NOT read here -- it holds actual fill-maintained holdings, and
+    // on_execution() is the sole writer of quantity / average_price / realized_pnl.
+    for (const auto& [symbol, inst_data] : instrument_data_) {
+        Position pos;
+        pos.symbol = symbol;
+        pos.quantity = Quantity(inst_data.target_position);
+        pos.average_price = Decimal(inst_data.current_price);
+
+        // Carry forward fill-derived PnL from the actual-holdings record.
+        auto pos_it = positions_.find(symbol);
+        if (pos_it != positions_.end()) {
+            pos.realized_pnl = pos_it->second.realized_pnl;
+            pos.unrealized_pnl = pos_it->second.unrealized_pnl;
+        }
+
+        pos.last_update = inst_data.last_update;
+        target_positions[symbol] = pos;
+    }
+
+    return target_positions;
 }
 
 void MeanReversionStrategy::trim_history(MeanReversionInstrumentData& data) const {


### PR DESCRIPTION
mean_reversion: positions_ now
  holds actual fill-maintained holdings (on_data no longer writes it); add get_target_positions() override. Fixes
  realized_pnl inflation that broke PnL reconciliation.

portfolio_manager: execution generator sizes orders as
   (target - filled) via a per-strategy filled-position ledger, replacing (target - prev_target). Self-correcting;
  fixes the symbol-dormancy regression.

postgres_database_extensions: fix swapped realized/unrealized values
  in store_backtest_positions_with_strategy.

CMakeLists: set @loader_path build rpath so binaries locate
  libtrade_ngin.dylib.
