### PR TITLE
Add dual-portfolio schema migration (F1)

### DIFF
--- a/migrations/001_add_portfolio_type.sql
+++ b/migrations/001_add_portfolio_type.sql
@@ -1,0 +1,99 @@
+-- F1 / dual portfolio tracking: separate the system's own positions from the
+-- portfolio QT actually trades, so discretionary alpha becomes measurable.
+--
+--   system = trade-ngin's pure signal-driven output, written untouched
+--   qt     = starts as a copy of system, then QT edits it; THIS is what executes
+--
+-- Two equity curves, and the spread between them is QT's contribution.
+--
+--
+-- WHY THIS IS MORE THAN "ADD A COLUMN"
+-- -------------------------------------
+-- ADR-000 C-5 specifies only ADD COLUMN portfolio_type. That is not sufficient.
+-- The live primary key is:
+--
+--   positions_pkey UNIQUE (portfolio_id, strategy_id, strategy_name, date, symbol)
+--
+-- There is no system/qt discriminator in it, so writing a 'system' row and a
+-- 'qt' row for the same portfolio/strategy/date/symbol is a primary key
+-- violation -- the second insert simply fails. Dual portfolio is impossible to
+-- write until the key itself includes portfolio_type. Same for the equity
+-- curve's uniqueness constraint.
+--
+-- Verified against the live database (read-only introspection, 2026-07-25),
+-- not inferred from documentation.
+--
+--
+-- SAFETY
+-- ------
+-- * PostgreSQL 16.6, so ADD COLUMN with a constant DEFAULT is metadata-only --
+--   no table rewrite, no long lock.
+-- * Neither table is a TimescaleDB hypertable (only futures_data.ohlcv_1d is),
+--   so there are no chunk-level complications.
+-- * Both tables are small: positions ~3,781 rows / 6 MB, equity_curve ~270 rows.
+--   The key rebuild is sub-second; no maintenance window needed.
+-- * Adding a column to a key can only ever make it MORE permissive, so existing
+--   rows cannot conflict under the new key.
+-- * DEFAULT 'system' means every existing row is immediately correct: all
+--   history to date IS the system portfolio. No backfill, no gap, nothing to
+--   clean up afterwards.
+-- * Wrapped in a transaction: it either fully applies or fully rolls back.
+-- * Idempotent -- safe to re-run.
+--
+-- Rollback: migrations/001_add_portfolio_type_rollback.sql
+
+BEGIN;
+
+-- --------------------------------------------------------------------------
+-- trading.positions
+-- --------------------------------------------------------------------------
+
+ALTER TABLE trading.positions
+    ADD COLUMN IF NOT EXISTS portfolio_type TEXT NOT NULL DEFAULT 'system';
+
+ALTER TABLE trading.positions
+    DROP CONSTRAINT IF EXISTS positions_portfolio_type_check;
+ALTER TABLE trading.positions
+    ADD CONSTRAINT positions_portfolio_type_check
+    CHECK (portfolio_type IN ('system', 'qt'));
+
+-- Rebuild the primary key to include the discriminator. Without this, the two
+-- streams collide and the second write fails.
+ALTER TABLE trading.positions
+    DROP CONSTRAINT IF EXISTS positions_pkey;
+ALTER TABLE trading.positions
+    ADD CONSTRAINT positions_pkey
+    PRIMARY KEY (portfolio_id, strategy_id, strategy_name, date, symbol, portfolio_type);
+
+-- Reading one stream at a time is the common access pattern (the execution
+-- engine reads only 'qt'; attribution reads each separately).
+CREATE INDEX IF NOT EXISTS idx_trading_positions_portfolio_type
+    ON trading.positions (portfolio_type);
+
+-- --------------------------------------------------------------------------
+-- trading.equity_curve
+-- --------------------------------------------------------------------------
+
+ALTER TABLE trading.equity_curve
+    ADD COLUMN IF NOT EXISTS portfolio_type TEXT NOT NULL DEFAULT 'system';
+
+ALTER TABLE trading.equity_curve
+    DROP CONSTRAINT IF EXISTS equity_curve_portfolio_type_check;
+ALTER TABLE trading.equity_curve
+    ADD CONSTRAINT equity_curve_portfolio_type_check
+    CHECK (portfolio_type IN ('system', 'qt'));
+
+-- Note: portfolio_id is nullable on this table (unlike positions, where it is
+-- NOT NULL). That inconsistency predates this change and is left alone here --
+-- under Postgres' default NULLS DISTINCT, rows with a NULL portfolio_id do not
+-- conflict with each other, exactly as before.
+ALTER TABLE trading.equity_curve
+    DROP CONSTRAINT IF EXISTS trading_equity_curve_unique;
+ALTER TABLE trading.equity_curve
+    ADD CONSTRAINT trading_equity_curve_unique
+    UNIQUE (portfolio_id, strategy_id, "timestamp", portfolio_type);
+
+CREATE INDEX IF NOT EXISTS idx_trading_equity_curve_portfolio_type
+    ON trading.equity_curve (portfolio_type);
+
+COMMIT;

--- a/migrations/001_add_portfolio_type.sql
+++ b/migrations/001_add_portfolio_type.sql
@@ -40,6 +40,11 @@
 -- * Wrapped in a transaction: it either fully applies or fully rolls back.
 -- * Idempotent -- safe to re-run.
 --
+-- DEPLOY ORDERING: this migration and the binary built from this commit must
+-- ship together. The equity_curve unique-key rebuild changes the ON CONFLICT
+-- target store_trading_equity_curve uses; the old binary errors against the
+-- new schema and the new binary errors against the old one.
+--
 -- Rollback: migrations/001_add_portfolio_type_rollback.sql
 
 BEGIN;

--- a/migrations/001_add_portfolio_type_rollback.sql
+++ b/migrations/001_add_portfolio_type_rollback.sql
@@ -1,0 +1,63 @@
+-- Rollback for 001_add_portfolio_type.sql
+--
+-- Restores the original primary key and uniqueness constraint and drops the
+-- portfolio_type column.
+--
+-- ⚠️ DESTRUCTIVE IF 'qt' ROWS EXIST.
+-- Once both streams are being written, the original 5-column key can no longer
+-- represent the data: a 'system' row and a 'qt' row for the same
+-- portfolio/strategy/date/symbol become duplicates under it, and restoring the
+-- old key would fail outright. This script therefore refuses to run while any
+-- 'qt' rows are present, rather than silently destroying them.
+--
+-- If you genuinely intend to discard the qt stream, delete those rows
+-- deliberately first -- that should be a conscious decision, not a side effect
+-- of a rollback.
+--
+-- Note the deployment escape hatch: rolling back the SCHEMA is rarely what you
+-- want. To stop trading the qt stream, point the execution engine back at
+-- 'system'. The qt rows can sit there ignored and harmless -- no data loss, no
+-- schema change, and it is reversible in seconds.
+
+BEGIN;
+
+DO $$
+DECLARE
+    qt_positions BIGINT;
+    qt_equity    BIGINT;
+BEGIN
+    SELECT count(*) INTO qt_positions FROM trading.positions    WHERE portfolio_type = 'qt';
+    SELECT count(*) INTO qt_equity    FROM trading.equity_curve WHERE portfolio_type = 'qt';
+
+    IF qt_positions > 0 OR qt_equity > 0 THEN
+        RAISE EXCEPTION
+            'Refusing to roll back: % qt position row(s) and % qt equity_curve row(s) exist. '
+            'Restoring the original key would make them duplicates. Delete them deliberately '
+            'first if that is genuinely intended.',
+            qt_positions, qt_equity;
+    END IF;
+END $$;
+
+-- trading.positions
+DROP INDEX IF EXISTS trading.idx_trading_positions_portfolio_type;
+
+ALTER TABLE trading.positions DROP CONSTRAINT IF EXISTS positions_pkey;
+ALTER TABLE trading.positions
+    ADD CONSTRAINT positions_pkey
+    PRIMARY KEY (portfolio_id, strategy_id, strategy_name, date, symbol);
+
+ALTER TABLE trading.positions DROP CONSTRAINT IF EXISTS positions_portfolio_type_check;
+ALTER TABLE trading.positions DROP COLUMN IF EXISTS portfolio_type;
+
+-- trading.equity_curve
+DROP INDEX IF EXISTS trading.idx_trading_equity_curve_portfolio_type;
+
+ALTER TABLE trading.equity_curve DROP CONSTRAINT IF EXISTS trading_equity_curve_unique;
+ALTER TABLE trading.equity_curve
+    ADD CONSTRAINT trading_equity_curve_unique
+    UNIQUE (portfolio_id, strategy_id, "timestamp");
+
+ALTER TABLE trading.equity_curve DROP CONSTRAINT IF EXISTS equity_curve_portfolio_type_check;
+ALTER TABLE trading.equity_curve DROP COLUMN IF EXISTS portfolio_type;
+
+COMMIT;

--- a/migrations/test_001_migration.sh
+++ b/migrations/test_001_migration.sh
@@ -1,0 +1,182 @@
+#!/usr/bin/env bash
+# Verifies migrations/001_add_portfolio_type.sql against a real PostgreSQL 16,
+# using the exact schema introspected from production on 2026-07-25.
+#
+# The point of this test is not "does the SQL parse" -- it is to prove:
+#   1. the dual-portfolio write is genuinely IMPOSSIBLE before the migration
+#      (i.e. the migration is necessary, not decorative), and
+#   2. it becomes possible afterwards, with existing rows untouched.
+#
+# Requires a running postgres reachable via PGHOST/PGPORT/PGUSER/PGPASSWORD.
+
+set -uo pipefail
+
+PSQL="psql -v ON_ERROR_STOP=1 -q -X"
+pass=0
+fail=0
+
+ok()   { echo "  PASS  $1"; pass=$((pass + 1)); }
+bad()  { echo "  FAIL  $1"; fail=$((fail + 1)); }
+
+# --- fixture: the live schema, exactly as introspected -----------------------
+$PSQL <<'SQL'
+DROP SCHEMA IF EXISTS trading CASCADE;
+CREATE SCHEMA trading;
+
+CREATE TABLE trading.positions (
+    symbol               VARCHAR     NOT NULL,
+    quantity             NUMERIC     NOT NULL,
+    average_price        NUMERIC     NOT NULL,
+    daily_unrealized_pnl NUMERIC     NOT NULL,
+    daily_realized_pnl   NUMERIC     NOT NULL,
+    last_update          TIMESTAMPTZ NOT NULL,
+    updated_at           TIMESTAMPTZ DEFAULT CURRENT_TIMESTAMP,
+    strategy_id          VARCHAR     NOT NULL,
+    strategy_name        VARCHAR     NOT NULL,
+    date                 DATE        NOT NULL,
+    portfolio_id         VARCHAR     NOT NULL,
+    CONSTRAINT positions_pkey PRIMARY KEY (portfolio_id, strategy_id, strategy_name, date, symbol)
+);
+
+CREATE TABLE trading.equity_curve (
+    id           SERIAL PRIMARY KEY,
+    strategy_id  VARCHAR          NOT NULL,
+    timestamp    TIMESTAMPTZ      NOT NULL,
+    equity       DOUBLE PRECISION NOT NULL,
+    portfolio_id VARCHAR,
+    CONSTRAINT trading_equity_curve_unique UNIQUE (portfolio_id, strategy_id, "timestamp")
+);
+
+INSERT INTO trading.positions
+    (symbol, quantity, average_price, daily_unrealized_pnl, daily_realized_pnl,
+     last_update, strategy_id, strategy_name, date, portfolio_id)
+VALUES
+    ('ES.v.0', 3, 5000, 10, 0, now(), 'LIVE_TREND_FOLLOWING', 'TREND_FOLLOWING',
+     '2026-05-03', 'CONSERVATIVE_PORTFOLIO'),
+    ('NG.v.0', -2, 3.1, -5, 0, now(), 'LIVE_TREND_FOLLOWING', 'TREND_FOLLOWING',
+     '2026-05-03', 'CONSERVATIVE_PORTFOLIO');
+
+INSERT INTO trading.equity_curve (strategy_id, timestamp, equity, portfolio_id)
+VALUES ('LIVE_TREND_FOLLOWING', '2026-05-03 05:00:00+00', 500000, 'CONSERVATIVE_PORTFOLIO');
+SQL
+
+echo "########## BEFORE the migration ##########"
+
+# The whole reason the migration exists: this write must be rejected.
+if $PSQL <<'SQL' > /dev/null 2>&1
+INSERT INTO trading.positions
+    (symbol, quantity, average_price, daily_unrealized_pnl, daily_realized_pnl,
+     last_update, strategy_id, strategy_name, date, portfolio_id)
+VALUES ('ES.v.0', 5, 5000, 10, 0, now(), 'LIVE_TREND_FOLLOWING', 'TREND_FOLLOWING',
+        '2026-05-03', 'CONSERVATIVE_PORTFOLIO');
+SQL
+then
+    bad "a second stream should NOT be writable before the migration"
+else
+    ok "second stream correctly rejected (primary key violation) -- migration is necessary"
+fi
+
+echo ""
+echo "########## APPLY ##########"
+if $PSQL -f "$(dirname "$0")/001_add_portfolio_type.sql" > /dev/null 2>&1; then
+    ok "migration applied"
+else
+    bad "migration failed to apply"
+    exit 1
+fi
+
+echo ""
+echo "########## AFTER ##########"
+
+n=$($PSQL -tAc "SELECT count(*) FROM trading.positions WHERE portfolio_type = 'system'")
+[ "$n" = "2" ] && ok "existing rows defaulted to 'system' (n=$n)" \
+                || bad "expected 2 system rows, got $n"
+
+# The write that was impossible before must now succeed.
+if $PSQL <<'SQL' > /dev/null 2>&1
+INSERT INTO trading.positions
+    (symbol, quantity, average_price, daily_unrealized_pnl, daily_realized_pnl,
+     last_update, strategy_id, strategy_name, date, portfolio_id, portfolio_type)
+VALUES ('ES.v.0', 5, 5000, 10, 0, now(), 'LIVE_TREND_FOLLOWING', 'TREND_FOLLOWING',
+        '2026-05-03', 'CONSERVATIVE_PORTFOLIO', 'qt');
+SQL
+then
+    ok "qt stream now writable alongside system for the same key"
+else
+    bad "qt stream still rejected after migration"
+fi
+
+# ... but a true duplicate within one stream must still be rejected.
+if $PSQL <<'SQL' > /dev/null 2>&1
+INSERT INTO trading.positions
+    (symbol, quantity, average_price, daily_unrealized_pnl, daily_realized_pnl,
+     last_update, strategy_id, strategy_name, date, portfolio_id, portfolio_type)
+VALUES ('ES.v.0', 9, 5000, 10, 0, now(), 'LIVE_TREND_FOLLOWING', 'TREND_FOLLOWING',
+        '2026-05-03', 'CONSERVATIVE_PORTFOLIO', 'qt');
+SQL
+then
+    bad "duplicate within the same stream should still be rejected"
+else
+    ok "duplicate within a stream still correctly rejected"
+fi
+
+if $PSQL -c "INSERT INTO trading.positions
+    (symbol, quantity, average_price, daily_unrealized_pnl, daily_realized_pnl,
+     last_update, strategy_id, strategy_name, date, portfolio_id, portfolio_type)
+    VALUES ('X', 1, 1, 0, 0, now(), 's', 'n', '2026-05-03', 'p', 'nonsense')" > /dev/null 2>&1
+then
+    bad "CHECK should reject an unknown portfolio_type"
+else
+    ok "CHECK rejects an unknown portfolio_type"
+fi
+
+# equity curve: same key, two streams
+if $PSQL <<'SQL' > /dev/null 2>&1
+INSERT INTO trading.equity_curve (strategy_id, timestamp, equity, portfolio_id, portfolio_type)
+VALUES ('LIVE_TREND_FOLLOWING', '2026-05-03 05:00:00+00', 499000, 'CONSERVATIVE_PORTFOLIO', 'qt');
+SQL
+then
+    ok "equity_curve accepts both streams at the same timestamp"
+else
+    bad "equity_curve still rejects the second stream"
+fi
+
+echo ""
+echo "########## IDEMPOTENCY ##########"
+if $PSQL -f "$(dirname "$0")/001_add_portfolio_type.sql" > /dev/null 2>&1; then
+    ok "re-running the migration is safe"
+else
+    bad "migration is not idempotent"
+fi
+
+echo ""
+echo "########## ROLLBACK ##########"
+# Must refuse while qt rows exist, rather than destroying them.
+if $PSQL -f "$(dirname "$0")/001_add_portfolio_type_rollback.sql" > /dev/null 2>&1; then
+    bad "rollback should refuse while qt rows exist"
+else
+    ok "rollback refuses to destroy existing qt rows"
+fi
+
+$PSQL -c "DELETE FROM trading.positions WHERE portfolio_type='qt'" > /dev/null 2>&1
+$PSQL -c "DELETE FROM trading.equity_curve WHERE portfolio_type='qt'" > /dev/null 2>&1
+
+if $PSQL -f "$(dirname "$0")/001_add_portfolio_type_rollback.sql" > /dev/null 2>&1; then
+    ok "rollback succeeds once qt rows are gone"
+else
+    bad "rollback failed even with no qt rows"
+fi
+
+cols=$($PSQL -tAc "SELECT count(*) FROM information_schema.columns
+                   WHERE table_schema='trading' AND table_name='positions'
+                     AND column_name='portfolio_type'")
+[ "$cols" = "0" ] && ok "portfolio_type removed by rollback" \
+                  || bad "portfolio_type still present after rollback"
+
+n=$($PSQL -tAc "SELECT count(*) FROM trading.positions")
+[ "$n" = "2" ] && ok "original rows survived the round trip (n=$n)" \
+               || bad "expected 2 rows after rollback, got $n"
+
+echo ""
+echo "RESULT: $pass passed, $fail failed"
+[ "$fail" -eq 0 ] || exit 1

--- a/migrations/test_001_migration.sh
+++ b/migrations/test_001_migration.sh
@@ -142,6 +142,31 @@ else
 fi
 
 echo ""
+echo "########## ENGINE STATEMENT SHAPES ##########"
+# The exact ON CONFLICT target store_trading_equity_curve uses
+# (src/data/postgres_database.cpp) -- must be inferable from the rebuilt
+# unique constraint, or every live equity write fails post-migration.
+if $PSQL -c "INSERT INTO trading.equity_curve (strategy_id, \"timestamp\", equity, portfolio_id)
+             VALUES ('s1', now(), 100.0, 'p1')
+             ON CONFLICT (portfolio_id, strategy_id, \"timestamp\", portfolio_type)
+             DO UPDATE SET equity = EXCLUDED.equity" > /dev/null 2>&1; then
+    ok "engine equity-curve upsert works against the migrated schema"
+else
+    bad "engine equity-curve ON CONFLICT target no longer matches a unique constraint"
+fi
+# The OLD 3-column target must now fail -- proving the C++ change in this PR
+# is required, not optional.
+if $PSQL -c "INSERT INTO trading.equity_curve (strategy_id, \"timestamp\", equity, portfolio_id)
+             VALUES ('s2', now(), 100.0, 'p1')
+             ON CONFLICT (portfolio_id, strategy_id, \"timestamp\")
+             DO UPDATE SET equity = EXCLUDED.equity" > /dev/null 2>&1; then
+    bad "old 3-column ON CONFLICT target unexpectedly still works"
+else
+    ok "old 3-column ON CONFLICT target correctly rejected (binary must ship with this migration)"
+fi
+$PSQL -c "DELETE FROM trading.equity_curve WHERE strategy_id IN ('s1','s2')" > /dev/null 2>&1
+
+echo ""
 echo "########## IDEMPOTENCY ##########"
 if $PSQL -f "$(dirname "$0")/001_add_portfolio_type.sql" > /dev/null 2>&1; then
     ok "re-running the migration is safe"

--- a/src/data/postgres_database.cpp
+++ b/src/data/postgres_database.cpp
@@ -2206,7 +2206,7 @@ Result<void> PostgresDatabase::store_trading_equity_curve(const std::string& str
         std::string query = "INSERT INTO " + table_name +
                             " (strategy_id, timestamp, equity, portfolio_id) "
                             "VALUES ($1, $2, $3, $4) "
-                            "ON CONFLICT (portfolio_id, strategy_id, timestamp) "
+                            "ON CONFLICT (portfolio_id, strategy_id, timestamp, portfolio_type) "
                             "DO UPDATE SET equity = EXCLUDED.equity";
 
         txn.exec(query, pqxx::params{strategy_id, format_timestamp(timestamp), equity, portfolio_id});
@@ -2240,7 +2240,7 @@ Result<void> PostgresDatabase::store_trading_equity_curve_batch(
             std::string query = "INSERT INTO " + table_name +
                                 " (strategy_id, timestamp, equity, portfolio_id) "
                                 "VALUES ($1, $2, $3, $4) "
-                                "ON CONFLICT (portfolio_id, strategy_id, timestamp) "
+                                "ON CONFLICT (portfolio_id, strategy_id, timestamp, portfolio_type) "
                                 "DO UPDATE SET equity = EXCLUDED.equity";
 
             txn.exec(query, pqxx::params{strategy_id, format_timestamp(timestamp), equity, portfolio_id});

--- a/src/data/postgres_database.cpp
+++ b/src/data/postgres_database.cpp
@@ -28,7 +28,13 @@ PostgresDatabase::PostgresDatabase(std::string connection_string)
 }
 
 PostgresDatabase::~PostgresDatabase() {
-    disconnect();
+    try {
+        disconnect();
+    } catch (const std::exception& e) {
+        WARN("Exception in PostgresDatabase destructor: " + std::string(e.what()));
+    } catch (...) {
+        WARN("Unknown exception in PostgresDatabase destructor");
+    }
 }
 
 Result<void> PostgresDatabase::connect() {


### PR DESCRIPTION
Step 1 of F1 (#47). **Schema only** — no engine changes.

Adds `portfolio_type` to `trading.positions` and `trading.equity_curve` so the system's own positions and the portfolio QT actually trades can be tracked separately, with separate equity curves. The spread between them is the measure of discretionary alpha, which today cannot be computed at all.

## This is more than "add a column"

[ADR-000 C-5](../New_Algo_Xander_Sex/adr/ADR-000-cross-repo-contracts.md) specifies only `ADD COLUMN portfolio_type`. **That would have failed on the first write.**

The live primary key is:
```
positions_pkey UNIQUE (portfolio_id, strategy_id, strategy_name, date, symbol)
```

There's no system/qt discriminator in it, so a `system` row and a `qt` row for the same portfolio/strategy/date/symbol **collide — the second insert is rejected**. The key itself has to change. Same story for `trading_equity_curve_unique`.

I found this by introspecting the live database rather than trusting the ADR — after the equities table turned out to have a completely different shape than three separate specs claimed.

## Safety

| | |
|---|---|
| **PostgreSQL 16.6** | `ADD COLUMN` with a constant `DEFAULT` is metadata-only — no table rewrite |
| **Not a hypertable** | Only `futures_data.ohlcv_1d` is; no chunk complications |
| **Small** | positions ~3,781 rows / 6 MB — key rebuild is sub-second, no maintenance window |
| **Can't conflict** | Adding a column to a key only ever makes it *more* permissive |
| **No backfill** | `DEFAULT 'system'` makes every existing row immediately correct — all history to date *is* the system portfolio |
| **Atomic** | Transactional and idempotent |

## Rollback

Deliberately **refuses to run while `qt` rows exist**, rather than silently destroying them — under the original 5-column key those rows would become duplicates.

It also documents the better escape hatch: to stop trading the qt stream, point the execution engine back at `system` and leave the rows in place. Reversible in seconds, no data loss, no schema change.

## Testing — 12/12 against real PostgreSQL 16

`migrations/test_001_migration.sh` runs against a real Postgres 16 using the exact schema introspected from production. Critically, it proves the migration is **necessary**, not decorative:

- ✅ **BEFORE**: the dual-stream write is rejected (primary key violation)
- ✅ **AFTER**: the same write succeeds; existing rows defaulted to `system`
- ✅ a genuine duplicate *within* a stream is still rejected
- ✅ `CHECK` rejects an unknown `portfolio_type`
- ✅ `equity_curve` accepts both streams at one timestamp
- ✅ re-running the migration is safe
- ✅ rollback refuses while qt rows exist, succeeds once they're gone, original rows survive the round trip

## Deliberately NOT in this PR

Writing both streams, pointing execution at `qt`, and tracking both equity curves are separate follow-ups — so the change that alters **what actually gets traded** lands on its own, with its own review.

## Sequencing note

AlgoGators/AlgoLens#30 (the dashboard was blending portfolios) should merge first. This adds a *third* dimension to the same tables, and stacking it on an already-ambiguous query would compound that bug.