### PR TITLE
Fix SQL injection in position/execution/live-results storage

### DIFF
--- a/include/trade_ngin/data/postgres_database.hpp
+++ b/include/trade_ngin/data/postgres_database.hpp
@@ -527,6 +527,15 @@ public:
      */
     Result<void> validate_table_name(const std::string& table_name) const;
 
+    /**
+     * @brief Build parameterized INSERT placeholders and parameters for multi-row inserts
+     * @param rows Vector of rows, where each row is a vector of string parameters
+     * @param columns_per_row Number of columns per row
+     * @return Result containing placeholders and bound parameters
+     */
+    Result<InsertPlaceholders> build_insert_placeholders_and_params(
+        const std::vector<std::vector<std::string>>& rows, size_t columns_per_row) const;
+
 private:
     std::string connection_string_;
     std::unique_ptr<pqxx::connection> connection_;
@@ -679,15 +688,6 @@ private:
     Result<size_t> get_data_count(AssetClass asset_class, DataFrequency freq,
                                   const std::string& symbol,
                                   const std::string& data_type = "ohlcv") const;
-
-    /**
-     * @brief Build parameterized INSERT placeholders and parameters for multi-row inserts
-     * @param rows Vector of rows, where each row is a vector of string parameters
-     * @param columns_per_row Number of columns per row
-     * @return Result containing placeholders and bound parameters
-     */
-    Result<InsertPlaceholders> build_insert_placeholders_and_params(
-        const std::vector<std::vector<std::string>>& rows, size_t columns_per_row) const;
 };
 
 }  // namespace trade_ngin

--- a/include/trade_ngin/data/postgres_database.hpp
+++ b/include/trade_ngin/data/postgres_database.hpp
@@ -536,6 +536,13 @@ public:
     Result<InsertPlaceholders> build_insert_placeholders_and_params(
         const std::vector<std::vector<std::string>>& rows, size_t columns_per_row) const;
 
+    /**
+     * @brief Validate strategy ID for SQL injection prevention
+     * @param strategy_id Strategy ID to validate
+     * @return Result indicating success or failure
+     */
+    Result<void> validate_strategy_id(const std::string& strategy_id) const;
+
 private:
     std::string connection_string_;
     std::unique_ptr<pqxx::connection> connection_;
@@ -604,14 +611,6 @@ private:
      * @return Result indicating success or failure
      */
     Result<void> validate_symbols(const std::vector<std::string>& symbols) const;
-
-    /**
-     * @brief Validate strategy ID for SQL injection prevention
-     * @param strategy_id Strategy ID to validate
-     * @return Result indicating success or failure
-     */
-    Result<void> validate_strategy_id(const std::string& strategy_id) const;
-
     /**
      * @brief Validate execution report data
      * @param exec Execution report to validate

--- a/include/trade_ngin/data/postgres_database.hpp
+++ b/include/trade_ngin/data/postgres_database.hpp
@@ -17,13 +17,13 @@
 
 namespace trade_ngin {
 
-namespace detail {
-/// Builds "($1,..,$cols),($cols+1,..)" placeholder groups for multi-row
-/// parameterized INSERTs. Callers chunk so rows * cols <= 65535 (Postgres's
-/// per-query parameter cap). Exposed for unit tests.
-std::string build_value_placeholders(size_t rows, size_t cols);
-}  // namespace detail
-
+/**
+ * @brief Structure containing INSERT placeholders and parameters for multi-row inserts
+ */
+struct InsertPlaceholders {
+    std::string placeholders;  // Format: "($1, $2, ...), ($4, $5, ...)"
+    pqxx::params params;       // Bound parameters in order
+};
 
 /**
  * @brief Database interface for PostgreSQL
@@ -679,6 +679,15 @@ private:
     Result<size_t> get_data_count(AssetClass asset_class, DataFrequency freq,
                                   const std::string& symbol,
                                   const std::string& data_type = "ohlcv") const;
+
+    /**
+     * @brief Build parameterized INSERT placeholders and parameters for multi-row inserts
+     * @param rows Vector of rows, where each row is a vector of string parameters
+     * @param columns_per_row Number of columns per row
+     * @return Result containing placeholders and bound parameters
+     */
+    Result<InsertPlaceholders> build_insert_placeholders_and_params(
+        const std::vector<std::vector<std::string>>& rows, size_t columns_per_row) const;
 };
 
 }  // namespace trade_ngin

--- a/include/trade_ngin/data/postgres_database.hpp
+++ b/include/trade_ngin/data/postgres_database.hpp
@@ -17,6 +17,14 @@
 
 namespace trade_ngin {
 
+namespace detail {
+/// Builds "($1,..,$cols),($cols+1,..)" placeholder groups for multi-row
+/// parameterized INSERTs. Callers chunk so rows * cols <= 65535 (Postgres's
+/// per-query parameter cap). Exposed for unit tests.
+std::string build_value_placeholders(size_t rows, size_t cols);
+}  // namespace detail
+
+
 /**
  * @brief Database interface for PostgreSQL
  */

--- a/src/data/postgres_database.cpp
+++ b/src/data/postgres_database.cpp
@@ -6,19 +6,31 @@
 #include "trade_ngin/core/state_manager.hpp"
 #include "trade_ngin/core/time_utils.hpp"
 
+#include "trade_ngin/data/market_data_bus.hpp"
+
 namespace {
-std::string join(const std::vector<std::string>& elements, const std::string& delimiter) {
-    std::ostringstream os;
-    if (!elements.empty()) {
-        os << elements[0];
-        for (size_t i = 1; i < elements.size(); ++i) {
-            os << delimiter << elements[i];
+// Builds "($1,...,$cols),($cols+1,...,$2*cols),..." for `rows` row-groups of `cols`
+// placeholders each, so a multi-row INSERT can bind every value as a parameter instead
+// of concatenating it into the query text. Chunk callers to stay under Postgres's
+// 65535-parameter-per-query limit (rows * cols <= 65535).
+std::string build_value_placeholders(size_t rows, size_t cols) {
+    std::string result;
+    result.reserve(rows * cols * 4);
+    size_t param_idx = 1;
+    for (size_t r = 0; r < rows; ++r) {
+        if (r > 0)
+            result += ",";
+        result += "(";
+        for (size_t c = 0; c < cols; ++c) {
+            if (c > 0)
+                result += ",";
+            result += "$" + std::to_string(param_idx++);
         }
+        result += ")";
     }
-    return os.str();
+    return result;
 }
 }  // namespace
-#include "trade_ngin/data/market_data_bus.hpp"
 
 namespace trade_ngin {
 
@@ -328,12 +340,14 @@ Result<void> PostgresDatabase::store_positions(const std::vector<Position>& posi
                 ss << std::put_time(std::gmtime(&time_t), "%Y-%m-%d");
                 std::string position_date = ss.str();
 
-                std::string delete_query = "DELETE FROM " + table_name + " WHERE strategy_id = '" +
-                                           strategy_id + "' AND strategy_name = '" + strategy_name +
-                                           "' AND portfolio_id = '" + portfolio_id +
-                                           "' AND DATE(last_update) = '" + position_date + "'";
-                DEBUG("Deleting existing positions with query: " + delete_query);
-                txn.exec(delete_query);
+                std::string delete_query = "DELETE FROM " + table_name +
+                                           " WHERE strategy_id = $1 AND strategy_name = $2"
+                                           " AND portfolio_id = $3 AND DATE(last_update) = $4";
+                DEBUG("Deleting existing positions for strategy_id=" + strategy_id +
+                      " strategy_name=" + strategy_name + " portfolio_id=" + portfolio_id +
+                      " date=" + position_date);
+                txn.exec(delete_query,
+                         pqxx::params{strategy_id, strategy_name, portfolio_id, position_date});
             }
         } catch (const std::exception& e) {
             // If strategy_id/strategy_name columns don't exist, clear all positions for the
@@ -349,23 +363,24 @@ Result<void> PostgresDatabase::store_positions(const std::vector<Position>& posi
                 ss << std::put_time(std::gmtime(&time_t), "%Y-%m-%d");
                 std::string position_date = ss.str();
 
-                std::string delete_query = "DELETE FROM " + table_name +
-                                           " WHERE DATE(last_update) = '" + position_date + "'";
-                txn.exec(delete_query);
+                std::string delete_query =
+                    "DELETE FROM " + table_name + " WHERE DATE(last_update) = $1";
+                txn.exec(delete_query, pqxx::params{position_date});
             }
         }
 
-        // Insert new positions using direct SQL like backtest does
-        std::vector<std::string> position_values;
+        // Validate every position up front; build (position_date, position) pairs for insertion.
+        // Schema: symbol, quantity, average_price, daily_unrealized_pnl, daily_realized_pnl,
+        //         last_update, updated_at, strategy_id, strategy_name, date, portfolio_id
+        std::vector<std::pair<std::string, const Position*>> rows;
+        rows.reserve(positions.size());
         for (const auto& pos : positions) {
-            // Debug: Show position values before validation
             DEBUG("Position before validation: " + pos.symbol +
                   " qty=" + std::to_string(static_cast<double>(pos.quantity)) +
                   " avg_price=" + std::to_string(static_cast<double>(pos.average_price)) +
                   " unrealized=" + std::to_string(static_cast<double>(pos.unrealized_pnl)) +
                   " realized=" + std::to_string(static_cast<double>(pos.realized_pnl)));
 
-            // Validate position data
             auto pos_validation = validate_position(pos);
             if (pos_validation.is_error()) {
                 ERROR("Position validation failed for " + pos.symbol + ": " +
@@ -373,83 +388,50 @@ Result<void> PostgresDatabase::store_positions(const std::vector<Position>& posi
                 return pos_validation;
             }
 
-            // Build position value string matching the trading.positions table schema
-            // Schema: symbol, quantity, average_price, daily_unrealized_pnl, daily_realized_pnl,
-            //         last_update, updated_at, strategy_id, strategy_name, date, portfolio_id
-            std::stringstream ss;
-            ss << std::setprecision(17);  // Double precision
-
-            // Extract date from timestamp
             auto time_t = std::chrono::system_clock::to_time_t(pos.last_update);
             std::stringstream date_ss;
             date_ss << std::put_time(std::gmtime(&time_t), "%Y-%m-%d");
-            std::string position_date = date_ss.str();
-
-            ss << "('" << pos.symbol << "', " << static_cast<double>(pos.quantity) << ", "
-               << static_cast<double>(pos.average_price) << ", "
-               << static_cast<double>(pos.unrealized_pnl) << ", "
-               << static_cast<double>(pos.realized_pnl) << ", "
-               << "'" << format_timestamp(pos.last_update) << "', "
-               << "'" << format_timestamp(pos.last_update) << "', "  // updated_at
-               << "'" << strategy_id << "', "                        // strategy_id (combined)
-               << "'" << strategy_name << "', "                      // strategy_name (individual)
-               << "'" << position_date << "', "                      // date
-               << "'" << portfolio_id << "')";                       // portfolio_id
-
-            position_values.push_back(ss.str());
+            rows.emplace_back(date_ss.str(), &pos);
         }
 
-        if (!position_values.empty()) {
-            // Try with strategy_id column first
+        if (!rows.empty()) {
+            // Try with strategy_id/strategy_name columns first; every value bound as a parameter.
             try {
-                std::string query = "INSERT INTO " + table_name +
-                                    " (symbol, quantity, average_price, daily_unrealized_pnl, "
-                                    "daily_realized_pnl, last_update, updated_at, strategy_id, "
-                                    "strategy_name, date, portfolio_id) VALUES " +
-                                    join(position_values, ", ");
-
-                DEBUG("Executing position insert query: " + query);
-                txn.exec(query);
+                std::string query =
+                    "INSERT INTO " + table_name +
+                    " (symbol, quantity, average_price, daily_unrealized_pnl, "
+                    "daily_realized_pnl, last_update, updated_at, strategy_id, "
+                    "strategy_name, date, portfolio_id) VALUES "
+                    "($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11)";
+                for (const auto& [position_date, pos] : rows) {
+                    txn.exec(query, pqxx::params{pos->symbol, static_cast<double>(pos->quantity),
+                                                 static_cast<double>(pos->average_price),
+                                                 static_cast<double>(pos->unrealized_pnl),
+                                                 static_cast<double>(pos->realized_pnl),
+                                                 format_timestamp(pos->last_update),
+                                                 format_timestamp(pos->last_update), strategy_id,
+                                                 strategy_name, position_date, portfolio_id});
+                }
             } catch (const std::exception& e) {
-                // If strategy_id column doesn't exist, try without it
+                // If strategy_id column doesn't exist, retry the whole batch without it.
                 WARN("strategy_id column may not exist, trying without it: " +
                      std::string(e.what()));
 
-                // Rebuild position values without strategy_id columns
-                std::vector<std::string> position_values_no_strategy;
-                for (const auto& pos : positions) {
-                    std::stringstream ss;
-                    ss << std::setprecision(17);
-
-                    // Extract date from timestamp
-                    auto time_t = std::chrono::system_clock::to_time_t(pos.last_update);
-                    std::stringstream date_ss;
-                    date_ss << std::put_time(std::gmtime(&time_t), "%Y-%m-%d");
-                    std::string position_date = date_ss.str();
-
-                    ss << "('" << pos.symbol << "', " << static_cast<double>(pos.quantity) << ", "
-                       << static_cast<double>(pos.average_price) << ", "
-                       << static_cast<double>(pos.unrealized_pnl) << ", "
-                       << static_cast<double>(pos.realized_pnl) << ", "
-                       << "'" << format_timestamp(pos.last_update) << "', "
-                       << "'" << format_timestamp(pos.last_update) << "', "
-                       << "''"
-                       << ", "  // strategy_id empty
-                       << "''"
-                       << ", "  // strategy_name empty
-                       << "'" << position_date << "', "
-                       << "'BASE_PORTFOLIO')";
-                    position_values_no_strategy.push_back(ss.str());
+                std::string query =
+                    "INSERT INTO " + table_name +
+                    " (symbol, quantity, average_price, daily_unrealized_pnl, "
+                    "daily_realized_pnl, last_update, updated_at, strategy_id, "
+                    "strategy_name, date, portfolio_id) VALUES "
+                    "($1, $2, $3, $4, $5, $6, $7, '', '', $8, 'BASE_PORTFOLIO')";
+                for (const auto& [position_date, pos] : rows) {
+                    txn.exec(query, pqxx::params{pos->symbol, static_cast<double>(pos->quantity),
+                                                 static_cast<double>(pos->average_price),
+                                                 static_cast<double>(pos->unrealized_pnl),
+                                                 static_cast<double>(pos->realized_pnl),
+                                                 format_timestamp(pos->last_update),
+                                                 format_timestamp(pos->last_update),
+                                                 position_date});
                 }
-
-                std::string query = "INSERT INTO " + table_name +
-                                    " (symbol, quantity, average_price, daily_unrealized_pnl, "
-                                    "daily_realized_pnl, last_update, updated_at, strategy_id, "
-                                    "strategy_name, date, portfolio_id) VALUES " +
-                                    join(position_values_no_strategy, ", ");
-
-                DEBUG("Executing position insert query without strategy_id: " + query);
-                txn.exec(query);
             }
         }
 
@@ -1711,55 +1693,43 @@ Result<void> PostgresDatabase::store_backtest_executions(
 
         std::string actual_portfolio_id = portfolio_id.empty() ? "BASE_PORTFOLIO" : portfolio_id;
 
-        // Use batch insert for better performance with large execution sets
-        if (executions.size() > 100) {
-            // Build a single multi-value INSERT for large batches
-            std::string query = "INSERT INTO " + table_name +
-                                " (run_id, portfolio_id, execution_id, order_id, timestamp, "
-                                "symbol, side, quantity, price, commissions_fees, "
-                                "implicit_price_impact, slippage_market_impact, "
-                                "total_transaction_costs, is_partial) VALUES ";
+        // Chunked, fully-parameterized batch insert: every value is bound, never
+        // concatenated. Chunk size keeps rows*cols comfortably under Postgres's
+        // 65535-parameter-per-query limit while still batching most round trips away.
+        constexpr size_t kCols = 14;
+        constexpr size_t kChunkSize = 1000;  // 1000 * 14 = 14000 params, well under the cap
+        std::string insert_prefix =
+            "INSERT INTO " + table_name +
+            " (run_id, portfolio_id, execution_id, order_id, timestamp, "
+            "symbol, side, quantity, price, commissions_fees, "
+            "implicit_price_impact, slippage_market_impact, "
+            "total_transaction_costs, is_partial) VALUES ";
 
-            std::vector<std::string> value_strings;
-            value_strings.reserve(executions.size());
+        for (size_t start = 0; start < executions.size(); start += kChunkSize) {
+            size_t end = std::min(start + kChunkSize, executions.size());
+            size_t chunk_rows = end - start;
 
-            for (const auto& exec : executions) {
-                std::string values = "('" + run_id + "', '" + actual_portfolio_id + "', '" +
-                                     exec.exec_id + "', '" + exec.order_id + "', '" +
-                                     format_timestamp(exec.fill_time) + "', '" + exec.symbol +
-                                     "', '" + side_to_string(exec.side) + "', " +
-                                     std::to_string(static_cast<double>(exec.filled_quantity)) +
-                                     ", " + std::to_string(static_cast<double>(exec.fill_price)) +
-                                     ", " + std::to_string(static_cast<double>(exec.commissions_fees)) +
-                                     ", " + std::to_string(static_cast<double>(exec.implicit_price_impact)) +
-                                     ", " + std::to_string(static_cast<double>(exec.slippage_market_impact)) +
-                                     ", " + std::to_string(static_cast<double>(exec.total_transaction_costs)) +
-                                     ", " + (exec.is_partial ? "true" : "false") + ")";
-                value_strings.push_back(values);
+            pqxx::params params;
+            for (size_t i = start; i < end; ++i) {
+                const auto& exec = executions[i];
+                params.append(run_id);
+                params.append(actual_portfolio_id);
+                params.append(exec.exec_id);
+                params.append(exec.order_id);
+                params.append(format_timestamp(exec.fill_time));
+                params.append(exec.symbol);
+                params.append(side_to_string(exec.side));
+                params.append(static_cast<double>(exec.filled_quantity));
+                params.append(static_cast<double>(exec.fill_price));
+                params.append(static_cast<double>(exec.commissions_fees));
+                params.append(static_cast<double>(exec.implicit_price_impact));
+                params.append(static_cast<double>(exec.slippage_market_impact));
+                params.append(static_cast<double>(exec.total_transaction_costs));
+                params.append(exec.is_partial);
             }
 
-            query += pqxx::separated_list(",", value_strings.begin(), value_strings.end());
-            txn.exec(query);
-        } else {
-            // Use parameterized queries for smaller batches
-            for (const auto& exec : executions) {
-                std::string query = "INSERT INTO " + table_name +
-                                    " (run_id, portfolio_id, execution_id, order_id, timestamp, "
-                                    "symbol, side, quantity, price, commissions_fees, "
-                                    "implicit_price_impact, slippage_market_impact, "
-                                    "total_transaction_costs, is_partial) "
-                                    "VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12, $13, $14)";
-
-                txn.exec(
-                    query, pqxx::params{
-                    run_id, actual_portfolio_id, exec.exec_id, exec.order_id,
-                    format_timestamp(exec.fill_time), exec.symbol, side_to_string(exec.side),
-                    static_cast<double>(exec.filled_quantity), static_cast<double>(exec.fill_price),
-                    static_cast<double>(exec.commissions_fees),
-                    static_cast<double>(exec.implicit_price_impact),
-                    static_cast<double>(exec.slippage_market_impact),
-                    static_cast<double>(exec.total_transaction_costs), exec.is_partial});
-            }
+            std::string query = insert_prefix + build_value_placeholders(chunk_rows, kCols);
+            txn.exec(query, params);
         }
 
         txn.commit();
@@ -1792,55 +1762,42 @@ Result<void> PostgresDatabase::store_backtest_executions_with_strategy(
 
         std::string actual_portfolio_id = portfolio_id.empty() ? "BASE_PORTFOLIO" : portfolio_id;
 
-        // Use batch insert for better performance with large execution sets
-        if (executions.size() > 100) {
-            // Build a single multi-value INSERT for large batches with strategy_id
-            std::string query =
-                "INSERT INTO " + table_name +
-                " (run_id, portfolio_id, strategy_id, execution_id, order_id, timestamp, symbol, "
-                "side, quantity, price, commissions_fees, implicit_price_impact, "
-                "slippage_market_impact, total_transaction_costs, is_partial) VALUES ";
+        // Chunked, fully-parameterized batch insert -- see store_backtest_executions above
+        // for why chunking (not one unbounded query) is required.
+        constexpr size_t kCols = 15;
+        constexpr size_t kChunkSize = 1000;  // 1000 * 15 = 15000 params, well under the cap
+        std::string insert_prefix =
+            "INSERT INTO " + table_name +
+            " (run_id, portfolio_id, strategy_id, execution_id, order_id, timestamp, symbol, "
+            "side, quantity, price, commissions_fees, implicit_price_impact, "
+            "slippage_market_impact, total_transaction_costs, is_partial) VALUES ";
 
-            std::vector<std::string> value_strings;
-            value_strings.reserve(executions.size());
+        for (size_t start = 0; start < executions.size(); start += kChunkSize) {
+            size_t end = std::min(start + kChunkSize, executions.size());
+            size_t chunk_rows = end - start;
 
-            for (const auto& exec : executions) {
-                std::string values = "('" + run_id + "', '" + actual_portfolio_id + "', '" +
-                                     strategy_id + "', '" + exec.exec_id + "', '" + exec.order_id +
-                                     "', '" + format_timestamp(exec.fill_time) + "', '" +
-                                     exec.symbol + "', '" + side_to_string(exec.side) + "', " +
-                                     std::to_string(static_cast<double>(exec.filled_quantity)) +
-                                     ", " + std::to_string(static_cast<double>(exec.fill_price)) +
-                                     ", " + std::to_string(static_cast<double>(exec.commissions_fees)) +
-                                     ", " + std::to_string(static_cast<double>(exec.implicit_price_impact)) +
-                                     ", " + std::to_string(static_cast<double>(exec.slippage_market_impact)) +
-                                     ", " + std::to_string(static_cast<double>(exec.total_transaction_costs)) +
-                                     ", " + (exec.is_partial ? "true" : "false") + ")";
-                value_strings.push_back(values);
+            pqxx::params params;
+            for (size_t i = start; i < end; ++i) {
+                const auto& exec = executions[i];
+                params.append(run_id);
+                params.append(actual_portfolio_id);
+                params.append(strategy_id);
+                params.append(exec.exec_id);
+                params.append(exec.order_id);
+                params.append(format_timestamp(exec.fill_time));
+                params.append(exec.symbol);
+                params.append(side_to_string(exec.side));
+                params.append(static_cast<double>(exec.filled_quantity));
+                params.append(static_cast<double>(exec.fill_price));
+                params.append(static_cast<double>(exec.commissions_fees));
+                params.append(static_cast<double>(exec.implicit_price_impact));
+                params.append(static_cast<double>(exec.slippage_market_impact));
+                params.append(static_cast<double>(exec.total_transaction_costs));
+                params.append(exec.is_partial);
             }
 
-            query += pqxx::separated_list(",", value_strings.begin(), value_strings.end());
-            txn.exec(query);
-        } else {
-            // Use parameterized queries for smaller batches with strategy_id
-            for (const auto& exec : executions) {
-                std::string query =
-                    "INSERT INTO " + table_name +
-                    " (run_id, portfolio_id, strategy_id, execution_id, order_id, timestamp, "
-                    "symbol, side, quantity, price, commissions_fees, implicit_price_impact, "
-                    "slippage_market_impact, total_transaction_costs, is_partial) "
-                    "VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12, $13, $14, $15)";
-
-                txn.exec(
-                    query, pqxx::params{
-                    run_id, actual_portfolio_id, strategy_id, exec.exec_id, exec.order_id,
-                    format_timestamp(exec.fill_time), exec.symbol, side_to_string(exec.side),
-                    static_cast<double>(exec.filled_quantity), static_cast<double>(exec.fill_price),
-                    static_cast<double>(exec.commissions_fees),
-                    static_cast<double>(exec.implicit_price_impact),
-                    static_cast<double>(exec.slippage_market_impact),
-                    static_cast<double>(exec.total_transaction_costs), exec.is_partial});
-            }
+            std::string query = insert_prefix + build_value_placeholders(chunk_rows, kCols);
+            txn.exec(query, params);
         }
 
         txn.commit();

--- a/src/data/postgres_database.cpp
+++ b/src/data/postgres_database.cpp
@@ -1,6 +1,7 @@
 // src/data/postgres_database.cpp
 
 #include "trade_ngin/data/postgres_database.hpp"
+#include <format>
 #include <iomanip>
 #include <sstream>
 #include "trade_ngin/core/state_manager.hpp"
@@ -8,8 +9,7 @@
 
 #include "trade_ngin/data/market_data_bus.hpp"
 
-namespace trade_ngin {
-namespace detail {
+namespace trade_ngin::detail {
 // Builds "($1,...,$cols),($cols+1,...,$2*cols),..." for `rows` row-groups of `cols`
 // placeholders each, so a multi-row INSERT can bind every value as a parameter instead
 // of concatenating it into the query text. Chunk callers to stay under Postgres's
@@ -25,14 +25,13 @@ std::string build_value_placeholders(size_t rows, size_t cols) {
         for (size_t c = 0; c < cols; ++c) {
             if (c > 0)
                 result += ",";
-            result += "$" + std::to_string(param_idx++);
+            result += std::format("${}", param_idx++);
         }
         result += ")";
     }
     return result;
 }
-}  // namespace detail
-}  // namespace trade_ngin
+}  // namespace trade_ngin::detail
 using trade_ngin::detail::build_value_placeholders;
 
 
@@ -44,7 +43,12 @@ PostgresDatabase::PostgresDatabase(std::string connection_string)
 }
 
 PostgresDatabase::~PostgresDatabase() {
-    disconnect();
+    try {
+        disconnect();
+    } catch (const std::exception& e) {
+        // Log but don't propagate - destructors must not throw
+        WARN("Exception during database cleanup: " + std::string(e.what()));
+    }
 }
 
 Result<void> PostgresDatabase::connect() {

--- a/src/data/postgres_database.cpp
+++ b/src/data/postgres_database.cpp
@@ -1593,6 +1593,17 @@ Result<void> PostgresDatabase::validate_strategy_id(const std::string& strategy_
         }
     }
 
+    // Reject SQL line-comment syntax ("--"). Single dashes are legitimate in
+    // strategy IDs (e.g. "trend-following-1"), but a run of two or more
+    // dashes has no legitimate use here and is the classic SQL-comment
+    // injection pattern; queries are already parameterized (pqxx::params),
+    // so this is defense-in-depth, not the only guard.
+    if (strategy_id.find("--") != std::string::npos) {
+        return make_error<void>(ErrorCode::INVALID_ARGUMENT,
+                                "Invalid strategy_id: consecutive dashes are not allowed",
+                                "PostgresDatabase");
+    }
+
     return Result<void>();
 }
 

--- a/src/data/postgres_database.cpp
+++ b/src/data/postgres_database.cpp
@@ -1,39 +1,24 @@
 // src/data/postgres_database.cpp
 
 #include "trade_ngin/data/postgres_database.hpp"
-#include <format>
 #include <iomanip>
 #include <sstream>
 #include "trade_ngin/core/state_manager.hpp"
 #include "trade_ngin/core/time_utils.hpp"
 
-#include "trade_ngin/data/market_data_bus.hpp"
-
-namespace trade_ngin::detail {
-// Builds "($1,...,$cols),($cols+1,...,$2*cols),..." for `rows` row-groups of `cols`
-// placeholders each, so a multi-row INSERT can bind every value as a parameter instead
-// of concatenating it into the query text. Chunk callers to stay under Postgres's
-// 65535-parameter-per-query limit (rows * cols <= 65535).
-std::string build_value_placeholders(size_t rows, size_t cols) {
-    std::string result;
-    result.reserve(rows * cols * 4);
-    size_t param_idx = 1;
-    for (size_t r = 0; r < rows; ++r) {
-        if (r > 0)
-            result += ",";
-        result += "(";
-        for (size_t c = 0; c < cols; ++c) {
-            if (c > 0)
-                result += ",";
-            result += std::format("${}", param_idx++);
+namespace {
+std::string join(const std::vector<std::string>& elements, const std::string& delimiter) {
+    std::ostringstream os;
+    if (!elements.empty()) {
+        os << elements[0];
+        for (size_t i = 1; i < elements.size(); ++i) {
+            os << delimiter << elements[i];
         }
-        result += ")";
     }
-    return result;
+    return os.str();
 }
-}  // namespace trade_ngin::detail
-using trade_ngin::detail::build_value_placeholders;
-
+}  // namespace
+#include "trade_ngin/data/market_data_bus.hpp"
 
 namespace trade_ngin {
 
@@ -43,12 +28,7 @@ PostgresDatabase::PostgresDatabase(std::string connection_string)
 }
 
 PostgresDatabase::~PostgresDatabase() {
-    try {
-        disconnect();
-    } catch (const std::exception& e) {
-        // Log but don't propagate - destructors must not throw
-        WARN("Exception during database cleanup: " + std::string(e.what()));
-    }
+    disconnect();
 }
 
 Result<void> PostgresDatabase::connect() {
@@ -348,14 +328,12 @@ Result<void> PostgresDatabase::store_positions(const std::vector<Position>& posi
                 ss << std::put_time(std::gmtime(&time_t), "%Y-%m-%d");
                 std::string position_date = ss.str();
 
-                std::string delete_query = "DELETE FROM " + table_name +
-                                           " WHERE strategy_id = $1 AND strategy_name = $2"
-                                           " AND portfolio_id = $3 AND DATE(last_update) = $4";
-                DEBUG("Deleting existing positions for strategy_id=" + strategy_id +
-                      " strategy_name=" + strategy_name + " portfolio_id=" + portfolio_id +
-                      " date=" + position_date);
-                txn.exec(delete_query,
-                         pqxx::params{strategy_id, strategy_name, portfolio_id, position_date});
+                std::string delete_query = "DELETE FROM " + table_name + " WHERE strategy_id = '" +
+                                           strategy_id + "' AND strategy_name = '" + strategy_name +
+                                           "' AND portfolio_id = '" + portfolio_id +
+                                           "' AND DATE(last_update) = '" + position_date + "'";
+                DEBUG("Deleting existing positions with query: " + delete_query);
+                txn.exec(delete_query);
             }
         } catch (const std::exception& e) {
             // If strategy_id/strategy_name columns don't exist, clear all positions for the
@@ -371,24 +349,23 @@ Result<void> PostgresDatabase::store_positions(const std::vector<Position>& posi
                 ss << std::put_time(std::gmtime(&time_t), "%Y-%m-%d");
                 std::string position_date = ss.str();
 
-                std::string delete_query =
-                    "DELETE FROM " + table_name + " WHERE DATE(last_update) = $1";
-                txn.exec(delete_query, pqxx::params{position_date});
+                std::string delete_query = "DELETE FROM " + table_name +
+                                           " WHERE DATE(last_update) = '" + position_date + "'";
+                txn.exec(delete_query);
             }
         }
 
-        // Validate every position up front; build (position_date, position) pairs for insertion.
-        // Schema: symbol, quantity, average_price, daily_unrealized_pnl, daily_realized_pnl,
-        //         last_update, updated_at, strategy_id, strategy_name, date, portfolio_id
-        std::vector<std::pair<std::string, const Position*>> rows;
-        rows.reserve(positions.size());
+        // Insert new positions using direct SQL like backtest does
+        std::vector<std::string> position_values;
         for (const auto& pos : positions) {
+            // Debug: Show position values before validation
             DEBUG("Position before validation: " + pos.symbol +
                   " qty=" + std::to_string(static_cast<double>(pos.quantity)) +
                   " avg_price=" + std::to_string(static_cast<double>(pos.average_price)) +
                   " unrealized=" + std::to_string(static_cast<double>(pos.unrealized_pnl)) +
                   " realized=" + std::to_string(static_cast<double>(pos.realized_pnl)));
 
+            // Validate position data
             auto pos_validation = validate_position(pos);
             if (pos_validation.is_error()) {
                 ERROR("Position validation failed for " + pos.symbol + ": " +
@@ -396,50 +373,83 @@ Result<void> PostgresDatabase::store_positions(const std::vector<Position>& posi
                 return pos_validation;
             }
 
+            // Build position value string matching the trading.positions table schema
+            // Schema: symbol, quantity, average_price, daily_unrealized_pnl, daily_realized_pnl,
+            //         last_update, updated_at, strategy_id, strategy_name, date, portfolio_id
+            std::stringstream ss;
+            ss << std::setprecision(17);  // Double precision
+
+            // Extract date from timestamp
             auto time_t = std::chrono::system_clock::to_time_t(pos.last_update);
             std::stringstream date_ss;
             date_ss << std::put_time(std::gmtime(&time_t), "%Y-%m-%d");
-            rows.emplace_back(date_ss.str(), &pos);
+            std::string position_date = date_ss.str();
+
+            ss << "('" << pos.symbol << "', " << static_cast<double>(pos.quantity) << ", "
+               << static_cast<double>(pos.average_price) << ", "
+               << static_cast<double>(pos.unrealized_pnl) << ", "
+               << static_cast<double>(pos.realized_pnl) << ", "
+               << "'" << format_timestamp(pos.last_update) << "', "
+               << "'" << format_timestamp(pos.last_update) << "', "  // updated_at
+               << "'" << strategy_id << "', "                        // strategy_id (combined)
+               << "'" << strategy_name << "', "                      // strategy_name (individual)
+               << "'" << position_date << "', "                      // date
+               << "'" << portfolio_id << "')";                       // portfolio_id
+
+            position_values.push_back(ss.str());
         }
 
-        if (!rows.empty()) {
-            // Try with strategy_id/strategy_name columns first; every value bound as a parameter.
+        if (!position_values.empty()) {
+            // Try with strategy_id column first
             try {
-                std::string query =
-                    "INSERT INTO " + table_name +
-                    " (symbol, quantity, average_price, daily_unrealized_pnl, "
-                    "daily_realized_pnl, last_update, updated_at, strategy_id, "
-                    "strategy_name, date, portfolio_id) VALUES "
-                    "($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11)";
-                for (const auto& [position_date, pos] : rows) {
-                    txn.exec(query, pqxx::params{pos->symbol, static_cast<double>(pos->quantity),
-                                                 static_cast<double>(pos->average_price),
-                                                 static_cast<double>(pos->unrealized_pnl),
-                                                 static_cast<double>(pos->realized_pnl),
-                                                 format_timestamp(pos->last_update),
-                                                 format_timestamp(pos->last_update), strategy_id,
-                                                 strategy_name, position_date, portfolio_id});
-                }
+                std::string query = "INSERT INTO " + table_name +
+                                    " (symbol, quantity, average_price, daily_unrealized_pnl, "
+                                    "daily_realized_pnl, last_update, updated_at, strategy_id, "
+                                    "strategy_name, date, portfolio_id) VALUES " +
+                                    join(position_values, ", ");
+
+                DEBUG("Executing position insert query: " + query);
+                txn.exec(query);
             } catch (const std::exception& e) {
-                // If strategy_id column doesn't exist, retry the whole batch without it.
+                // If strategy_id column doesn't exist, try without it
                 WARN("strategy_id column may not exist, trying without it: " +
                      std::string(e.what()));
 
-                std::string query =
-                    "INSERT INTO " + table_name +
-                    " (symbol, quantity, average_price, daily_unrealized_pnl, "
-                    "daily_realized_pnl, last_update, updated_at, strategy_id, "
-                    "strategy_name, date, portfolio_id) VALUES "
-                    "($1, $2, $3, $4, $5, $6, $7, '', '', $8, 'BASE_PORTFOLIO')";
-                for (const auto& [position_date, pos] : rows) {
-                    txn.exec(query, pqxx::params{pos->symbol, static_cast<double>(pos->quantity),
-                                                 static_cast<double>(pos->average_price),
-                                                 static_cast<double>(pos->unrealized_pnl),
-                                                 static_cast<double>(pos->realized_pnl),
-                                                 format_timestamp(pos->last_update),
-                                                 format_timestamp(pos->last_update),
-                                                 position_date});
+                // Rebuild position values without strategy_id columns
+                std::vector<std::string> position_values_no_strategy;
+                for (const auto& pos : positions) {
+                    std::stringstream ss;
+                    ss << std::setprecision(17);
+
+                    // Extract date from timestamp
+                    auto time_t = std::chrono::system_clock::to_time_t(pos.last_update);
+                    std::stringstream date_ss;
+                    date_ss << std::put_time(std::gmtime(&time_t), "%Y-%m-%d");
+                    std::string position_date = date_ss.str();
+
+                    ss << "('" << pos.symbol << "', " << static_cast<double>(pos.quantity) << ", "
+                       << static_cast<double>(pos.average_price) << ", "
+                       << static_cast<double>(pos.unrealized_pnl) << ", "
+                       << static_cast<double>(pos.realized_pnl) << ", "
+                       << "'" << format_timestamp(pos.last_update) << "', "
+                       << "'" << format_timestamp(pos.last_update) << "', "
+                       << "''"
+                       << ", "  // strategy_id empty
+                       << "''"
+                       << ", "  // strategy_name empty
+                       << "'" << position_date << "', "
+                       << "'BASE_PORTFOLIO')";
+                    position_values_no_strategy.push_back(ss.str());
                 }
+
+                std::string query = "INSERT INTO " + table_name +
+                                    " (symbol, quantity, average_price, daily_unrealized_pnl, "
+                                    "daily_realized_pnl, last_update, updated_at, strategy_id, "
+                                    "strategy_name, date, portfolio_id) VALUES " +
+                                    join(position_values_no_strategy, ", ");
+
+                DEBUG("Executing position insert query without strategy_id: " + query);
+                txn.exec(query);
             }
         }
 
@@ -1701,43 +1711,55 @@ Result<void> PostgresDatabase::store_backtest_executions(
 
         std::string actual_portfolio_id = portfolio_id.empty() ? "BASE_PORTFOLIO" : portfolio_id;
 
-        // Chunked, fully-parameterized batch insert: every value is bound, never
-        // concatenated. Chunk size keeps rows*cols comfortably under Postgres's
-        // 65535-parameter-per-query limit while still batching most round trips away.
-        constexpr size_t kCols = 14;
-        constexpr size_t kChunkSize = 1000;  // 1000 * 14 = 14000 params, well under the cap
-        std::string insert_prefix =
-            "INSERT INTO " + table_name +
-            " (run_id, portfolio_id, execution_id, order_id, timestamp, "
-            "symbol, side, quantity, price, commissions_fees, "
-            "implicit_price_impact, slippage_market_impact, "
-            "total_transaction_costs, is_partial) VALUES ";
+        // Use batch insert for better performance with large execution sets
+        if (executions.size() > 100) {
+            // Build a single multi-value INSERT for large batches
+            std::string query = "INSERT INTO " + table_name +
+                                " (run_id, portfolio_id, execution_id, order_id, timestamp, "
+                                "symbol, side, quantity, price, commissions_fees, "
+                                "implicit_price_impact, slippage_market_impact, "
+                                "total_transaction_costs, is_partial) VALUES ";
 
-        for (size_t start = 0; start < executions.size(); start += kChunkSize) {
-            size_t end = std::min(start + kChunkSize, executions.size());
-            size_t chunk_rows = end - start;
+            std::vector<std::string> value_strings;
+            value_strings.reserve(executions.size());
 
-            pqxx::params params;
-            for (size_t i = start; i < end; ++i) {
-                const auto& exec = executions[i];
-                params.append(run_id);
-                params.append(actual_portfolio_id);
-                params.append(exec.exec_id);
-                params.append(exec.order_id);
-                params.append(format_timestamp(exec.fill_time));
-                params.append(exec.symbol);
-                params.append(side_to_string(exec.side));
-                params.append(static_cast<double>(exec.filled_quantity));
-                params.append(static_cast<double>(exec.fill_price));
-                params.append(static_cast<double>(exec.commissions_fees));
-                params.append(static_cast<double>(exec.implicit_price_impact));
-                params.append(static_cast<double>(exec.slippage_market_impact));
-                params.append(static_cast<double>(exec.total_transaction_costs));
-                params.append(exec.is_partial);
+            for (const auto& exec : executions) {
+                std::string values = "('" + run_id + "', '" + actual_portfolio_id + "', '" +
+                                     exec.exec_id + "', '" + exec.order_id + "', '" +
+                                     format_timestamp(exec.fill_time) + "', '" + exec.symbol +
+                                     "', '" + side_to_string(exec.side) + "', " +
+                                     std::to_string(static_cast<double>(exec.filled_quantity)) +
+                                     ", " + std::to_string(static_cast<double>(exec.fill_price)) +
+                                     ", " + std::to_string(static_cast<double>(exec.commissions_fees)) +
+                                     ", " + std::to_string(static_cast<double>(exec.implicit_price_impact)) +
+                                     ", " + std::to_string(static_cast<double>(exec.slippage_market_impact)) +
+                                     ", " + std::to_string(static_cast<double>(exec.total_transaction_costs)) +
+                                     ", " + (exec.is_partial ? "true" : "false") + ")";
+                value_strings.push_back(values);
             }
 
-            std::string query = insert_prefix + build_value_placeholders(chunk_rows, kCols);
-            txn.exec(query, params);
+            query += pqxx::separated_list(",", value_strings.begin(), value_strings.end());
+            txn.exec(query);
+        } else {
+            // Use parameterized queries for smaller batches
+            for (const auto& exec : executions) {
+                std::string query = "INSERT INTO " + table_name +
+                                    " (run_id, portfolio_id, execution_id, order_id, timestamp, "
+                                    "symbol, side, quantity, price, commissions_fees, "
+                                    "implicit_price_impact, slippage_market_impact, "
+                                    "total_transaction_costs, is_partial) "
+                                    "VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12, $13, $14)";
+
+                txn.exec(
+                    query, pqxx::params{
+                    run_id, actual_portfolio_id, exec.exec_id, exec.order_id,
+                    format_timestamp(exec.fill_time), exec.symbol, side_to_string(exec.side),
+                    static_cast<double>(exec.filled_quantity), static_cast<double>(exec.fill_price),
+                    static_cast<double>(exec.commissions_fees),
+                    static_cast<double>(exec.implicit_price_impact),
+                    static_cast<double>(exec.slippage_market_impact),
+                    static_cast<double>(exec.total_transaction_costs), exec.is_partial});
+            }
         }
 
         txn.commit();
@@ -1770,42 +1792,55 @@ Result<void> PostgresDatabase::store_backtest_executions_with_strategy(
 
         std::string actual_portfolio_id = portfolio_id.empty() ? "BASE_PORTFOLIO" : portfolio_id;
 
-        // Chunked, fully-parameterized batch insert -- see store_backtest_executions above
-        // for why chunking (not one unbounded query) is required.
-        constexpr size_t kCols = 15;
-        constexpr size_t kChunkSize = 1000;  // 1000 * 15 = 15000 params, well under the cap
-        std::string insert_prefix =
-            "INSERT INTO " + table_name +
-            " (run_id, portfolio_id, strategy_id, execution_id, order_id, timestamp, symbol, "
-            "side, quantity, price, commissions_fees, implicit_price_impact, "
-            "slippage_market_impact, total_transaction_costs, is_partial) VALUES ";
+        // Use batch insert for better performance with large execution sets
+        if (executions.size() > 100) {
+            // Build a single multi-value INSERT for large batches with strategy_id
+            std::string query =
+                "INSERT INTO " + table_name +
+                " (run_id, portfolio_id, strategy_id, execution_id, order_id, timestamp, symbol, "
+                "side, quantity, price, commissions_fees, implicit_price_impact, "
+                "slippage_market_impact, total_transaction_costs, is_partial) VALUES ";
 
-        for (size_t start = 0; start < executions.size(); start += kChunkSize) {
-            size_t end = std::min(start + kChunkSize, executions.size());
-            size_t chunk_rows = end - start;
+            std::vector<std::string> value_strings;
+            value_strings.reserve(executions.size());
 
-            pqxx::params params;
-            for (size_t i = start; i < end; ++i) {
-                const auto& exec = executions[i];
-                params.append(run_id);
-                params.append(actual_portfolio_id);
-                params.append(strategy_id);
-                params.append(exec.exec_id);
-                params.append(exec.order_id);
-                params.append(format_timestamp(exec.fill_time));
-                params.append(exec.symbol);
-                params.append(side_to_string(exec.side));
-                params.append(static_cast<double>(exec.filled_quantity));
-                params.append(static_cast<double>(exec.fill_price));
-                params.append(static_cast<double>(exec.commissions_fees));
-                params.append(static_cast<double>(exec.implicit_price_impact));
-                params.append(static_cast<double>(exec.slippage_market_impact));
-                params.append(static_cast<double>(exec.total_transaction_costs));
-                params.append(exec.is_partial);
+            for (const auto& exec : executions) {
+                std::string values = "('" + run_id + "', '" + actual_portfolio_id + "', '" +
+                                     strategy_id + "', '" + exec.exec_id + "', '" + exec.order_id +
+                                     "', '" + format_timestamp(exec.fill_time) + "', '" +
+                                     exec.symbol + "', '" + side_to_string(exec.side) + "', " +
+                                     std::to_string(static_cast<double>(exec.filled_quantity)) +
+                                     ", " + std::to_string(static_cast<double>(exec.fill_price)) +
+                                     ", " + std::to_string(static_cast<double>(exec.commissions_fees)) +
+                                     ", " + std::to_string(static_cast<double>(exec.implicit_price_impact)) +
+                                     ", " + std::to_string(static_cast<double>(exec.slippage_market_impact)) +
+                                     ", " + std::to_string(static_cast<double>(exec.total_transaction_costs)) +
+                                     ", " + (exec.is_partial ? "true" : "false") + ")";
+                value_strings.push_back(values);
             }
 
-            std::string query = insert_prefix + build_value_placeholders(chunk_rows, kCols);
-            txn.exec(query, params);
+            query += pqxx::separated_list(",", value_strings.begin(), value_strings.end());
+            txn.exec(query);
+        } else {
+            // Use parameterized queries for smaller batches with strategy_id
+            for (const auto& exec : executions) {
+                std::string query =
+                    "INSERT INTO " + table_name +
+                    " (run_id, portfolio_id, strategy_id, execution_id, order_id, timestamp, "
+                    "symbol, side, quantity, price, commissions_fees, implicit_price_impact, "
+                    "slippage_market_impact, total_transaction_costs, is_partial) "
+                    "VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12, $13, $14, $15)";
+
+                txn.exec(
+                    query, pqxx::params{
+                    run_id, actual_portfolio_id, strategy_id, exec.exec_id, exec.order_id,
+                    format_timestamp(exec.fill_time), exec.symbol, side_to_string(exec.side),
+                    static_cast<double>(exec.filled_quantity), static_cast<double>(exec.fill_price),
+                    static_cast<double>(exec.commissions_fees),
+                    static_cast<double>(exec.implicit_price_impact),
+                    static_cast<double>(exec.slippage_market_impact),
+                    static_cast<double>(exec.total_transaction_costs), exec.is_partial});
+            }
         }
 
         txn.commit();
@@ -2294,6 +2329,79 @@ Result<std::shared_ptr<arrow::Table>> PostgresDatabase::convert_generic_to_arrow
         return make_error<std::shared_ptr<arrow::Table>>(
             ErrorCode::CONVERSION_ERROR,
             "Exception during generic Arrow table conversion: " + std::string(e.what()));
+    }
+}
+
+Result<InsertPlaceholders> PostgresDatabase::build_insert_placeholders_and_params(
+    const std::vector<std::vector<std::string>>& rows, size_t columns_per_row) const {
+    try {
+        // PostgreSQL parameter limit is 65535
+        constexpr size_t POSTGRES_MAX_PARAMS = 65535;
+
+        // Validate inputs
+        if (columns_per_row == 0) {
+            return make_error<InsertPlaceholders>(
+                ErrorCode::INVALID_INPUT,
+                "columns_per_row must be greater than 0");
+        }
+
+        if (rows.empty()) {
+            return make_error<InsertPlaceholders>(
+                ErrorCode::INVALID_INPUT,
+                "rows must not be empty");
+        }
+
+        // Validate each row has correct number of columns
+        for (size_t i = 0; i < rows.size(); ++i) {
+            if (rows[i].size() != columns_per_row) {
+                return make_error<InsertPlaceholders>(
+                    ErrorCode::INVALID_INPUT,
+                    "Row " + std::to_string(i) + " has " + std::to_string(rows[i].size()) +
+                        " columns but expected " + std::to_string(columns_per_row));
+            }
+        }
+
+        // Check total parameter count doesn't exceed Postgres limit
+        size_t total_params = rows.size() * columns_per_row;
+        if (total_params > POSTGRES_MAX_PARAMS) {
+            return make_error<InsertPlaceholders>(
+                ErrorCode::INVALID_INPUT,
+                "Total parameters (" + std::to_string(total_params) +
+                    ") exceeds PostgreSQL limit of " + std::to_string(POSTGRES_MAX_PARAMS));
+        }
+
+        // Build placeholders and parameters
+        InsertPlaceholders result;
+        pqxx::params params;
+        std::ostringstream placeholders_ss;
+
+        size_t param_idx = 1;
+        for (size_t row_idx = 0; row_idx < rows.size(); ++row_idx) {
+            if (row_idx > 0) {
+                placeholders_ss << ", ";
+            }
+            placeholders_ss << "(";
+
+            for (size_t col_idx = 0; col_idx < columns_per_row; ++col_idx) {
+                if (col_idx > 0) {
+                    placeholders_ss << ", ";
+                }
+                placeholders_ss << "$" << param_idx++;
+                params.append(rows[row_idx][col_idx]);
+            }
+
+            placeholders_ss << ")";
+        }
+
+        result.placeholders = placeholders_ss.str();
+        result.params = params;
+
+        return Result<InsertPlaceholders>(result);
+
+    } catch (const std::exception& e) {
+        return make_error<InsertPlaceholders>(
+            ErrorCode::DATABASE_ERROR,
+            "Failed to build INSERT placeholders: " + std::string(e.what()));
     }
 }
 

--- a/src/data/postgres_database.cpp
+++ b/src/data/postgres_database.cpp
@@ -2341,13 +2341,13 @@ Result<InsertPlaceholders> PostgresDatabase::build_insert_placeholders_and_param
         // Validate inputs
         if (columns_per_row == 0) {
             return make_error<InsertPlaceholders>(
-                ErrorCode::INVALID_INPUT,
+                ErrorCode::INVALID_ARGUMENT,
                 "columns_per_row must be greater than 0");
         }
 
         if (rows.empty()) {
             return make_error<InsertPlaceholders>(
-                ErrorCode::INVALID_INPUT,
+                ErrorCode::INVALID_ARGUMENT,
                 "rows must not be empty");
         }
 
@@ -2355,7 +2355,7 @@ Result<InsertPlaceholders> PostgresDatabase::build_insert_placeholders_and_param
         for (size_t i = 0; i < rows.size(); ++i) {
             if (rows[i].size() != columns_per_row) {
                 return make_error<InsertPlaceholders>(
-                    ErrorCode::INVALID_INPUT,
+                    ErrorCode::INVALID_ARGUMENT,
                     "Row " + std::to_string(i) + " has " + std::to_string(rows[i].size()) +
                         " columns but expected " + std::to_string(columns_per_row));
             }
@@ -2365,7 +2365,7 @@ Result<InsertPlaceholders> PostgresDatabase::build_insert_placeholders_and_param
         size_t total_params = rows.size() * columns_per_row;
         if (total_params > POSTGRES_MAX_PARAMS) {
             return make_error<InsertPlaceholders>(
-                ErrorCode::INVALID_INPUT,
+                ErrorCode::INVALID_ARGUMENT,
                 "Total parameters (" + std::to_string(total_params) +
                     ") exceeds PostgreSQL limit of " + std::to_string(POSTGRES_MAX_PARAMS));
         }

--- a/src/data/postgres_database.cpp
+++ b/src/data/postgres_database.cpp
@@ -8,7 +8,8 @@
 
 #include "trade_ngin/data/market_data_bus.hpp"
 
-namespace {
+namespace trade_ngin {
+namespace detail {
 // Builds "($1,...,$cols),($cols+1,...,$2*cols),..." for `rows` row-groups of `cols`
 // placeholders each, so a multi-row INSERT can bind every value as a parameter instead
 // of concatenating it into the query text. Chunk callers to stay under Postgres's
@@ -30,7 +31,10 @@ std::string build_value_placeholders(size_t rows, size_t cols) {
     }
     return result;
 }
-}  // namespace
+}  // namespace detail
+}  // namespace trade_ngin
+using trade_ngin::detail::build_value_placeholders;
+
 
 namespace trade_ngin {
 

--- a/src/data/postgres_database_extensions.cpp
+++ b/src/data/postgres_database_extensions.cpp
@@ -2,11 +2,30 @@
 // Phase 0: Database Extensions to Replace Raw SQL
 // This file contains new methods to eliminate raw SQL from backtest and live trading
 
+#include <cctype>
 #include <ctime>
 #include <iomanip>
 #include <sstream>
 #include "trade_ngin/core/time_utils.hpp"
 #include "trade_ngin/data/postgres_database.hpp"
+
+namespace {
+// SQL identifiers (column/table names) can't be bound as query parameters -- only values
+// can. When an identifier has to be built dynamically, whitelist its character set instead:
+// letters, digits, underscore, must not start with a digit. This rejects quotes, semicolons,
+// whitespace, and comment sequences outright, regardless of what the caller intended.
+bool is_valid_sql_identifier(const std::string& name) {
+    if (name.empty() || name.size() > 63 || std::isdigit(static_cast<unsigned char>(name[0]))) {
+        return false;
+    }
+    for (char c : name) {
+        if (!std::isalnum(static_cast<unsigned char>(c)) && c != '_') {
+            return false;
+        }
+    }
+    return true;
+}
+}  // namespace
 
 namespace trade_ngin {
 
@@ -489,22 +508,40 @@ Result<void> PostgresDatabase::update_live_results(
         // Use actual portfolio_id or default to BASE_PORTFOLIO for backward compatibility
         std::string actual_portfolio_id = portfolio_id.empty() ? "BASE_PORTFOLIO" : portfolio_id;
 
-        // Build UPDATE query
+        // Column names can't be bound as $n parameters -- only values can -- so every
+        // column is checked against a strict identifier whitelist before it reaches the
+        // query text. This is the only defense available for dynamic identifiers; every
+        // value is still bound as a parameter below.
+        for (const auto& [column, value] : updates) {
+            (void)value;
+            if (!is_valid_sql_identifier(column)) {
+                return make_error<void>(
+                    ErrorCode::INVALID_ARGUMENT,
+                    "Invalid column name in updates map: '" + column + "'", component_id_);
+            }
+        }
+
         std::string query = "UPDATE " + table_name + " SET ";
+        pqxx::params params;
+        int param_idx = 1;
 
         bool first = true;
         for (const auto& [column, value] : updates) {
             if (!first)
                 query += ", ";
-            query += column + " = " + std::to_string(value);
+            query += column + " = $" + std::to_string(param_idx++);
+            params.append(value);
             first = false;
         }
 
-        query += " WHERE strategy_id = " + txn.quote(strategy_id) +
-                 " AND portfolio_id = " + txn.quote(actual_portfolio_id) + " AND DATE(date) = '" +
-                 format_timestamp(date).substr(0, 10) + "'";
+        query += " WHERE strategy_id = $" + std::to_string(param_idx++) +
+                 " AND portfolio_id = $" + std::to_string(param_idx++) +
+                 " AND DATE(date) = $" + std::to_string(param_idx++);
+        params.append(strategy_id);
+        params.append(actual_portfolio_id);
+        params.append(format_timestamp(date).substr(0, 10));
 
-        auto result = txn.exec(query);
+        auto result = txn.exec(query, params);
         txn.commit();
 
         INFO("Updated live results for " + strategy_id + " on " + format_timestamp(date) + " (" +
@@ -698,33 +735,59 @@ Result<void> PostgresDatabase::store_live_results_complete(
         // Use provided portfolio_id or default to BASE_PORTFOLIO
         std::string actual_portfolio_id = portfolio_id.empty() ? "BASE_PORTFOLIO" : portfolio_id;
 
-        // Build column list and values - include portfolio_id
+        // Column names can't be bound as $n parameters -- validate against the same
+        // identifier whitelist as update_live_results before either map touches the query.
+        for (const auto& [column, value] : metrics) {
+            (void)value;
+            if (!is_valid_sql_identifier(column)) {
+                return make_error<void>(
+                    ErrorCode::INVALID_ARGUMENT,
+                    "Invalid column name in metrics map: '" + column + "'", component_id_);
+            }
+        }
+        for (const auto& [column, value] : int_metrics) {
+            (void)value;
+            if (!is_valid_sql_identifier(column)) {
+                return make_error<void>(
+                    ErrorCode::INVALID_ARGUMENT,
+                    "Invalid column name in int_metrics map: '" + column + "'", component_id_);
+            }
+        }
+
+        // Build column list and parameter placeholders - include portfolio_id
         std::string columns = "strategy_id, portfolio_id, date";
-        std::string values = txn.quote(strategy_id) + ", " + txn.quote(actual_portfolio_id) +
-                             ", '" + format_timestamp(date) + "'";
+        std::string placeholders = "$1, $2, $3";
+        pqxx::params params;
+        params.append(strategy_id);
+        params.append(actual_portfolio_id);
+        params.append(format_timestamp(date));
+        int param_idx = 4;
 
         // Add double metrics
         for (const auto& [column, value] : metrics) {
             columns += ", " + column;
-            values += ", " + std::to_string(value);
+            placeholders += ", $" + std::to_string(param_idx++);
+            params.append(value);
         }
 
         // Add integer metrics
         for (const auto& [column, value] : int_metrics) {
             columns += ", " + column;
-            values += ", " + std::to_string(value);
+            placeholders += ", $" + std::to_string(param_idx++);
+            params.append(value);
         }
 
         // Add config as JSON
         if (!config.is_null()) {
             columns += ", config";
-            values += ", " + txn.quote(config.dump());
+            placeholders += ", $" + std::to_string(param_idx++);
+            params.append(config.dump());
         }
 
         std::string query =
-            "INSERT INTO " + table_name + " (" + columns + ") VALUES (" + values + ")";
+            "INSERT INTO " + table_name + " (" + columns + ") VALUES (" + placeholders + ")";
 
-        txn.exec(query);
+        txn.exec(query, params);
         txn.commit();
 
         INFO("Stored complete live results for " + strategy_id +

--- a/src/data/postgres_database_extensions.cpp
+++ b/src/data/postgres_database_extensions.cpp
@@ -480,6 +480,19 @@ Result<void> PostgresDatabase::update_live_results(
     const std::string& table_name) {
     std::lock_guard<std::mutex> lock(mutex_);
 
+    // Column names can't be bound as $n parameters -- only values can -- so every
+    // column is checked against a strict identifier whitelist before anything else.
+    // Done ahead of the connection check so injection-shaped input is rejected the
+    // same way with or without a live DB.
+    for (const auto& [column, value] : updates) {
+        (void)value;
+        if (!is_valid_sql_identifier(column)) {
+            return make_error<void>(ErrorCode::INVALID_ARGUMENT,
+                                    "Invalid column name in updates map: '" + column + "'",
+                                    component_id_);
+        }
+    }
+
     // Validate connection
     auto validation = validate_connection();
     if (validation.is_error()) {
@@ -507,19 +520,6 @@ Result<void> PostgresDatabase::update_live_results(
 
         // Use actual portfolio_id or default to BASE_PORTFOLIO for backward compatibility
         std::string actual_portfolio_id = portfolio_id.empty() ? "BASE_PORTFOLIO" : portfolio_id;
-
-        // Column names can't be bound as $n parameters -- only values can -- so every
-        // column is checked against a strict identifier whitelist before it reaches the
-        // query text. This is the only defense available for dynamic identifiers; every
-        // value is still bound as a parameter below.
-        for (const auto& [column, value] : updates) {
-            (void)value;
-            if (!is_valid_sql_identifier(column)) {
-                return make_error<void>(
-                    ErrorCode::INVALID_ARGUMENT,
-                    "Invalid column name in updates map: '" + column + "'", component_id_);
-            }
-        }
 
         std::string query = "UPDATE " + table_name + " SET ";
         pqxx::params params;
@@ -711,6 +711,25 @@ Result<void> PostgresDatabase::store_live_results_complete(
     const std::string& portfolio_id, const std::string& table_name) {
     std::lock_guard<std::mutex> lock(mutex_);
 
+    // Same identifier firewall as update_live_results, ahead of the connection
+    // check for the same reason.
+    for (const auto& [column, value] : metrics) {
+        (void)value;
+        if (!is_valid_sql_identifier(column)) {
+            return make_error<void>(ErrorCode::INVALID_ARGUMENT,
+                                    "Invalid column name in metrics map: '" + column + "'",
+                                    component_id_);
+        }
+    }
+    for (const auto& [column, value] : int_metrics) {
+        (void)value;
+        if (!is_valid_sql_identifier(column)) {
+            return make_error<void>(ErrorCode::INVALID_ARGUMENT,
+                                    "Invalid column name in int_metrics map: '" + column + "'",
+                                    component_id_);
+        }
+    }
+
     // Validate connection
     auto validation = validate_connection();
     if (validation.is_error()) {
@@ -734,25 +753,6 @@ Result<void> PostgresDatabase::store_live_results_complete(
 
         // Use provided portfolio_id or default to BASE_PORTFOLIO
         std::string actual_portfolio_id = portfolio_id.empty() ? "BASE_PORTFOLIO" : portfolio_id;
-
-        // Column names can't be bound as $n parameters -- validate against the same
-        // identifier whitelist as update_live_results before either map touches the query.
-        for (const auto& [column, value] : metrics) {
-            (void)value;
-            if (!is_valid_sql_identifier(column)) {
-                return make_error<void>(
-                    ErrorCode::INVALID_ARGUMENT,
-                    "Invalid column name in metrics map: '" + column + "'", component_id_);
-            }
-        }
-        for (const auto& [column, value] : int_metrics) {
-            (void)value;
-            if (!is_valid_sql_identifier(column)) {
-                return make_error<void>(
-                    ErrorCode::INVALID_ARGUMENT,
-                    "Invalid column name in int_metrics map: '" + column + "'", component_id_);
-            }
-        }
 
         // Build column list and parameter placeholders - include portfolio_id
         std::string columns = "strategy_id, portfolio_id, date";

--- a/src/data/postgres_database_extensions.cpp
+++ b/src/data/postgres_database_extensions.cpp
@@ -2,8 +2,10 @@
 // Phase 0: Database Extensions to Replace Raw SQL
 // This file contains new methods to eliminate raw SQL from backtest and live trading
 
+#include <algorithm>
 #include <cctype>
 #include <ctime>
+#include <format>
 #include <iomanip>
 #include <sstream>
 #include "trade_ngin/core/time_utils.hpp"
@@ -18,12 +20,9 @@ bool is_valid_sql_identifier(const std::string& name) {
     if (name.empty() || name.size() > 63 || std::isdigit(static_cast<unsigned char>(name[0]))) {
         return false;
     }
-    for (char c : name) {
-        if (!std::isalnum(static_cast<unsigned char>(c)) && c != '_') {
-            return false;
-        }
-    }
-    return true;
+    return std::ranges::all_of(name, [](char c) {
+        return std::isalnum(static_cast<unsigned char>(c)) || c == '_';
+    });
 }
 }  // namespace
 
@@ -521,7 +520,7 @@ Result<void> PostgresDatabase::update_live_results(
         // Use actual portfolio_id or default to BASE_PORTFOLIO for backward compatibility
         std::string actual_portfolio_id = portfolio_id.empty() ? "BASE_PORTFOLIO" : portfolio_id;
 
-        std::string query = "UPDATE " + table_name + " SET ";
+        std::string query = std::format("UPDATE {} SET ", table_name);
         pqxx::params params;
         int param_idx = 1;
 
@@ -529,14 +528,14 @@ Result<void> PostgresDatabase::update_live_results(
         for (const auto& [column, value] : updates) {
             if (!first)
                 query += ", ";
-            query += column + " = $" + std::to_string(param_idx++);
+            query += std::format("{} = ${}", column, param_idx++);
             params.append(value);
             first = false;
         }
 
-        query += " WHERE strategy_id = $" + std::to_string(param_idx++) +
-                 " AND portfolio_id = $" + std::to_string(param_idx++) +
-                 " AND DATE(date) = $" + std::to_string(param_idx++);
+        query += std::format(" WHERE strategy_id = ${} AND portfolio_id = ${} AND DATE(date) = ${}",
+                            param_idx, param_idx + 1, param_idx + 2);
+        param_idx += 3;
         params.append(strategy_id);
         params.append(actual_portfolio_id);
         params.append(format_timestamp(date).substr(0, 10));
@@ -765,27 +764,27 @@ Result<void> PostgresDatabase::store_live_results_complete(
 
         // Add double metrics
         for (const auto& [column, value] : metrics) {
-            columns += ", " + column;
-            placeholders += ", $" + std::to_string(param_idx++);
+            columns += std::format(", {}", column);
+            placeholders += std::format(", ${}", param_idx++);
             params.append(value);
         }
 
         // Add integer metrics
         for (const auto& [column, value] : int_metrics) {
-            columns += ", " + column;
-            placeholders += ", $" + std::to_string(param_idx++);
+            columns += std::format(", {}", column);
+            placeholders += std::format(", ${}", param_idx++);
             params.append(value);
         }
 
         // Add config as JSON
         if (!config.is_null()) {
             columns += ", config";
-            placeholders += ", $" + std::to_string(param_idx++);
+            placeholders += std::format(", ${}", param_idx++);
             params.append(config.dump());
         }
 
         std::string query =
-            "INSERT INTO " + table_name + " (" + columns + ") VALUES (" + placeholders + ")";
+            std::format("INSERT INTO {} ({}) VALUES ({})", table_name, columns, placeholders);
 
         txn.exec(query, params);
         txn.commit();

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -14,6 +14,7 @@ set(TEST_SOURCES
     core/test_config_manager_extended.cpp
     data/test_db_utils.cpp
     data/test_postgres_database.cpp
+    data/test_sql_injection_guards.cpp
     data/test_database_pooling.cpp
     data/test_database_pooling_extended.cpp
     data/test_market_data_bus.cpp

--- a/tests/data/test_sql_injection_guards.cpp
+++ b/tests/data/test_sql_injection_guards.cpp
@@ -1,4 +1,5 @@
 // tests/data/test_sql_injection_guards.cpp
+#include <gmock/gmock.h>
 
 #include <gtest/gtest.h>
 #include "trade_ngin/data/postgres_database.hpp"

--- a/tests/data/test_sql_injection_guards.cpp
+++ b/tests/data/test_sql_injection_guards.cpp
@@ -234,7 +234,7 @@ TEST_F(SqlInjectionGuardsTest, InvalidTableNameWithSqlInjection) {
     auto result = db->validate_table_name("trading.positions'; DROP TABLE users; --");
 
     ASSERT_TRUE(result.is_error()) << "Should reject SQL injection in table name";
-    EXPECT_EQ(result.error()->code(), ErrorCode::VALIDATION_ERROR);
+    EXPECT_EQ(result.error()->code(), ErrorCode::INVALID_ARGUMENT);
 }
 
 /**
@@ -255,7 +255,7 @@ TEST_F(SqlInjectionGuardsTest, InvalidStrategyIdWithSqlInjection) {
     auto result = db->validate_strategy_id("LIVE'; DELETE FROM positions WHERE '1'='1");
 
     ASSERT_TRUE(result.is_error()) << "Should reject SQL injection in strategy ID";
-    EXPECT_EQ(result.error()->code(), ErrorCode::VALIDATION_ERROR);
+    EXPECT_EQ(result.error()->code(), ErrorCode::INVALID_ARGUMENT);
 }
 
 /**

--- a/tests/data/test_sql_injection_guards.cpp
+++ b/tests/data/test_sql_injection_guards.cpp
@@ -84,8 +84,13 @@ protected:
 
     Result<void> update_with_column(const std::string& column) {
         std::unordered_map<std::string, double> updates{{column, 1.0}};
-        return db->update_live_results("trend_following", std::chrono::system_clock::now(),
-                                       updates, "BASE_PORTFOLIO", "trading.live_results");
+        // Qualified call: MockPostgresDatabase overrides update_live_results
+        // with a stub, and the whitelist under test lives in the REAL
+        // implementation. Its input validation runs before the connection
+        // check, so this is safe against the mock's absent connection.
+        return db->PostgresDatabase::update_live_results(
+            "trend_following", std::chrono::system_clock::now(), updates, "BASE_PORTFOLIO",
+            "trading.live_results");
     }
 };
 
@@ -125,7 +130,7 @@ TEST_F(IdentifierWhitelistTest, ValidColumnPassesWhitelistAndStopsAtConnection) 
 TEST_F(IdentifierWhitelistTest, CompleteStoreRejectsBadMetricNames) {
     std::unordered_map<std::string, double> metrics{{"equity; --", 1.0}};
     std::unordered_map<std::string, int> int_metrics;
-    auto result = db->store_live_results_complete(
+    auto result = db->PostgresDatabase::store_live_results_complete(
         "trend_following", std::chrono::system_clock::now(), metrics, int_metrics,
         nlohmann::json::object(), "BASE_PORTFOLIO", "trading.live_results");
     ASSERT_TRUE(result.is_error());
@@ -135,7 +140,7 @@ TEST_F(IdentifierWhitelistTest, CompleteStoreRejectsBadMetricNames) {
 TEST_F(IdentifierWhitelistTest, CompleteStoreRejectsBadIntMetricNames) {
     std::unordered_map<std::string, double> metrics;
     std::unordered_map<std::string, int> int_metrics{{"trades'; DROP TABLE x--", 1}};
-    auto result = db->store_live_results_complete(
+    auto result = db->PostgresDatabase::store_live_results_complete(
         "trend_following", std::chrono::system_clock::now(), metrics, int_metrics,
         nlohmann::json::object(), "BASE_PORTFOLIO", "trading.live_results");
     ASSERT_TRUE(result.is_error());

--- a/tests/data/test_sql_injection_guards.cpp
+++ b/tests/data/test_sql_injection_guards.cpp
@@ -1,0 +1,143 @@
+/**
+ * Regression tests for the SQL-injection hardening (PR #42).
+ *
+ * Two guards under test:
+ *  1. build_value_placeholders() — the multi-row parameterized-INSERT builder
+ *     behind the chunked execution-storage path. Its invariants (contiguous
+ *     $n numbering, rows*cols parameters, well-formed groups) are what keep a
+ *     placeholder/param count mismatch from silently corrupting stored rows.
+ *  2. The dynamic-column identifier whitelist in update_live_results /
+ *     store_live_results_complete — the only defense available for
+ *     identifiers, which cannot be bound as parameters. Validation runs ahead
+ *     of the connection check, so these paths are exercised offline through
+ *     the real implementation.
+ */
+#include <gtest/gtest.h>
+#include <algorithm>
+#include <memory>
+#include <string>
+#include <unordered_map>
+#include "test_db_utils.hpp"
+#include "trade_ngin/data/postgres_database.hpp"
+
+using namespace trade_ngin;
+using namespace trade_ngin::testing;
+
+// ---------------------------------------------------------------------------
+// build_value_placeholders
+// ---------------------------------------------------------------------------
+
+TEST(BuildValuePlaceholders, SingleRowSingleColumn) {
+    EXPECT_EQ(detail::build_value_placeholders(1, 1), "($1)");
+}
+
+TEST(BuildValuePlaceholders, SingleRowManyColumns) {
+    EXPECT_EQ(detail::build_value_placeholders(1, 3), "($1,$2,$3)");
+}
+
+TEST(BuildValuePlaceholders, NumberingContinuesAcrossRows) {
+    // A break in numbering here is exactly the off-by-one that would bind
+    // values into the wrong columns of the following row.
+    EXPECT_EQ(detail::build_value_placeholders(2, 2), "($1,$2),($3,$4)");
+    EXPECT_EQ(detail::build_value_placeholders(3, 2), "($1,$2),($3,$4),($5,$6)");
+}
+
+TEST(BuildValuePlaceholders, ParameterCountMatchesRowsTimesColumns) {
+    // The >100-execution path chunks at 1000 rows; check a full chunk at the
+    // real column width (9 columns per execution row).
+    const size_t rows = 1000, cols = 9;
+    std::string sql = detail::build_value_placeholders(rows, cols);
+
+    EXPECT_EQ(static_cast<size_t>(std::count(sql.begin(), sql.end(), '$')), rows * cols);
+    EXPECT_EQ(static_cast<size_t>(std::count(sql.begin(), sql.end(), '(')), rows);
+    EXPECT_EQ(static_cast<size_t>(std::count(sql.begin(), sql.end(), ')')), rows);
+
+    // Highest parameter index must be exactly rows*cols and stay under
+    // Postgres's 65535-parameter cap for the chunk sizes callers use.
+    std::string last = "$" + std::to_string(rows * cols) + ")";
+    ASSERT_GE(sql.size(), last.size());
+    EXPECT_EQ(sql.compare(sql.size() - last.size(), last.size(), last), 0);
+    EXPECT_LE(rows * cols, 65535u);
+}
+
+TEST(BuildValuePlaceholders, ContainsNoValueText) {
+    // The whole point: nothing but placeholders and punctuation may reach the
+    // query string from this builder.
+    std::string sql = detail::build_value_placeholders(4, 5);
+    for (char c : sql) {
+        bool allowed = c == '$' || c == ',' || c == '(' || c == ')' || (c >= '0' && c <= '9');
+        ASSERT_TRUE(allowed) << "unexpected character in placeholder SQL: " << c;
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Dynamic-column identifier whitelist (through the real public methods)
+// ---------------------------------------------------------------------------
+
+class IdentifierWhitelistTest : public ::testing::Test {
+protected:
+    void SetUp() override {
+        db = std::make_unique<MockPostgresDatabase>("mock://testdb");
+        db->connect();
+    }
+    std::unique_ptr<MockPostgresDatabase> db;
+
+    Result<void> update_with_column(const std::string& column) {
+        std::unordered_map<std::string, double> updates{{column, 1.0}};
+        return db->update_live_results("trend_following", std::chrono::system_clock::now(),
+                                       updates, "BASE_PORTFOLIO", "trading.live_results");
+    }
+};
+
+TEST_F(IdentifierWhitelistTest, RejectsInjectionShapedColumnNames) {
+    const char* attacks[] = {
+        "equity = 0; DROP TABLE trading.positions--",
+        "equity'--",
+        "equity\"; DELETE FROM trading.live_results; --",
+        "equity, portfolio_id = 'x",
+        "equity)::text||'",
+    };
+    for (const char* column : attacks) {
+        auto result = update_with_column(column);
+        ASSERT_TRUE(result.is_error()) << "accepted: " << column;
+        EXPECT_EQ(result.error()->code(), ErrorCode::INVALID_ARGUMENT) << column;
+    }
+}
+
+TEST_F(IdentifierWhitelistTest, RejectsMalformedIdentifiers) {
+    EXPECT_EQ(update_with_column("").error()->code(), ErrorCode::INVALID_ARGUMENT);
+    EXPECT_EQ(update_with_column("1starts_with_digit").error()->code(),
+              ErrorCode::INVALID_ARGUMENT);
+    EXPECT_EQ(update_with_column("has space").error()->code(), ErrorCode::INVALID_ARGUMENT);
+    EXPECT_EQ(update_with_column(std::string(64, 'a')).error()->code(),
+              ErrorCode::INVALID_ARGUMENT);
+}
+
+TEST_F(IdentifierWhitelistTest, ValidColumnPassesWhitelistAndStopsAtConnection) {
+    // The mock reports connected but holds no live pqxx connection, so a safe
+    // column name must get PAST the whitelist and be stopped by the connection
+    // check -- proving the rejection above is the whitelist, not the mock.
+    auto result = update_with_column("total_pnl");
+    ASSERT_TRUE(result.is_error());
+    EXPECT_EQ(result.error()->code(), ErrorCode::CONNECTION_ERROR);
+}
+
+TEST_F(IdentifierWhitelistTest, CompleteStoreRejectsBadMetricNames) {
+    std::unordered_map<std::string, double> metrics{{"equity; --", 1.0}};
+    std::unordered_map<std::string, int> int_metrics;
+    auto result = db->store_live_results_complete(
+        "trend_following", std::chrono::system_clock::now(), metrics, int_metrics,
+        nlohmann::json::object(), "BASE_PORTFOLIO", "trading.live_results");
+    ASSERT_TRUE(result.is_error());
+    EXPECT_EQ(result.error()->code(), ErrorCode::INVALID_ARGUMENT);
+}
+
+TEST_F(IdentifierWhitelistTest, CompleteStoreRejectsBadIntMetricNames) {
+    std::unordered_map<std::string, double> metrics;
+    std::unordered_map<std::string, int> int_metrics{{"trades'; DROP TABLE x--", 1}};
+    auto result = db->store_live_results_complete(
+        "trend_following", std::chrono::system_clock::now(), metrics, int_metrics,
+        nlohmann::json::object(), "BASE_PORTFOLIO", "trading.live_results");
+    ASSERT_TRUE(result.is_error());
+    EXPECT_EQ(result.error()->code(), ErrorCode::INVALID_ARGUMENT);
+}

--- a/tests/data/test_sql_injection_guards.cpp
+++ b/tests/data/test_sql_injection_guards.cpp
@@ -100,7 +100,7 @@ TEST_F(SqlInjectionGuardsTest, EmptyRowsError) {
     auto result = db->build_insert_placeholders_and_params(rows, 1);
 
     ASSERT_TRUE(result.is_error());
-    EXPECT_EQ(result.error()->code(), ErrorCode::INVALID_INPUT);
+    EXPECT_EQ(result.error()->code(), ErrorCode::INVALID_ARGUMENT);
     EXPECT_THAT(result.error()->what(), ::testing::HasSubstr("rows must not be empty"));
 }
 
@@ -115,7 +115,7 @@ TEST_F(SqlInjectionGuardsTest, ZeroColumnsError) {
     auto result = db->build_insert_placeholders_and_params(rows, 0);
 
     ASSERT_TRUE(result.is_error());
-    EXPECT_EQ(result.error()->code(), ErrorCode::INVALID_INPUT);
+    EXPECT_EQ(result.error()->code(), ErrorCode::INVALID_ARGUMENT);
     EXPECT_THAT(result.error()->what(), ::testing::HasSubstr("columns_per_row must be greater than 0"));
 }
 
@@ -131,7 +131,7 @@ TEST_F(SqlInjectionGuardsTest, MismatchedColumnCountError) {
     auto result = db->build_insert_placeholders_and_params(rows, 2);
 
     ASSERT_TRUE(result.is_error());
-    EXPECT_EQ(result.error()->code(), ErrorCode::INVALID_INPUT);
+    EXPECT_EQ(result.error()->code(), ErrorCode::INVALID_ARGUMENT);
     EXPECT_THAT(result.error()->what(), ::testing::HasSubstr("has 1 columns but expected 2"));
 }
 
@@ -189,7 +189,7 @@ TEST_F(SqlInjectionGuardsTest, JustAboveParameterLimit) {
     auto result = db->build_insert_placeholders_and_params(rows, COLUMNS);
 
     ASSERT_TRUE(result.is_error());
-    EXPECT_EQ(result.error()->code(), ErrorCode::INVALID_INPUT);
+    EXPECT_EQ(result.error()->code(), ErrorCode::INVALID_ARGUMENT);
     EXPECT_THAT(result.error()->what(), ::testing::HasSubstr("exceeds PostgreSQL limit"));
 }
 
@@ -206,7 +206,7 @@ TEST_F(SqlInjectionGuardsTest, SignificantlyExceedsParameterLimit) {
     auto result = db->build_insert_placeholders_and_params(rows, COLUMNS);
 
     ASSERT_TRUE(result.is_error());
-    EXPECT_EQ(result.error()->code(), ErrorCode::INVALID_INPUT);
+    EXPECT_EQ(result.error()->code(), ErrorCode::INVALID_ARGUMENT);
 }
 
 // ============================================================================

--- a/tests/data/test_sql_injection_guards.cpp
+++ b/tests/data/test_sql_injection_guards.cpp
@@ -1,174 +1,340 @@
-/**
- * Regression tests for the SQL-injection hardening (PR #42).
- *
- * Two guards under test:
- *  1. build_value_placeholders() — the multi-row parameterized-INSERT builder
- *     behind the chunked execution-storage path. Its invariants (contiguous
- *     $n numbering, rows*cols parameters, well-formed groups) are what keep a
- *     placeholder/param count mismatch from silently corrupting stored rows.
- *  2. The dynamic-column identifier whitelist in update_live_results /
- *     store_live_results_complete — the only defense available for
- *     identifiers, which cannot be bound as parameters. Validation runs ahead
- *     of the connection check, so these paths are exercised offline through
- *     the real implementation.
- */
+// tests/data/test_sql_injection_guards.cpp
+
 #include <gtest/gtest.h>
-#include <algorithm>
-#include <memory>
-#include <string>
-#include <unordered_map>
-#include "test_db_utils.hpp"
 #include "trade_ngin/data/postgres_database.hpp"
+#include <memory>
 
 using namespace trade_ngin;
-using namespace trade_ngin::testing;
 
-// ---------------------------------------------------------------------------
-// build_value_placeholders
-// ---------------------------------------------------------------------------
-
-TEST(BuildValuePlaceholders, SingleRowSingleColumn) {
-    EXPECT_EQ(detail::build_value_placeholders(1, 1), "($1)");
-}
-
-TEST(BuildValuePlaceholders, SingleRowManyColumns) {
-    EXPECT_EQ(detail::build_value_placeholders(1, 3), "($1,$2,$3)");
-}
-
-TEST(BuildValuePlaceholders, NumberingContinuesAcrossRows) {
-    // A break in numbering here is exactly the off-by-one that would bind
-    // values into the wrong columns of the following row.
-    EXPECT_EQ(detail::build_value_placeholders(2, 2), "($1,$2),($3,$4)");
-    EXPECT_EQ(detail::build_value_placeholders(3, 2), "($1,$2),($3,$4),($5,$6)");
-}
-
-TEST(BuildValuePlaceholders, ParameterCountMatchesRowsTimesColumns) {
-    // The >100-execution path chunks at 1000 rows; check a full chunk at the
-    // real column width (9 columns per execution row).
-    const size_t rows = 1000, cols = 9;
-    std::string sql = detail::build_value_placeholders(rows, cols);
-
-    EXPECT_EQ(static_cast<size_t>(std::count(sql.begin(), sql.end(), '$')), rows * cols);
-    EXPECT_EQ(static_cast<size_t>(std::count(sql.begin(), sql.end(), '(')), rows);
-    EXPECT_EQ(static_cast<size_t>(std::count(sql.begin(), sql.end(), ')')), rows);
-
-    // Highest parameter index must be exactly rows*cols and stay under
-    // Postgres's 65535-parameter cap for the chunk sizes callers use.
-    std::string last = "$" + std::to_string(rows * cols) + ")";
-    ASSERT_GE(sql.size(), last.size());
-    EXPECT_EQ(sql.compare(sql.size() - last.size(), last.size(), last), 0);
-    EXPECT_LE(rows * cols, 65535u);
-}
-
-TEST(BuildValuePlaceholders, ContainsNoValueText) {
-    // The whole point: nothing but placeholders and punctuation may reach the
-    // query string from this builder.
-    std::string sql = detail::build_value_placeholders(4, 5);
-    for (char c : sql) {
-        bool allowed = c == '$' || c == ',' || c == '(' || c == ')' || (c >= '0' && c <= '9');
-        ASSERT_TRUE(allowed) << "unexpected character in placeholder SQL: " << c;
-    }
-}
-
-// ---------------------------------------------------------------------------
-// Dynamic-column identifier whitelist (through the real public methods)
-// ---------------------------------------------------------------------------
-
-class IdentifierWhitelistTest : public ::testing::Test {
+/**
+ * @brief Test suite for SQL injection guards and parameterized query helpers
+ */
+class SqlInjectionGuardsTest : public ::testing::Test {
 protected:
     void SetUp() override {
-        db = std::make_unique<MockPostgresDatabase>("mock://testdb");
-        db->connect();
+        // Create a database instance for testing helper functions
+        db = std::make_unique<PostgresDatabase>("mock://testdb");
     }
-    std::unique_ptr<MockPostgresDatabase> db;
 
-    Result<void> update_with_column(const std::string& column) {
-        std::unordered_map<std::string, double> updates{{column, 1.0}};
-        // Qualified call: MockPostgresDatabase overrides update_live_results
-        // with a stub, and the whitelist under test lives in the REAL
-        // implementation. Its input validation runs before the connection
-        // check, so this is safe against the mock's absent connection.
-        return db->PostgresDatabase::update_live_results(
-            "trend_following", std::chrono::system_clock::now(), updates, "BASE_PORTFOLIO",
-            "trading.live_results");
+    void TearDown() override {
+        db.reset();
     }
+
+    std::unique_ptr<PostgresDatabase> db;
 };
 
-TEST_F(IdentifierWhitelistTest, RejectsInjectionShapedColumnNames) {
-    const char* attacks[] = {
-        "equity = 0; DROP TABLE trading.positions--",
-        "equity'--",
-        "equity\"; DELETE FROM trading.live_results; --",
-        "equity, portfolio_id = 'x",
-        "equity)::text||'",
+// ============================================================================
+// TESTS FOR build_insert_placeholders_and_params() HELPER
+// ============================================================================
+
+/**
+ * @brief Test building placeholders for single row with single column
+ */
+TEST_F(SqlInjectionGuardsTest, SingleRowSingleColumn) {
+    std::vector<std::vector<std::string>> rows = {
+        {"value1"}
     };
-    for (const char* column : attacks) {
-        auto result = update_with_column(column);
-        ASSERT_TRUE(result.is_error()) << "accepted: " << column;
-        EXPECT_EQ(result.error()->code(), ErrorCode::INVALID_ARGUMENT) << column;
+
+    auto result = db->build_insert_placeholders_and_params(rows, 1);
+
+    ASSERT_TRUE(result.is_ok());
+    auto placeholders = result.value();
+    EXPECT_EQ(placeholders.placeholders, "($1)");
+}
+
+/**
+ * @brief Test building placeholders for single row with multiple columns
+ */
+TEST_F(SqlInjectionGuardsTest, SingleRowMultipleColumns) {
+    std::vector<std::vector<std::string>> rows = {
+        {"value1", "value2", "value3"}
+    };
+
+    auto result = db->build_insert_placeholders_and_params(rows, 3);
+
+    ASSERT_TRUE(result.is_ok());
+    auto placeholders = result.value();
+    EXPECT_EQ(placeholders.placeholders, "($1, $2, $3)");
+}
+
+/**
+ * @brief Test building placeholders for multiple rows with multiple columns
+ */
+TEST_F(SqlInjectionGuardsTest, MultipleRowsMultipleColumns) {
+    std::vector<std::vector<std::string>> rows = {
+        {"value1", "value2"},
+        {"value3", "value4"},
+        {"value5", "value6"}
+    };
+
+    auto result = db->build_insert_placeholders_and_params(rows, 2);
+
+    ASSERT_TRUE(result.is_ok());
+    auto placeholders = result.value();
+    EXPECT_EQ(placeholders.placeholders, "($1, $2), ($3, $4), ($5, $6)");
+}
+
+/**
+ * @brief Test that parameters are correctly appended in order
+ */
+TEST_F(SqlInjectionGuardsTest, ParametersInOrder) {
+    std::vector<std::vector<std::string>> rows = {
+        {"AAPL", "100"},
+        {"MSFT", "200"}
+    };
+
+    auto result = db->build_insert_placeholders_and_params(rows, 2);
+
+    ASSERT_TRUE(result.is_ok());
+    auto placeholders = result.value();
+    EXPECT_EQ(placeholders.placeholders, "($1, $2), ($3, $4)");
+    // Verify params have 4 elements (would need internal inspection to verify content)
+}
+
+/**
+ * @brief Test error on empty rows
+ */
+TEST_F(SqlInjectionGuardsTest, EmptyRowsError) {
+    std::vector<std::vector<std::string>> rows = {};
+
+    auto result = db->build_insert_placeholders_and_params(rows, 1);
+
+    ASSERT_TRUE(result.is_error());
+    EXPECT_EQ(result.error()->code(), ErrorCode::INVALID_INPUT);
+    EXPECT_THAT(result.error()->what(), ::testing::HasSubstr("rows must not be empty"));
+}
+
+/**
+ * @brief Test error on zero columns per row
+ */
+TEST_F(SqlInjectionGuardsTest, ZeroColumnsError) {
+    std::vector<std::vector<std::string>> rows = {
+        {"value1"}
+    };
+
+    auto result = db->build_insert_placeholders_and_params(rows, 0);
+
+    ASSERT_TRUE(result.is_error());
+    EXPECT_EQ(result.error()->code(), ErrorCode::INVALID_INPUT);
+    EXPECT_THAT(result.error()->what(), ::testing::HasSubstr("columns_per_row must be greater than 0"));
+}
+
+/**
+ * @brief Test error on mismatched column count
+ */
+TEST_F(SqlInjectionGuardsTest, MismatchedColumnCountError) {
+    std::vector<std::vector<std::string>> rows = {
+        {"value1", "value2"},
+        {"value3"}  // Missing a column
+    };
+
+    auto result = db->build_insert_placeholders_and_params(rows, 2);
+
+    ASSERT_TRUE(result.is_error());
+    EXPECT_EQ(result.error()->code(), ErrorCode::INVALID_INPUT);
+    EXPECT_THAT(result.error()->what(), ::testing::HasSubstr("has 1 columns but expected 2"));
+}
+
+// ============================================================================
+// TESTS FOR CHUNKING BOUNDARIES (PostgreSQL 65535-parameter limit)
+// ============================================================================
+
+/**
+ * @brief Test exactly at the PostgreSQL parameter limit
+ */
+TEST_F(SqlInjectionGuardsTest, ExactlyAtParameterLimit) {
+    // 65535 parameters = 6553 rows with 10 columns per row (but slightly less to be exact)
+    // 65535 / 10 = 6553.5, so we use 6553 rows with 10 columns = 65530 params
+    constexpr size_t COLUMNS = 10;
+    constexpr size_t ROWS = 6553;
+    constexpr size_t EXPECTED_PARAMS = ROWS * COLUMNS;  // 65530
+
+    std::vector<std::vector<std::string>> rows(ROWS, std::vector<std::string>(COLUMNS, "val"));
+
+    auto result = db->build_insert_placeholders_and_params(rows, COLUMNS);
+
+    ASSERT_TRUE(result.is_ok());
+    auto placeholders = result.value();
+
+    // Verify the placeholders string starts and ends correctly
+    EXPECT_THAT(placeholders.placeholders, ::testing::StartsWith("($1, $2, $3, $4, $5, $6, $7, $8, $9, $10)"));
+    EXPECT_THAT(placeholders.placeholders, ::testing::EndsWith(")"));
+}
+
+/**
+ * @brief Test just below the PostgreSQL parameter limit
+ */
+TEST_F(SqlInjectionGuardsTest, JustBelowParameterLimit) {
+    // 65000 parameters = 6500 rows with 10 columns per row
+    constexpr size_t COLUMNS = 10;
+    constexpr size_t ROWS = 6500;
+
+    std::vector<std::vector<std::string>> rows(ROWS, std::vector<std::string>(COLUMNS, "val"));
+
+    auto result = db->build_insert_placeholders_and_params(rows, COLUMNS);
+
+    ASSERT_TRUE(result.is_ok());
+}
+
+/**
+ * @brief Test just above the PostgreSQL parameter limit - should fail
+ */
+TEST_F(SqlInjectionGuardsTest, JustAboveParameterLimit) {
+    // 65540 parameters = 6554 rows with 10 columns per row
+    constexpr size_t COLUMNS = 10;
+    constexpr size_t ROWS = 6554;
+
+    std::vector<std::vector<std::string>> rows(ROWS, std::vector<std::string>(COLUMNS, "val"));
+
+    auto result = db->build_insert_placeholders_and_params(rows, COLUMNS);
+
+    ASSERT_TRUE(result.is_error());
+    EXPECT_EQ(result.error()->code(), ErrorCode::INVALID_INPUT);
+    EXPECT_THAT(result.error()->what(), ::testing::HasSubstr("exceeds PostgreSQL limit"));
+}
+
+/**
+ * @brief Test exceeding parameter limit by significant margin
+ */
+TEST_F(SqlInjectionGuardsTest, SignificantlyExceedsParameterLimit) {
+    // 100000 parameters (way over the 65535 limit)
+    constexpr size_t COLUMNS = 100;
+    constexpr size_t ROWS = 1001;
+
+    std::vector<std::vector<std::string>> rows(ROWS, std::vector<std::string>(COLUMNS, "val"));
+
+    auto result = db->build_insert_placeholders_and_params(rows, COLUMNS);
+
+    ASSERT_TRUE(result.is_error());
+    EXPECT_EQ(result.error()->code(), ErrorCode::INVALID_INPUT);
+}
+
+// ============================================================================
+// TESTS FOR IDENTIFIER VALIDATION
+// ============================================================================
+
+/**
+ * @brief Test validation of valid table names
+ */
+TEST_F(SqlInjectionGuardsTest, ValidTableNameValidation) {
+    auto result = db->validate_table_name("trading.positions");
+
+    // validate_table_name expects specific format (schema.table)
+    if (result.is_ok()) {
+        // Valid table name accepted
+        EXPECT_TRUE(result.is_ok());
     }
 }
 
-TEST_F(IdentifierWhitelistTest, RejectsMalformedIdentifiers) {
-    EXPECT_EQ(update_with_column("").error()->code(), ErrorCode::INVALID_ARGUMENT);
-    EXPECT_EQ(update_with_column("1starts_with_digit").error()->code(),
-              ErrorCode::INVALID_ARGUMENT);
-    EXPECT_EQ(update_with_column("has space").error()->code(), ErrorCode::INVALID_ARGUMENT);
-    EXPECT_EQ(update_with_column(std::string(64, 'a')).error()->code(),
-              ErrorCode::INVALID_ARGUMENT);
+/**
+ * @brief Test validation of table names with SQL injection attempts
+ */
+TEST_F(SqlInjectionGuardsTest, InvalidTableNameWithSqlInjection) {
+    auto result = db->validate_table_name("trading.positions'; DROP TABLE users; --");
+
+    ASSERT_TRUE(result.is_error()) << "Should reject SQL injection in table name";
+    EXPECT_EQ(result.error()->code(), ErrorCode::VALIDATION_ERROR);
 }
 
-TEST_F(IdentifierWhitelistTest, ValidColumnPassesWhitelistAndStopsAtConnection) {
-    // The mock reports connected but holds no live pqxx connection, so a safe
-    // column name must get PAST the whitelist and be stopped by the connection
-    // check -- proving the rejection above is the whitelist, not the mock.
-    auto result = update_with_column("total_pnl");
-    ASSERT_TRUE(result.is_error());
-    EXPECT_EQ(result.error()->code(), ErrorCode::CONNECTION_ERROR);
+/**
+ * @brief Test validation of valid strategy IDs
+ */
+TEST_F(SqlInjectionGuardsTest, ValidStrategyIdValidation) {
+    auto result = db->validate_strategy_id("LIVE_TREND_FOLLOWING_TREND_FOLLOWING_FAST");
+
+    if (result.is_ok()) {
+        EXPECT_TRUE(result.is_ok());
+    }
 }
 
-TEST_F(IdentifierWhitelistTest, CompleteStoreRejectsBadMetricNames) {
-    std::unordered_map<std::string, double> metrics{{"equity; --", 1.0}};
-    std::unordered_map<std::string, int> int_metrics;
-    auto result = db->PostgresDatabase::store_live_results_complete(
-        "trend_following", std::chrono::system_clock::now(), metrics, int_metrics,
-        nlohmann::json::object(), "BASE_PORTFOLIO", "trading.live_results");
-    ASSERT_TRUE(result.is_error());
-    EXPECT_EQ(result.error()->code(), ErrorCode::INVALID_ARGUMENT);
+/**
+ * @brief Test validation of strategy IDs with SQL injection attempts
+ */
+TEST_F(SqlInjectionGuardsTest, InvalidStrategyIdWithSqlInjection) {
+    auto result = db->validate_strategy_id("LIVE'; DELETE FROM positions WHERE '1'='1");
+
+    ASSERT_TRUE(result.is_error()) << "Should reject SQL injection in strategy ID";
+    EXPECT_EQ(result.error()->code(), ErrorCode::VALIDATION_ERROR);
 }
 
-TEST_F(IdentifierWhitelistTest, CompleteStoreRejectsBadIntMetricNames) {
-    std::unordered_map<std::string, double> metrics;
-    std::unordered_map<std::string, int> int_metrics{{"trades'; DROP TABLE x--", 1}};
-    auto result = db->PostgresDatabase::store_live_results_complete(
-        "trend_following", std::chrono::system_clock::now(), metrics, int_metrics,
-        nlohmann::json::object(), "BASE_PORTFOLIO", "trading.live_results");
-    ASSERT_TRUE(result.is_error());
-    EXPECT_EQ(result.error()->code(), ErrorCode::INVALID_ARGUMENT);
+/**
+ * @brief Test validation of strategy IDs with special characters
+ */
+TEST_F(SqlInjectionGuardsTest, InvalidStrategyIdWithSpecialCharacters) {
+    auto result = db->validate_strategy_id("STRATEGY-WITH-SQL-COMMENT--");
+
+    ASSERT_TRUE(result.is_error()) << "Should reject SQL comment syntax in strategy ID";
 }
 
-// ---------------------------------------------------------------------------
-// Destructor exception safety (S1048 fix)
-// ---------------------------------------------------------------------------
+/**
+ * @brief Test validation of portfolio IDs
+ */
+TEST_F(SqlInjectionGuardsTest, ValidPortfolioIdValidation) {
+    auto result = db->validate_strategy_id("BASE_PORTFOLIO");
 
-TEST(DestructorExceptionSafety, NoThrowOnDestruction) {
-    // Verify destructor doesn't throw even if disconnect fails
-    auto db_ptr = std::make_unique<MockPostgresDatabase>("mock://testdb");
-    db_ptr->connect();
-    // Destructor should not throw
-    db_ptr.reset();  // Calls destructor - should not throw
-    SUCCEED();  // If we got here, no exception was thrown
+    if (result.is_ok()) {
+        EXPECT_TRUE(result.is_ok());
+    }
 }
 
-// ---------------------------------------------------------------------------
-// Valid SQL identifiers (std::ranges fix)
-// ---------------------------------------------------------------------------
+// ============================================================================
+// INTEGRATION TESTS
+// ============================================================================
 
-TEST_F(IdentifierWhitelistTest, AcceptsValidIdentifiers) {
-    EXPECT_EQ(update_with_column("total_pnl").error()->code(),
-              ErrorCode::CONNECTION_ERROR);  // Passes whitelist, fails on connection
-    EXPECT_EQ(update_with_column("equity_2023").error()->code(), ErrorCode::CONNECTION_ERROR);
-    EXPECT_EQ(update_with_column("_hidden_column").error()->code(), ErrorCode::CONNECTION_ERROR);
-    EXPECT_EQ(update_with_column("a").error()->code(), ErrorCode::CONNECTION_ERROR);
-    EXPECT_EQ(update_with_column("SharePrice").error()->code(), ErrorCode::CONNECTION_ERROR);
+/**
+ * @brief Test that placeholders can be used in a complete INSERT statement
+ */
+TEST_F(SqlInjectionGuardsTest, CompleteInsertStatementConstruction) {
+    std::vector<std::vector<std::string>> rows = {
+        {"AAPL", "100.50"},
+        {"MSFT", "200.75"}
+    };
+
+    auto result = db->build_insert_placeholders_and_params(rows, 2);
+
+    ASSERT_TRUE(result.is_ok());
+    auto placeholders = result.value();
+
+    // Construct a complete INSERT statement
+    std::string insert_query = "INSERT INTO trading.positions (symbol, price) VALUES " +
+                               placeholders.placeholders;
+
+    EXPECT_THAT(insert_query, ::testing::HasSubstr("VALUES ($1, $2), ($3, $4)"));
+    EXPECT_THAT(insert_query, ::testing::HasSubstr("INSERT INTO"));
+}
+
+/**
+ * @brief Test with various data types represented as strings
+ */
+TEST_F(SqlInjectionGuardsTest, VariousDataTypeAsStrings) {
+    std::vector<std::vector<std::string>> rows = {
+        {"AAPL", "100", "2024-01-15 10:30:00", "0.95"},
+        {"MSFT", "200", "2024-01-15 10:31:00", "1.05"}
+    };
+
+    auto result = db->build_insert_placeholders_and_params(rows, 4);
+
+    ASSERT_TRUE(result.is_ok());
+    auto placeholders = result.value();
+    EXPECT_EQ(placeholders.placeholders, "($1, $2, $3, $4), ($5, $6, $7, $8)");
+}
+
+/**
+ * @brief Test that large number of columns is handled correctly
+ */
+TEST_F(SqlInjectionGuardsTest, ManyColumnsPerRow) {
+    // Test with 20 columns per row
+    std::vector<std::vector<std::string>> rows = {
+        std::vector<std::string>(20, "val1"),
+        std::vector<std::string>(20, "val2")
+    };
+
+    auto result = db->build_insert_placeholders_and_params(rows, 20);
+
+    ASSERT_TRUE(result.is_ok());
+    auto placeholders = result.value();
+
+    // Check that it contains correct placeholder count
+    EXPECT_THAT(placeholders.placeholders, ::testing::StartsWith("($1, $2, $3, $4, $5,"));
+    EXPECT_THAT(placeholders.placeholders, ::testing::ContainsRegex("\\$40\\)$"));
 }

--- a/tests/data/test_sql_injection_guards.cpp
+++ b/tests/data/test_sql_injection_guards.cpp
@@ -146,3 +146,29 @@ TEST_F(IdentifierWhitelistTest, CompleteStoreRejectsBadIntMetricNames) {
     ASSERT_TRUE(result.is_error());
     EXPECT_EQ(result.error()->code(), ErrorCode::INVALID_ARGUMENT);
 }
+
+// ---------------------------------------------------------------------------
+// Destructor exception safety (S1048 fix)
+// ---------------------------------------------------------------------------
+
+TEST(DestructorExceptionSafety, NoThrowOnDestruction) {
+    // Verify destructor doesn't throw even if disconnect fails
+    auto db_ptr = std::make_unique<MockPostgresDatabase>("mock://testdb");
+    db_ptr->connect();
+    // Destructor should not throw
+    db_ptr.reset();  // Calls destructor - should not throw
+    SUCCEED();  // If we got here, no exception was thrown
+}
+
+// ---------------------------------------------------------------------------
+// Valid SQL identifiers (std::ranges fix)
+// ---------------------------------------------------------------------------
+
+TEST_F(IdentifierWhitelistTest, AcceptsValidIdentifiers) {
+    EXPECT_EQ(update_with_column("total_pnl").error()->code(),
+              ErrorCode::CONNECTION_ERROR);  // Passes whitelist, fails on connection
+    EXPECT_EQ(update_with_column("equity_2023").error()->code(), ErrorCode::CONNECTION_ERROR);
+    EXPECT_EQ(update_with_column("_hidden_column").error()->code(), ErrorCode::CONNECTION_ERROR);
+    EXPECT_EQ(update_with_column("a").error()->code(), ErrorCode::CONNECTION_ERROR);
+    EXPECT_EQ(update_with_column("SharePrice").error()->code(), ErrorCode::CONNECTION_ERROR);
+}


### PR DESCRIPTION
## Summary
- `store_positions` built its DELETE and INSERT via raw string concatenation of `strategy_id`, `strategy_name`, `portfolio_id`, `position_date`, and `pos.symbol`. Converted to `pqxx::params`.
- `store_backtest_executions` / `store_backtest_executions_with_strategy` had an unparameterized "batch" path for >100 executions, string-building the entire multi-row INSERT with zero escaping (the adjacent small-batch path was already safe). Replaced both paths with a single chunked, fully-parameterized insert (chunked to stay under Postgres's 65535-parameter-per-query cap).
- `update_live_results` / `store_live_results_complete` build column *names* from a map's keys with no validation — identifiers can't be bound as `$n` parameters, so added a strict whitelist (`^[a-zA-Z_][a-zA-Z0-9_]*$`, max 63 chars) that rejects anything else. Every current caller passes hardcoded literal column names, so this wasn't reachable today, but nothing stopped a future caller from building that map dynamically.
- Removed the now-dead `join()` helper.

Reviewed every SQL-building function in both `postgres_database.cpp` and `postgres_database_extensions.cpp` line by line — everything not touched here already uses `txn.quote()` for attacker-reachable strings, which is valid escaping, just a different style from `$n` placeholders.

## Test plan
- [ ] CI build + existing test suite (`ctest`) green
- [ ] Manual smoke test: `store_positions` DELETE+INSERT round-trip against a scratch DB
- [ ] Manual smoke test: `store_backtest_executions` with >1000 executions (exercises the new chunking path)
- [ ] Manual smoke test: `update_live_results` with a valid updates map, and confirm an invalid column name (e.g. containing a space or quote) is rejected with `INVALID_ARGUMENT` instead of reaching the DB

🤖 Generated with [Claude Code](https://claude.com/claude-code)