### PR TITLE
fix(core): preserve sign in Decimal::to_string for values between -1 and 0

### DIFF
--- a/include/trade_ngin/core/types.hpp
+++ b/include/trade_ngin/core/types.hpp
@@ -183,10 +183,18 @@ public:
 
     // String conversion
     std::string to_string() const {
-        int64_t integer_part = value_ / SCALE;
-        int64_t fractional_part = std::abs(value_ % SCALE);
+        // Format from the magnitude and prepend the sign explicitly so values
+        // in (-1, 0) keep their sign: value_ / SCALE truncates -0.5 to 0,
+        // which would otherwise print as "0.5".
+        bool negative = value_ < 0;
+        // Two's-complement negate in unsigned arithmetic; safe for INT64_MIN.
+        uint64_t magnitude = negative ? ~static_cast<uint64_t>(value_) + 1
+                                      : static_cast<uint64_t>(value_);
+        uint64_t integer_part = magnitude / SCALE;
+        uint64_t fractional_part = magnitude % SCALE;
 
-        std::string result = std::to_string(integer_part);
+        std::string result = negative ? "-" : "";
+        result += std::to_string(integer_part);
         if (fractional_part > 0) {
             std::string frac_str = std::to_string(fractional_part);
             // Pad with leading zeros

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -1,5 +1,6 @@
 # Set test source files
 set(TEST_SOURCES
+    core/test_decimal.cpp
     core/test_result.cpp
     core/test_state_manager.cpp
     core/test_state_manager_extended.cpp

--- a/tests/core/test_decimal.cpp
+++ b/tests/core/test_decimal.cpp
@@ -1,0 +1,37 @@
+#include <gtest/gtest.h>
+#include <climits>
+#include <string>
+#include "trade_ngin/core/types.hpp"
+
+using namespace trade_ngin;
+
+class DecimalTest : public ::testing::Test {};
+
+// ========== String conversion: to_string ==========
+
+TEST_F(DecimalTest, ToStringPositiveValues) {
+    EXPECT_EQ(Decimal(1.5).to_string(), "1.5");
+    EXPECT_EQ(Decimal(0.5).to_string(), "0.5");
+    EXPECT_EQ(Decimal(2.25).to_string(), "2.25");
+    EXPECT_EQ(Decimal(100).to_string(), "100");
+    EXPECT_EQ(Decimal(0).to_string(), "0");
+}
+
+TEST_F(DecimalTest, ToStringNegativeValues) {
+    EXPECT_EQ(Decimal(-1.5).to_string(), "-1.5");
+    EXPECT_EQ(Decimal(-100).to_string(), "-100");
+}
+
+TEST_F(DecimalTest, ToStringNegativeFractionBelowOne) {
+    // Regression: value_ / SCALE truncates -0.5 to 0, which used to drop
+    // the sign and print "0.5".
+    EXPECT_EQ(Decimal(-0.5).to_string(), "-0.5");
+    EXPECT_EQ(Decimal(-0.00000001).to_string(), "-0.00000001");
+    EXPECT_EQ(Decimal(-0.25).to_string(), "-0.25");
+}
+
+TEST_F(DecimalTest, ToStringInt64MinDoesNotOverflow) {
+    // std::abs(INT64_MIN) is UB; the unsigned-magnitude path must not trip it.
+    Decimal min_val = Decimal::from_raw(INT64_MIN);
+    EXPECT_EQ(min_val.to_string(), "-92233720368.54775808");
+}


### PR DESCRIPTION
## Summary

`Decimal::to_string()` computes the integer part with `value_ / SCALE`, which truncates toward zero. For values in `(-1, 0)` the integer part becomes `0` and the sign is silently dropped:

```cpp
Decimal(-0.5).to_string()  // returned "0.5"
```

Any position, price, or PnL in that range serialized with the wrong sign (CSV exports, logs, DB writes that go through `to_string`).

## Fix

- Format from the unsigned magnitude and prepend the sign explicitly.
- Two's-complement negation in unsigned arithmetic also removes the `std::abs(value_ % SCALE)` call, which was UB for `INT64_MIN`.

## Tests

New `tests/core/test_decimal.cpp`:
- positive values, negative values ≥ 1 in magnitude
- the regression cases `-0.5`, `-0.25`, `-0.00000001`
- `INT64_MIN` raw value formats without overflow

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XLW6nHQqVqpta884RC8MJW
