### PR TITLE
Fix live trading: cron ran a binary that does not exist, and had no credentials

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,16 @@
+# Anything the Linux container executes must keep LF endings regardless of the
+# platform it was checked out on.
+#
+# The Dockerfile does `COPY . .`, so a checkout made on Windows with
+# core.autocrlf=true would copy CRLF files straight into the image. A shell
+# script whose shebang ends "bash\r" fails at runtime with
+# "bad interpreter: /usr/bin/env bash^M" -- and crontab silently rejects a cron
+# file with CRLF endings. Both would reproduce the exact class of failure this
+# repo just spent 81 days not noticing.
+
+*.sh    text eol=lf
+*.cron  text eol=lf
+Dockerfile text eol=lf
+*.py    text eol=lf
+*.yml   text eol=lf
+*.yaml  text eol=lf

--- a/.github/workflows/live-trading-watchdog.yml
+++ b/.github/workflows/live-trading-watchdog.yml
@@ -1,0 +1,62 @@
+name: Live Trading Watchdog
+
+# Answers one question every weekday morning: did the trading engine actually
+# write anything?
+#
+# It exists because live trading stopped on 2026-05-05 and nothing noticed for
+# 81 days. The engine was failing nightly -- cron invoked a binary that does not
+# exist -- and logging the error inside the container where nothing surfaced it.
+#
+# This checks the OUTCOME rather than the process, so it catches every failure
+# mode at once: container down, cron dead, binary missing, credentials
+# unavailable, or the engine crashing mid-run.
+#
+# REQUIRES repo secrets: DB_HOST, DB_PORT, DB_USER, DB_PASSWORD, DB_NAME.
+# (data-ngin already has these configured and verified working against the same
+# database -- the trading schema lives there too.)
+
+on:
+  schedule:
+    # 15:00 UTC = 11:00 ET, ~1.5h after the 09:30 ET scheduled run, so a slow
+    # run is not mistaken for a missing one.
+    - cron: "0 15 * * 1-5"
+  workflow_dispatch:
+  pull_request:
+    # Keep the staleness logic itself under test on any change to it.
+    paths:
+      - "scripts/check_live_trading.py"
+      - ".github/workflows/live-trading-watchdog.yml"
+
+permissions:
+  contents: read
+  issues: write
+
+jobs:
+  watchdog:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.11"
+
+      # Runs everywhere, including PRs from forks, since it needs no database.
+      - name: Self-test the staleness logic
+        run: python scripts/check_live_trading.py --self-test
+
+      - name: Install database dependencies
+        if: github.event_name != 'pull_request'
+        run: pip install psycopg2-binary requests
+
+      - name: Check that live trading is writing
+        if: github.event_name != 'pull_request'
+        env:
+          DB_HOST: ${{ secrets.DB_HOST }}
+          DB_PORT: ${{ secrets.DB_PORT }}
+          DB_USER: ${{ secrets.DB_USER }}
+          DB_PASSWORD: ${{ secrets.DB_PASSWORD }}
+          DB_NAME: ${{ secrets.DB_NAME }}
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GITHUB_REPO: ${{ github.repository }}
+        run: python scripts/check_live_trading.py

--- a/Dockerfile
+++ b/Dockerfile
@@ -110,9 +110,18 @@ COPY --from=builder /app /app
 
 WORKDIR /app
 
-COPY live_trend.cron /etc/cron.d/live_trend
-RUN chmod 0644 /etc/cron.d/live_trend && \
-    crontab /etc/cron.d/live_trend && \
-    touch /var/log/cron.log
+COPY live_portfolio.cron /etc/cron.d/live_portfolio
+RUN chmod 0644 /etc/cron.d/live_portfolio && \
+    crontab /etc/cron.d/live_portfolio && \
+    chmod 0755 /app/scripts/run_live_portfolio.sh /app/scripts/docker-entrypoint.sh
 
-CMD ["cron", "-f"]
+# The container's only job is running cron. If the cron daemon dies, the container
+# can sit there looking alive while nothing is scheduled -- externally
+# indistinguishable from the three-month silence this change addresses.
+# Pair with `restart: unless-stopped` in the compose file on the host.
+HEALTHCHECK --interval=5m --timeout=10s --start-period=30s --retries=3 \
+    CMD pgrep -x cron > /dev/null || exit 1
+
+# The entrypoint snapshots the container environment for cron (cron does not
+# inherit it) and then execs cron in the foreground.
+ENTRYPOINT ["/app/scripts/docker-entrypoint.sh"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -99,6 +99,7 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
         libcurl4t64 \
         cron \
         gnuplot-nox \
+        procps \
         tzdata \
     && apt-get purge -y --auto-remove gnupg lsb-release \
     && rm -rf /var/lib/apt/lists/*

--- a/live_portfolio.cron
+++ b/live_portfolio.cron
@@ -1,0 +1,10 @@
+# Daily live portfolio run.
+#
+# 09:30 Mon-Fri, America/New_York (TZ is set in the image, so this is ET not UTC).
+# The script guards against weekends too, but restricting here keeps the log clean.
+#
+# Output goes to /proc/1/fd/1 -- the container's stdout -- so `docker logs
+# trade-ngin` shows every run and every failure. The previous version wrote to
+# /var/log/cron.log inside the container, where three months of daily failures
+# accumulated unseen.
+30 9 * * 1-5 /app/scripts/run_live_portfolio.sh >> /proc/1/fd/1 2>&1

--- a/live_trend.cron
+++ b/live_trend.cron
@@ -1,1 +1,0 @@
-30 9 * * * sh /app/scripts/run_live_trend.sh >> /var/log/cron.log 2>&1

--- a/scripts/check_live_trading.py
+++ b/scripts/check_live_trading.py
@@ -1,0 +1,253 @@
+"""Watchdog: has the live trading engine actually run recently?
+
+Live trading stopped on 2026-05-05 and nothing noticed for 81 days. The engine
+had been failing every night -- cron invoked a binary that does not exist -- and
+writing the error to a log file inside the container that nothing surfaced.
+
+This is the outcome-based check that would have caught it on day one: rather than
+asking "did the process start", it asks "did anything actually reach the
+database". That covers every failure mode at once -- container down, cron dead,
+binary missing, credentials unavailable, engine crashing mid-run.
+
+Read-only. Files or updates a GitHub issue when the answer is no.
+
+Environment:
+  DB_HOST / DB_PORT / DB_USER / DB_PASSWORD / DB_NAME   required
+  GITHUB_TOKEN / GITHUB_REPO                            optional; issue filing
+  MAX_BUSINESS_DAYS_SILENT                              optional; default 3
+
+Run with --self-test to exercise the staleness logic without a database.
+"""
+
+import os
+import sys
+from datetime import date, datetime, timedelta, timezone
+
+ISSUE_LABEL = "live-trading-down"
+DEFAULT_REPO = "AlgoGators/trade-ngin"
+
+# Trading runs Mon-Fri, so calendar-day thresholds produce weekend false alarms.
+# Three business days tolerates a public holiday next to a weekend while still
+# surfacing a genuine outage inside the same week.
+MAX_BUSINESS_DAYS_SILENT = int(os.environ.get("MAX_BUSINESS_DAYS_SILENT", "3"))
+
+
+def business_days_between(start: date, end: date) -> int:
+    """Weekdays strictly after `start`, up to and including `end`.
+
+    Holidays are deliberately not modelled: a market holiday makes this
+    over-count by one, which the threshold absorbs. Under-counting would be the
+    dangerous direction, and this never does that.
+    """
+    if end <= start:
+        return 0
+    days = 0
+    cursor = start + timedelta(days=1)
+    while cursor <= end:
+        if cursor.weekday() < 5:  # Mon-Fri
+            days += 1
+        cursor += timedelta(days=1)
+    return days
+
+
+def evaluate(last_run_at, last_position_at, today, threshold):
+    """Pure decision function: returns (is_stale, list_of_reasons).
+
+    Takes the two independent signals -- when the engine last recorded a run, and
+    when a position row was last physically written -- because they fail
+    differently. A run that starts and dies mid-way updates one but not the other.
+    """
+    reasons = []
+
+    if last_run_at is None:
+        reasons.append(
+            "trading.live_run_metadata is empty -- the engine has never recorded a run"
+        )
+    else:
+        gap = business_days_between(last_run_at.date(), today)
+        if gap > threshold:
+            reasons.append(
+                f"last engine run was {last_run_at:%Y-%m-%d %H:%M} "
+                f"({gap} business days ago, threshold {threshold})"
+            )
+
+    if last_position_at is None:
+        reasons.append(
+            "trading.positions is empty -- no positions have ever been written"
+        )
+    else:
+        gap = business_days_between(last_position_at.date(), today)
+        if gap > threshold:
+            reasons.append(
+                f"last position write was {last_position_at:%Y-%m-%d %H:%M} "
+                f"({gap} business days ago, threshold {threshold})"
+            )
+
+    return bool(reasons), reasons
+
+
+def _fetch(conn):
+    with conn.cursor() as cur:
+        cur.execute("SELECT max(created_at) FROM trading.live_run_metadata")
+        last_run = cur.fetchone()[0]
+        cur.execute("SELECT max(updated_at) FROM trading.positions")
+        last_pos = cur.fetchone()[0]
+    return last_run, last_pos
+
+
+def _file_issue(reasons, repo, token):
+    import requests
+
+    headers = {
+        "Authorization": f"Bearer {token}",
+        "Accept": "application/vnd.github+json",
+    }
+    title = "[live-trading-down] The trading engine has stopped writing"
+    body = (
+        "The live-trading watchdog found no recent writes to the `trading` schema.\n\n"
+        + "\n".join(f"- {r}" for r in reasons)
+        + "\n\nThe database can only show that nothing arrived, not why. Check, in order:\n"
+        "1. Is the `trade-ngin` container running on the trading host? (`docker ps`)\n"
+        "2. Is cron alive inside it? (the image has a HEALTHCHECK for this)\n"
+        "3. `docker logs trade-ngin` -- the scheduled run logs there now, timestamped\n"
+    )
+
+    query = f"repo:{repo} is:issue is:open label:{ISSUE_LABEL}"
+    resp = requests.get(
+        "https://api.github.com/search/issues",
+        params={"q": query},
+        headers=headers,
+        timeout=10,
+    )
+    resp.raise_for_status()
+    items = resp.json().get("items", [])
+
+    if items:
+        number = items[0]["number"]
+        resp = requests.post(
+            f"https://api.github.com/repos/{repo}/issues/{number}/comments",
+            json={"body": body},
+            headers=headers,
+            timeout=10,
+        )
+        resp.raise_for_status()
+        print(f"Updated existing issue #{number}")
+    else:
+        resp = requests.post(
+            f"https://api.github.com/repos/{repo}/issues",
+            json={"title": title, "body": body, "labels": [ISSUE_LABEL]},
+            headers=headers,
+            timeout=10,
+        )
+        resp.raise_for_status()
+        print(f"Filed issue #{resp.json()['number']}")
+
+
+def self_test():
+    """Exercise the staleness logic without a database.
+
+    Kept in-process rather than as a pytest suite because this is a C++ repo with
+    no Python test infrastructure; CI runs `--self-test` directly.
+    """
+    failures = []
+
+    def check(name, got, want):
+        if got != want:
+            failures.append(f"{name}: got {got!r}, wanted {want!r}")
+
+    # business_days_between
+    check(
+        "Fri->Mon is 1 business day",
+        business_days_between(date(2026, 7, 24), date(2026, 7, 27)),
+        1,
+    )
+    check(
+        "Fri->Sat is 0", business_days_between(date(2026, 7, 24), date(2026, 7, 25)), 0
+    )
+    check(
+        "Mon->Fri is 4", business_days_between(date(2026, 7, 20), date(2026, 7, 24)), 4
+    )
+    check(
+        "same day is 0", business_days_between(date(2026, 7, 24), date(2026, 7, 24)), 0
+    )
+    check(
+        "backwards is 0", business_days_between(date(2026, 7, 24), date(2026, 7, 20)), 0
+    )
+
+    monday = date(2026, 7, 27)
+    dt = lambda d: datetime(d.year, d.month, d.day, 9, 30, tzinfo=timezone.utc)
+
+    # A Friday run seen on Monday is healthy -- the weekend must not alarm.
+    stale, _ = evaluate(dt(date(2026, 7, 24)), dt(date(2026, 7, 24)), monday, 3)
+    check("friday run, monday check => healthy", stale, False)
+
+    # The real outage: last run 2026-05-05, checked 2026-07-25.
+    stale, reasons = evaluate(
+        dt(date(2026, 5, 5)), dt(date(2026, 5, 3)), date(2026, 7, 25), 3
+    )
+    check("the actual 81-day outage => stale", stale, True)
+    check("outage reports both signals", len(reasons), 2)
+
+    # Empty tables are stale, not silently healthy.
+    stale, reasons = evaluate(None, None, monday, 3)
+    check("empty tables => stale", stale, True)
+    check("empty tables report both", len(reasons), 2)
+
+    # Engine recorded a run but wrote no positions -- a partial failure.
+    stale, reasons = evaluate(dt(monday), dt(date(2026, 5, 3)), monday, 3)
+    check("run ok but positions stale => stale", stale, True)
+    check("partial failure names one signal", len(reasons), 1)
+
+    if failures:
+        print("SELF-TEST FAILED:")
+        for f in failures:
+            print(f"  {f}")
+        return 1
+    print("self-test: all checks passed")
+    return 0
+
+
+def main():
+    if "--self-test" in sys.argv:
+        return self_test()
+
+    import psycopg2
+
+    conn = psycopg2.connect(
+        host=os.environ["DB_HOST"],
+        port=os.environ.get("DB_PORT", "5432"),
+        user=os.environ["DB_USER"],
+        password=os.environ["DB_PASSWORD"],
+        dbname=os.environ["DB_NAME"],
+        connect_timeout=15,
+    )
+    try:
+        last_run, last_pos = _fetch(conn)
+    finally:
+        conn.close()
+
+    today = datetime.now(timezone.utc).date()
+    print(f"last engine run:     {last_run}")
+    print(f"last position write: {last_pos}")
+
+    stale, reasons = evaluate(last_run, last_pos, today, MAX_BUSINESS_DAYS_SILENT)
+
+    if not stale:
+        print("OK: live trading is writing within the expected window.")
+        return 0
+
+    print("STALE:")
+    for r in reasons:
+        print(f"  {r}")
+
+    token = os.environ.get("GITHUB_TOKEN")
+    if token:
+        _file_issue(reasons, os.environ.get("GITHUB_REPO", DEFAULT_REPO), token)
+    else:
+        print("GITHUB_TOKEN not set; skipping issue filing.", file=sys.stderr)
+
+    return 1
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/dev_build_run.sh
+++ b/scripts/dev_build_run.sh
@@ -2,23 +2,23 @@
 set -euo pipefail
 
 # Usage:
-#   scripts/dev_build_run.sh bt_trend [Release|Debug]
-#   scripts/dev_build_run.sh live_trend [Release|Debug]
+#   scripts/dev_build_run.sh bt_portfolio [Release|Debug]
+#   scripts/dev_build_run.sh live_portfolio [Release|Debug]
 #
 # Examples:
-#   scripts/dev_build_run.sh bt_trend Release
-#   scripts/dev_build_run.sh live_trend Debug
+#   scripts/dev_build_run.sh bt_portfolio Release
+#   scripts/dev_build_run.sh live_portfolio Debug
 
 TARGET_NAME="${1:-}"
 CONFIG="${2:-Release}"
 
 if [[ -z "${TARGET_NAME}" ]]; then
-  echo "Error: missing target. Use: bt_trend or live_trend" >&2
+  echo "Error: missing target. Use: bt_portfolio, live_portfolio or live_portfolio_conservative" >&2
   exit 1
 fi
 
-if [[ "${TARGET_NAME}" != "bt_trend" && "${TARGET_NAME}" != "live_trend" ]]; then
-  echo "Error: invalid target '${TARGET_NAME}'. Use: bt_trend or live_trend" >&2
+if [[ "${TARGET_NAME}" != "bt_portfolio" && "${TARGET_NAME}" != "live_portfolio" && "${TARGET_NAME}" != "live_portfolio_conservative" ]]; then
+  echo "Error: invalid target '${TARGET_NAME}'. Use: bt_portfolio, live_portfolio or live_portfolio_conservative" >&2
   exit 1
 fi
 

--- a/scripts/docker-entrypoint.sh
+++ b/scripts/docker-entrypoint.sh
@@ -1,0 +1,47 @@
+#!/usr/bin/env bash
+# Container entrypoint: snapshot the environment for cron, then run cron.
+#
+# WHY THIS EXISTS
+# ---------------
+# cron does not inherit the environment of the process that starts it. It builds
+# a fresh, minimal environment for every job (essentially HOME, LOGNAME, PATH,
+# SHELL). So anything passed in via `docker run -e` / compose `environment:` --
+# including TRADING_CONFIG_PATH and TRADING_ENCRYPTION_KEY, which is how
+# CredentialStore locates and decrypts the DB credentials -- is invisible to the
+# scheduled job, even though it is plainly visible to `docker exec`.
+#
+# That asymmetry is exactly what makes this failure mode so easy to miss: run the
+# job by hand and it works; let cron run it and it cannot reach the database.
+#
+# So: capture the relevant variables at container start into a file the cron
+# script sources. Written with printf %q so values containing spaces, quotes or
+# newlines survive the round trip.
+
+set -euo pipefail
+
+CRON_ENV=/app/.cron_env
+
+: > "$CRON_ENV"
+chmod 600 "$CRON_ENV"
+
+# Only export what the job legitimately needs -- not the whole environment.
+while IFS='=' read -r -d '' name value; do
+    case "$name" in
+        TRADING_* | DB_* | PG* | TZ | LD_LIBRARY_PATH)
+            printf 'export %s=%q\n' "$name" "$value" >> "$CRON_ENV"
+            ;;
+    esac
+done < <(env -0)
+
+echo "$(date -Is) [entrypoint] captured $(wc -l < "$CRON_ENV") env var(s) for cron"
+
+# Warn loudly if the credentials the job needs are absent, rather than letting
+# the first scheduled run fail silently at 09:30.
+if ! grep -q '^export TRADING_ENCRYPTION_KEY=' "$CRON_ENV" \
+   && [ ! -f "${TRADING_CONFIG_PATH:-/app/config_template}.key" ]; then
+    echo "$(date -Is) [entrypoint] WARNING: neither TRADING_ENCRYPTION_KEY nor a" \
+         "key file is present -- the scheduled run will not be able to decrypt" \
+         "database credentials." >&2
+fi
+
+exec cron -f

--- a/scripts/run_live_portfolio.sh
+++ b/scripts/run_live_portfolio.sh
@@ -1,0 +1,80 @@
+#!/usr/bin/env bash
+# Daily live-portfolio run, invoked by cron inside the container.
+#
+# Replaces scripts/run_live_trend.sh, which invoked
+# /app/build/bin/Release/live_trend -- a binary this project does not build. The
+# CMake targets are `live_portfolio` and `live_portfolio_conservative`; there has
+# never been a `live_trend` target. Every scheduled run therefore failed
+# instantly with "not found", into a log file inside the container that nothing
+# surfaced.
+#
+# Everything below is written so that a failure is loud rather than silent:
+# output goes to container stdout (visible in `docker logs`), every line is
+# timestamped, and the exit code is both logged and propagated.
+
+set -uo pipefail  # deliberately NOT -e: we capture the binary's exit code ourselves
+
+# Which portfolio to run. Defaults to the conservative binary because that is
+# what the live database shows was actually being run -- CONSERVATIVE_PORTFOLIO
+# has data through 2026-05-03, while BASE_PORTFOLIO stops in December 2025.
+# Override with -e LIVE_BINARY=... to run a different one.
+BINARY="${LIVE_BINARY:-/app/build/bin/Release/live_portfolio_conservative}"
+
+CRON_ENV="${CRON_ENV:-/app/.cron_env}"
+LOCK_DIR="${LOCK_DIR:-/tmp/live_portfolio.lock}"
+
+log() { printf '%s [live-portfolio] %s\n' "$(date -Is)" "$*"; }
+
+# --- environment -------------------------------------------------------------
+# cron builds a fresh minimal environment, so the credentials passed into the
+# container are not visible here. docker-entrypoint.sh snapshots them at startup.
+if [ -f "$CRON_ENV" ]; then
+    # shellcheck disable=SC1090
+    . "$CRON_ENV"
+    log "sourced environment from $CRON_ENV"
+else
+    log "WARNING: $CRON_ENV missing -- database credentials are probably unavailable."
+    log "         (is the container running scripts/docker-entrypoint.sh?)"
+fi
+
+# --- weekday guard -----------------------------------------------------------
+# There is no market data for Saturday or Sunday, so a weekend run can only fail
+# or no-op. The cron schedule also restricts to Mon-Fri; this is the second belt.
+DOW="$(date +%u)"  # 1=Monday .. 7=Sunday
+if [ "$DOW" -ge 6 ]; then
+    log "skipping: weekend (day-of-week $DOW)"
+    exit 0
+fi
+
+# --- single instance ---------------------------------------------------------
+# mkdir is atomic, so this is a safe lock without extra tooling. A catch-up run
+# started by hand should not collide with the scheduled one.
+if ! mkdir "$LOCK_DIR" 2>/dev/null; then
+    log "skipping: another run already holds $LOCK_DIR"
+    exit 0
+fi
+trap 'rmdir "$LOCK_DIR" 2>/dev/null || true' EXIT
+
+# --- preflight ---------------------------------------------------------------
+if [ ! -x "$BINARY" ]; then
+    log "FATAL: binary not found or not executable: $BINARY"
+    log "       built targets are live_portfolio and live_portfolio_conservative"
+    exit 127
+fi
+
+# --- run ---------------------------------------------------------------------
+DATE="$(date +%Y-%m-%d)"
+log "starting $BINARY for $DATE"
+
+"$BINARY" "$DATE" --send-email
+rc=$?
+
+if [ "$rc" -eq 0 ]; then
+    log "completed successfully for $DATE"
+else
+    log "FAILED for $DATE (exit $rc)"
+fi
+
+# Propagate the real exit code so cron -- and anything reading container logs --
+# sees the failure.
+exit "$rc"

--- a/scripts/run_live_portfolio.sh
+++ b/scripts/run_live_portfolio.sh
@@ -62,6 +62,14 @@ if [ ! -x "$BINARY" ]; then
     exit 127
 fi
 
+# --- working directory -------------------------------------------------------
+# cron starts jobs from $HOME, but both live binaries resolve their config
+# ("./config", see live_portfolio*.cpp ConfigLoader::load) and log directory
+# relative to the current directory. Without this cd every scheduled run dies
+# on config-not-found -- the same class of silent failure this script exists
+# to eliminate.
+cd /app || { log "FATAL: cannot cd /app"; exit 1; }
+
 # --- run ---------------------------------------------------------------------
 DATE="$(date +%Y-%m-%d)"
 log "starting $BINARY for $DATE"

--- a/scripts/run_live_trend.sh
+++ b/scripts/run_live_trend.sh
@@ -1,4 +1,0 @@
-DATE=$(date +%Y-%m-%d)
-echo "$DATE"
-cd /app
-/app/build/bin/Release/live_trend "$DATE" --send-email


### PR DESCRIPTION
Fixes #52.

Live trading wrote nothing between **2026-05-05 and 2026-07-25 — 81 days** — and nothing detected it. There are **two independent root causes**, both provable from this repo alone.

---

## Root cause 1: the scheduled command does not exist

`live_trend.cron` ran `/app/build/bin/Release/live_trend`.

**That binary is not built by this project and never has been.** The CMake targets are `live_portfolio` and `live_portfolio_conservative` — grepping every `CMakeLists.txt` finds no `live_trend` target, alias, or install rule.

So every scheduled run has failed instantly with "not found". `scripts/dev_build_run.sh` carried the same stale names (`bt_trend`, `live_trend`), which points to a rename that missed its callers.

## Root cause 2: cron cannot see the container's environment

`CredentialStore` reads `TRADING_CONFIG_PATH` and `TRADING_ENCRYPTION_KEY` from the environment to locate and decrypt the DB credentials.

**cron does not inherit the environment of the process that starts it** — it builds a fresh minimal one per job. So credentials passed via compose `environment:` are visible to `docker exec` but invisible to the scheduled job.

That asymmetry explains the observed data precisely. `live_run_metadata` shows almost no genuine daily runs, but large manual catch-up batches — **136 runs in one sitting on 2026-05-05, covering five months**. Running it by hand worked. Letting cron run it could not.

## Why nobody noticed

Output went to `/var/log/cron.log` **inside the container**. Three months of nightly failures accumulated somewhere nothing reads.

---

## What changed

| File | Change |
|---|---|
| `live_portfolio.cron` | Replaces `live_trend.cron`. Correct script, Mon–Fri only, logs to `/proc/1/fd/1` so runs show in `docker logs`. |
| `scripts/run_live_portfolio.sh` | Replaces `run_live_trend.sh`. Sources the captured env, skips weekends, takes an atomic lock, refuses to start if the binary is missing (exit 127, naming the real targets), timestamps every line, propagates the engine's exit code. |
| `scripts/docker-entrypoint.sh` | **New.** Snapshots `TRADING_*`/`DB_*`/`PG*`/`TZ` to `/app/.cron_env` via `printf %q`, then execs cron. Warns at startup if no key is present rather than letting 09:30 discover it. |
| `Dockerfile` | `ENTRYPOINT` + `HEALTHCHECK` on the cron daemon, so a dead scheduler is visible instead of looking like a healthy container. |
| `.gitattributes` | **New.** Forces LF for anything the container executes — `COPY . .` from a Windows checkout would otherwise bake in a broken shebang. |
| `dev_build_run.sh` | Corrected to targets that exist. |

Defaults to `live_portfolio_conservative`, matching what the database shows was actually being run (CONSERVATIVE has data to 2026-05-03; BASE stops December 2025). Override with `LIVE_BINARY`.

## The watchdog

`scripts/check_live_trading.py` + `.github/workflows/live-trading-watchdog.yml` ask whether anything **actually reached the database**, not whether a process started — so one check covers container down, cron dead, binary missing, credentials absent, or a mid-run crash.

Business-day aware: a Friday run checked on Monday is healthy, so weekends don't cry wolf. Files or updates a GitHub issue when stale.

⚠️ **Requires repo secrets** `DB_HOST`/`DB_PORT`/`DB_USER`/`DB_PASSWORD`/`DB_NAME`. data-ngin already has these configured and verified against the same database.

## Testing — verified in containers, not asserted

- **Reproduced root cause 2**: under a cron-like minimal environment `TRADING_ENCRYPTION_KEY` is unset; after the entrypoint runs and the script sources `/app/.cron_env` it is restored — including a value containing spaces and quotes.
- Only intended variables are captured; an unrelated variable is correctly excluded.
- **Runner**: missing binary → 127 · Saturday skips without invoking the binary · Monday invokes it · exit 42 propagates as 42 · a held lock skips cleanly · missing `.cron_env` warns loudly.
- **Watchdog**: self-test passes, and **mutation testing confirms it fails** when the business-day logic or the staleness comparison is deliberately broken.
- Fresh Linux clone verified to get LF endings and a working shebang.
- `shellcheck` clean on both new scripts; both workflow YAMLs parse.

## What I could NOT verify, and cannot from here

**Whether the production container is currently running at all.** This PR changes what happens *when* it runs — it cannot start it.

**After merge, someone must:**
1. Add the DB secrets to this repo (for the watchdog)
2. Redeploy the container
3. Confirm the first scheduled run appears in `docker logs trade-ngin`
4. Consider `restart: unless-stopped` in the host compose file (it lives on the host, not in this repo — worth version-controlling it separately)