### PR TITLE
fix(backtest): stop volatility and monthly returns from silently producing NaN/inf

### DIFF
--- a/src/backtest/backtest_metrics_calculator.cpp
+++ b/src/backtest/backtest_metrics_calculator.cpp
@@ -105,12 +105,22 @@ double BacktestMetricsCalculator::calculate_volatility(const std::vector<double>
         return 0.0;
     }
 
+    // Two-pass standard deviation. The previous one-pass formula
+    // (E[r^2] - mean^2) suffers catastrophic cancellation for small daily
+    // returns and can round to a slightly negative variance, turning
+    // sqrt() into NaN. That NaN passed the `volatility <= 0` guard in
+    // calculate_sharpe_ratio (NaN comparisons are false) and silently
+    // propagated into Sharpe/reporting.
     double mean_return = calculate_mean(returns);
-    double sq_sum = std::inner_product(returns.begin(), returns.end(), returns.begin(), 0.0);
-    double variance = sq_sum / returns.size() - mean_return * mean_return;
 
     // Annualize using sqrt(252) for daily volatility
-    return std::sqrt(variance) * std::sqrt(252.0);
+    double volatility = calculate_std_dev(returns, mean_return) * std::sqrt(252.0);
+
+    // A constant series still leaves rounding dust (~1e-17) in the deviations;
+    // collapse it to a clean 0 so the `volatility <= 0` guard in
+    // calculate_sharpe_ratio treats the degenerate case as such instead of
+    // dividing by dust and reporting an absurd Sharpe.
+    return volatility < 1e-12 ? 0.0 : volatility;
 }
 
 double BacktestMetricsCalculator::calculate_downside_volatility(
@@ -371,6 +381,12 @@ std::unordered_map<std::string, double> BacktestMetricsCalculator::calculate_mon
     std::unordered_map<std::string, double> monthly_returns;
 
     for (size_t i = 1; i < equity_curve.size(); ++i) {
+        // Skip non-positive equity points, matching calculate_returns_from_equity:
+        // dividing by 0 would silently inject inf/NaN into the monthly totals.
+        if (equity_curve[i - 1].second <= 0.0) {
+            continue;
+        }
+
         auto time_t = std::chrono::system_clock::to_time_t(equity_curve[i].first);
         std::tm tm;
         core::safe_localtime(&time_t, &tm);

--- a/tests/backtesting/test_backtest_metrics_calculator.cpp
+++ b/tests/backtesting/test_backtest_metrics_calculator.cpp
@@ -91,6 +91,22 @@ TEST_F(BacktestMetricsCalculatorTest, VolatilityEmptyIsZero) {
     EXPECT_DOUBLE_EQ(calc_.calculate_volatility({}), 0.0);
 }
 
+TEST_F(BacktestMetricsCalculatorTest, VolatilityConstantSeriesIsZeroNotNaN) {
+    // Regression: the one-pass E[r^2] - mean^2 formula cancels catastrophically
+    // and rounds to a slightly negative variance for this input, so sqrt()
+    // returned NaN instead of 0.
+    auto vol = calc_.calculate_volatility({0.007, 0.007, 0.007, 0.007, 0.007});
+    EXPECT_DOUBLE_EQ(vol, 0.0);
+}
+
+TEST_F(BacktestMetricsCalculatorTest, SharpeConstantSeriesIsZeroNotNaN) {
+    // With NaN volatility the `volatility <= 0` guard was passed (NaN
+    // comparisons are false) and Sharpe itself became NaN.
+    auto sharpe = calc_.calculate_sharpe_ratio({0.007, 0.007, 0.007, 0.007, 0.007}, 5, 0.0);
+    EXPECT_TRUE(std::isfinite(sharpe));
+    EXPECT_DOUBLE_EQ(sharpe, 0.0);
+}
+
 TEST_F(BacktestMetricsCalculatorTest, VolatilityComputesAnnualizedStdev) {
     std::vector<double> r{0.01, -0.01, 0.01, -0.01};
     // mean=0, var=0.0001, daily std = 0.01, annualized = 0.01 * sqrt(252)
@@ -298,6 +314,20 @@ TEST_F(BacktestMetricsCalculatorTest, MonthlyReturnsAggregatesByYearMonthKey) {
     auto m = calc_.calculate_monthly_returns(curve);
     EXPECT_NEAR(m["2026-01"], 0.10, 1e-9);
     EXPECT_NEAR(m["2026-02"], 0.10, 1e-9);
+}
+
+TEST_F(BacktestMetricsCalculatorTest, MonthlyReturnsSkipsNonPositivePriorEquity) {
+    // Regression: dividing by a zero prior equity injected inf into the
+    // monthly totals and every later sum on them.
+    std::vector<std::pair<Timestamp, double>> curve;
+    curve.emplace_back(date_at(2026, 1, 15), 100.0);
+    curve.emplace_back(date_at(2026, 1, 16), 0.0);    // wiped out
+    curve.emplace_back(date_at(2026, 1, 20), 50.0);   // prior equity 0: skipped
+    curve.emplace_back(date_at(2026, 1, 22), 55.0);   // +10%
+    auto m = calc_.calculate_monthly_returns(curve);
+    EXPECT_TRUE(std::isfinite(m["2026-01"]));
+    // -100% (100 -> 0) plus +10% (50 -> 55); the 0 -> 50 step is skipped.
+    EXPECT_NEAR(m["2026-01"], -1.0 + 0.10, 1e-9);
 }
 
 TEST_F(BacktestMetricsCalculatorTest, FilterWarmupTrimsLeadingDays) {


### PR DESCRIPTION
## Summary

Two silent NaN/inf paths in `BacktestMetricsCalculator`:

**1. `calculate_volatility` returns NaN for near-constant returns.**
The one-pass formula `E[r²] − mean²` cancels catastrophically for small daily returns and can round to a *slightly negative* variance. `sqrt(negative)` = NaN. Deterministic repro: a constant `0.007` return series.

Worse, the NaN then slips past the guard in `calculate_sharpe_ratio`:

```cpp
if (volatility <= 0.0) return 0.0;   // NaN <= 0.0 is false → passes
return (annualized_return - rf) / volatility;   // Sharpe = NaN
```

so Sharpe and everything reported downstream silently becomes NaN.

Fix: reuse the existing two-pass `calculate_std_dev` helper, which is non-negative by construction.

**2. `calculate_monthly_returns` divides by prior equity unguarded.**
Its sibling `calculate_returns_from_equity` already skips non-positive prior equity; this loop didn't, so an equity value of `0` (wiped-out account) injected `inf` into the monthly totals. Apply the same skip.

## Tests

- `VolatilityConstantSeriesIsZeroNotNaN` — the `0.007 × 5` series reproduces the negative-variance rounding on any IEEE-754 double implementation
- `SharpeConstantSeriesIsZeroNotNaN` — proves the guard bypass is closed
- `MonthlyReturnsSkipsNonPositivePriorEquity`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XLW6nHQqVqpta884RC8MJW
