### PR TITLE
fix(core): parse negative fractional strings correctly in Decimal(std::string)

### DIFF
--- a/include/trade_ngin/core/types.hpp
+++ b/include/trade_ngin/core/types.hpp
@@ -49,7 +49,13 @@ public:
             while (frac_part.length() < 8) {
                 frac_part += "0";
             }
-            value_ = std::stoll(int_part) * SCALE + std::stoll(frac_part);
+            // The fractional digits carry the same sign as the whole number.
+            // Subtracting for negatives (and honoring "-0.x", where the integer
+            // part alone loses the sign) keeps values like "-1.5" exact.
+            bool negative = !int_part.empty() && int_part[0] == '-';
+            int64_t int_value = std::stoll(int_part) * SCALE;
+            int64_t frac_value = std::stoll(frac_part);
+            value_ = negative ? int_value - frac_value : int_value + frac_value;
         }
     }
 

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -1,5 +1,6 @@
 # Set test source files
 set(TEST_SOURCES
+    core/test_decimal.cpp
     core/test_result.cpp
     core/test_state_manager.cpp
     core/test_state_manager_extended.cpp

--- a/tests/core/test_decimal.cpp
+++ b/tests/core/test_decimal.cpp
@@ -1,0 +1,37 @@
+#include <gtest/gtest.h>
+#include <stdexcept>
+#include <string>
+#include "trade_ngin/core/types.hpp"
+
+using namespace trade_ngin;
+
+class DecimalTest : public ::testing::Test {};
+
+// ========== String parsing constructor ==========
+
+TEST_F(DecimalTest, ParsePositiveStrings) {
+    EXPECT_EQ(Decimal(std::string("1.5")), Decimal(1.5));
+    EXPECT_EQ(Decimal(std::string("2.25")), Decimal(2.25));
+    EXPECT_EQ(Decimal(std::string("100")), Decimal(100));
+    EXPECT_EQ(Decimal(std::string("0")), Decimal(0));
+    EXPECT_EQ(Decimal(std::string("0.00000001")), Decimal(0.00000001));
+}
+
+TEST_F(DecimalTest, ParseNegativeStrings) {
+    // Regression: fractional digits were added instead of subtracted for
+    // negatives, so "-1.5" parsed as -0.5 and "-0.5" as +0.5.
+    EXPECT_EQ(Decimal(std::string("-1.5")), Decimal(-1.5));
+    EXPECT_EQ(Decimal(std::string("-2.25")), Decimal(-2.25));
+    EXPECT_EQ(Decimal(std::string("-100")), Decimal(-100));
+}
+
+TEST_F(DecimalTest, ParseNegativeFractionBelowOne) {
+    // "-0.5" is the worst case: stoll("-0") is 0, so the old code produced
+    // +0.5 - the sign flipped entirely.
+    EXPECT_EQ(Decimal(std::string("-0.5")), Decimal(-0.5));
+    EXPECT_EQ(Decimal(std::string("-0.00000001")), Decimal(-0.00000001));
+}
+
+TEST_F(DecimalTest, ParseTooManyDecimalsThrows) {
+    EXPECT_THROW(Decimal(std::string("1.123456789")), std::overflow_error);
+}


### PR DESCRIPTION
## Summary

> Targets `feature/wrapper`, where the `Decimal(std::string)` constructor was introduced.

The string constructor combines integer and fractional parts with unconditional addition:

```cpp
value_ = std::stoll(int_part) * SCALE + std::stoll(frac_part);
```

For negative inputs the fractional digits must be *subtracted*, so every negative value with a fractional part parsed wrong:

| input | parsed as |
|-------|-----------|
| `"-1.5"` | `-0.5` (fraction pulled the value toward zero) |
| `"-0.5"` | `+0.5` (`stoll("-0")` is 0 — the sign vanished entirely) |

Any negative price, quantity, or PnL entering through this path was silently corrupted.

## Fix

Detect the sign from the integer part's leading `-` and subtract the fractional value for negatives. Handles `-0.x` correctly since the sign no longer depends on `stoll(int_part)` being negative.

## Tests

New `tests/core/test_decimal.cpp`: positive parsing, negative parsing, the `-0.x` regression cases, and the too-many-decimals throw.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XLW6nHQqVqpta884RC8MJW
