### PR TITLE
Add Dependabot (Docker base image + Actions)

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,16 @@
+version: 2
+updates:
+  # Base image in the Dockerfile (C/C++ library deps are managed via the CI image
+  # and install scripts, which Dependabot does not track).
+  - package-ecosystem: docker
+    directory: /
+    schedule:
+      interval: weekly
+    labels: [dependencies, docker]
+
+  # Keep the Actions in the CI/CD pipeline current
+  - package-ecosystem: github-actions
+    directory: /
+    schedule:
+      interval: weekly
+    labels: [dependencies, ci]


### PR DESCRIPTION
## Why
trade-ngin already has the most mature CI of the four repos — full `ci-cd-pipeline.yml` (clang-format/tidy/cppcheck/cpplint, Debug+Release build, Valgrind, coverage + threshold, SonarCloud, GHCR image, EC2 deploy) plus branch-protection-as-code. The one missing piece is dependency automation.

## What
- **`dependabot.yml`** — weekly update PRs for the **Dockerfile base image** and the **workflow Actions**.

## Scope notes
- C/C++ library deps are handled by the CI container image + `requirements/` install scripts, which Dependabot doesn't track — so there's no pip/vcpkg ecosystem to add.
- **No CodeQL** here: SonarCloud + cppcheck + clang-tidy already provide SAST for C++.

YAML validated locally.