### PR TITLE
Fix ExecutionConfig ODR collision, unsubscribe engine bus callbacks, re-enable 25 execution tests

### DIFF
--- a/include/trade_ngin/core/config_loader.hpp
+++ b/include/trade_ngin/core/config_loader.hpp
@@ -103,8 +103,13 @@ struct DatabaseConfig {
 
 /**
  * @brief Execution configuration
+ *
+ * Named ExecutionSettingsConfig, not ExecutionConfig: the execution engine owns
+ * trade_ngin::ExecutionConfig (execution_engine.hpp). Two classes with one mangled
+ * name is an ODR violation — the linker folds their ctors/dtors and corrupts
+ * whichever object loses the coin toss.
  */
-struct ExecutionConfig {
+struct ExecutionSettingsConfig {
     double commission_rate{0.0005};
     double slippage_bps{1.0};
     double position_limit_backtest{1000.0};
@@ -244,7 +249,7 @@ struct AppConfig {
     DatabaseConfig database;
 
     // Execution configuration
-    ExecutionConfig execution;
+    ExecutionSettingsConfig execution;
 
     // Optimization configuration
     DynamicOptConfig opt_config;

--- a/src/execution/execution_engine.cpp
+++ b/src/execution/execution_engine.cpp
@@ -54,6 +54,19 @@ ExecutionEngine::~ExecutionEngine() {
             }
         }
 
+        // Deactivate our MarketDataBus subscriptions: the engine-wide one from
+        // initialize() and any per-job ADAPTIVE_ ones a failed cancel left behind.
+        // The bus is a process-lifetime singleton; a subscription left active here
+        // holds a callback into this destroyed engine.
+        try {
+            (void)MarketDataBus::instance().unsubscribe("EXECUTION_ENGINE");
+            for (const auto& job_id : jobs_to_cancel) {
+                (void)MarketDataBus::instance().unsubscribe("ADAPTIVE_" + job_id);
+            }
+        } catch (const std::exception& e) {
+            std::cerr << "Exception during bus unsubscription: " << e.what() << std::endl;
+        }
+
         std::lock_guard<std::mutex> lock(mutex_);
         active_jobs_.clear();
 
@@ -262,7 +275,7 @@ Result<std::string> ExecutionEngine::submit_execution(const Order& order, Execut
 Result<void> ExecutionEngine::cancel_execution(const std::string& job_id) {
     INFO("Attempting to cancel execution job " << job_id);
 
-    std::lock_guard<std::mutex> lock(mutex_);
+    std::unique_lock<std::mutex> lock(mutex_);
 
     auto it = active_jobs_.find(job_id);
     if (it == active_jobs_.end()) {
@@ -300,6 +313,11 @@ Result<void> ExecutionEngine::cancel_execution(const std::string& job_id) {
 
     // Remove from active jobs
     active_jobs_.erase(it);
+
+    // Release our lock before touching the bus: publish() invokes callbacks that
+    // take mutex_, so unsubscribing under it risks lock-order inversion.
+    lock.unlock();
+    (void)MarketDataBus::instance().unsubscribe("ADAPTIVE_" + job_id);
 
     INFO("Successfully cancelled execution job " << job_id);
     return Result<void>();

--- a/tests/core/test_config_loader.cpp
+++ b/tests/core/test_config_loader.cpp
@@ -230,12 +230,12 @@ TEST_F(ConfigLoaderTest, EmailConfigJsonRoundTrip) {
 }
 
 TEST_F(ConfigLoaderTest, ExecutionConfigJsonRoundTrip) {
-    ExecutionConfig ex;
+    ExecutionSettingsConfig ex;
     ex.commission_rate = 0.001;
     ex.slippage_bps = 2.5;
     ex.position_limit_backtest = 5000.0;
     ex.position_limit_live = 1000.0;
-    ExecutionConfig r;
+    ExecutionSettingsConfig r;
     r.from_json(ex.to_json());
     EXPECT_DOUBLE_EQ(r.commission_rate, 0.001);
     EXPECT_DOUBLE_EQ(r.slippage_bps, 2.5);

--- a/tests/execution/test_execution_engine.cpp
+++ b/tests/execution/test_execution_engine.cpp
@@ -69,7 +69,7 @@ protected:
     std::unique_ptr<ExecutionEngine> engine_;
 };
 
-TEST_F(ExecutionEngineTest, DISABLED_SimpleMarketOrder) {
+TEST_F(ExecutionEngineTest, SimpleMarketOrder) {
     try {
         // Create a simple market order
         Order order;
@@ -118,7 +118,7 @@ TEST_F(ExecutionEngineTest, DISABLED_SimpleMarketOrder) {
     }
 }
 
-TEST_F(ExecutionEngineTest, DISABLED_TWAPExecution) {
+TEST_F(ExecutionEngineTest, TWAPExecution) {
     Order order;
     order.symbol = "MSFT";
     order.side = Side::BUY;
@@ -157,7 +157,7 @@ TEST_F(ExecutionEngineTest, DISABLED_TWAPExecution) {
         << "Participation rate exceeded max limit";
 }
 
-TEST_F(ExecutionEngineTest, DISABLED_VWAPExecution) {
+TEST_F(ExecutionEngineTest, VWAPExecution) {
     Order order;
     order.symbol = "AAPL";
     order.side = Side::SELL;
@@ -193,7 +193,7 @@ TEST_F(ExecutionEngineTest, DISABLED_VWAPExecution) {
     EXPECT_LT(price_deviation, 0.01);  // Within 1% of VWAP
 }
 
-TEST_F(ExecutionEngineTest, DISABLED_POVExecution) {
+TEST_F(ExecutionEngineTest, POVExecution) {
     Order order;
     order.symbol = "GOOG";
     order.side = Side::BUY;
@@ -223,7 +223,7 @@ TEST_F(ExecutionEngineTest, DISABLED_POVExecution) {
     EXPECT_GT(metrics.num_child_orders, 1);
 }
 
-TEST_F(ExecutionEngineTest, DISABLED_ImplementationShortfallExecution) {
+TEST_F(ExecutionEngineTest, ImplementationShortfallExecution) {
     Order order;
     order.symbol = "AMZN";
     order.side = Side::BUY;
@@ -253,7 +253,7 @@ TEST_F(ExecutionEngineTest, DISABLED_ImplementationShortfallExecution) {
     EXPECT_GT(metrics.completion_rate, 0.0);
 }
 
-TEST_F(ExecutionEngineTest, DISABLED_AdaptiveLimitExecution) {
+TEST_F(ExecutionEngineTest, AdaptiveLimitExecution) {
     Order order;
     order.symbol = "FB";
     order.side = Side::SELL;
@@ -284,7 +284,7 @@ TEST_F(ExecutionEngineTest, DISABLED_AdaptiveLimitExecution) {
     EXPECT_GT(metrics.completion_rate, 0.0);
 }
 
-TEST_F(ExecutionEngineTest, DISABLED_DarkPoolExecution) {
+TEST_F(ExecutionEngineTest, DarkPoolExecution) {
     Order order;
     order.symbol = "NVDA";
     order.side = Side::BUY;
@@ -314,7 +314,7 @@ TEST_F(ExecutionEngineTest, DISABLED_DarkPoolExecution) {
     EXPECT_GT(metrics.completion_rate, 0.0);
 }
 
-TEST_F(ExecutionEngineTest, DISABLED_CancelExecution) {
+TEST_F(ExecutionEngineTest, CancelExecution) {
     Order order;
     order.symbol = "GOOG";
     order.side = Side::SELL;
@@ -348,7 +348,7 @@ TEST_F(ExecutionEngineTest, DISABLED_CancelExecution) {
     EXPECT_FALSE(job_found);
 }
 
-TEST_F(ExecutionEngineTest, DISABLED_ParticipationConstraints) {
+TEST_F(ExecutionEngineTest, ParticipationConstraints) {
     Order order;
     order.symbol = "AAPL";
     order.side = Side::BUY;
@@ -375,7 +375,7 @@ TEST_F(ExecutionEngineTest, DISABLED_ParticipationConstraints) {
     EXPECT_GT(metrics.num_child_orders, 1);
 }
 
-TEST_F(ExecutionEngineTest, DISABLED_InvalidConfigurations) {
+TEST_F(ExecutionEngineTest, InvalidConfigurations) {
     Order order;
     order.symbol = "MSFT";
     order.side = Side::BUY;
@@ -398,7 +398,7 @@ TEST_F(ExecutionEngineTest, DISABLED_InvalidConfigurations) {
     EXPECT_TRUE(result2.is_error());
 }
 
-TEST_F(ExecutionEngineTest, DISABLED_StressTest) {
+TEST_F(ExecutionEngineTest, StressTest) {
     const int num_orders = 5;
     std::vector<std::string> job_ids;
 
@@ -456,7 +456,7 @@ TEST_F(ExecutionEngineTest, DISABLED_StressTest) {
     EXPECT_GE(active_jobs.value().size(), 0) << "No active jobs remaining after cancellation";
 }
 
-TEST_F(ExecutionEngineTest, DISABLED_MetricsAccuracy) {
+TEST_F(ExecutionEngineTest, MetricsAccuracy) {
     Order order;
     order.symbol = "AAPL";
     order.side = Side::BUY;

--- a/tests/execution/test_execution_engine_extended.cpp
+++ b/tests/execution/test_execution_engine_extended.cpp
@@ -67,7 +67,7 @@ protected:
 
 // ===== initialize is not idempotent =====
 
-TEST_F(ExecutionEngineExtendedTest, DISABLED_InitializeTwiceReturnsError) {
+TEST_F(ExecutionEngineExtendedTest, InitializeTwiceReturnsError) {
     // FIXME: production behavior — ExecutionEngine::initialize() is NOT
     // idempotent. The fixture's SetUp already initialized once; a second call
     // returns an error (likely due to duplicate event-bus subscription
@@ -78,27 +78,27 @@ TEST_F(ExecutionEngineExtendedTest, DISABLED_InitializeTwiceReturnsError) {
 
 // ===== cancel_execution error path =====
 
-TEST_F(ExecutionEngineExtendedTest, DISABLED_CancelNonExistentJobReturnsError) {
+TEST_F(ExecutionEngineExtendedTest, CancelNonExistentJobReturnsError) {
     auto r = engine_->cancel_execution("nonexistent-job-id");
     EXPECT_TRUE(r.is_error());
 }
 
 // ===== get_metrics error path =====
 
-TEST_F(ExecutionEngineExtendedTest, DISABLED_GetMetricsForUnknownJobReturnsError) {
+TEST_F(ExecutionEngineExtendedTest, GetMetricsForUnknownJobReturnsError) {
     auto r = engine_->get_metrics("nonexistent-job-id");
     EXPECT_TRUE(r.is_error());
 }
 
 // ===== get_active_jobs =====
 
-TEST_F(ExecutionEngineExtendedTest, DISABLED_GetActiveJobsEmptyBeforeAnySubmission) {
+TEST_F(ExecutionEngineExtendedTest, GetActiveJobsEmptyBeforeAnySubmission) {
     auto r = engine_->get_active_jobs();
     ASSERT_TRUE(r.is_ok());
     EXPECT_TRUE(r.value().empty());
 }
 
-TEST_F(ExecutionEngineExtendedTest, DISABLED_GetActiveJobsContainsSubmittedJob) {
+TEST_F(ExecutionEngineExtendedTest, GetActiveJobsContainsSubmittedJob) {
     auto sub = engine_->submit_execution(make_order("AAPL", Side::BUY, 10, 150.0),
                                           ExecutionAlgo::TWAP, basic_config());
     ASSERT_TRUE(sub.is_ok());
@@ -111,14 +111,14 @@ TEST_F(ExecutionEngineExtendedTest, DISABLED_GetActiveJobsContainsSubmittedJob) 
     EXPECT_TRUE(found);
 }
 
-TEST_F(ExecutionEngineExtendedTest, DISABLED_CancelExecutionRemovesJobFromActive) {
+TEST_F(ExecutionEngineExtendedTest, CancelExecutionRemovesJobFromActive) {
     auto sub = engine_->submit_execution(make_order("AAPL", Side::BUY, 10, 150.0),
                                           ExecutionAlgo::TWAP, basic_config());
     ASSERT_TRUE(sub.is_ok());
     EXPECT_TRUE(engine_->cancel_execution(sub.value()).is_ok());
 }
 
-TEST_F(ExecutionEngineExtendedTest, DISABLED_GetMetricsAvailableForSubmittedJob) {
+TEST_F(ExecutionEngineExtendedTest, GetMetricsAvailableForSubmittedJob) {
     auto sub = engine_->submit_execution(make_order("AAPL", Side::BUY, 10, 150.0),
                                           ExecutionAlgo::TWAP, basic_config());
     ASSERT_TRUE(sub.is_ok());
@@ -128,14 +128,14 @@ TEST_F(ExecutionEngineExtendedTest, DISABLED_GetMetricsAvailableForSubmittedJob)
 
 // ===== custom algo registration =====
 
-TEST_F(ExecutionEngineExtendedTest, DISABLED_RegisterCustomAlgoSucceedsWithUniqueName) {
+TEST_F(ExecutionEngineExtendedTest, RegisterCustomAlgoSucceedsWithUniqueName) {
     auto r = engine_->register_custom_algo(
         "MY_CUSTOM_ALGO",
         [](const ExecutionJob&) { return Result<void>(); });
     EXPECT_TRUE(r.is_ok());
 }
 
-TEST_F(ExecutionEngineExtendedTest, DISABLED_RegisterCustomAlgoOverwritesSameName) {
+TEST_F(ExecutionEngineExtendedTest, RegisterCustomAlgoOverwritesSameName) {
     std::atomic<int> v1_calls{0};
     auto r1 = engine_->register_custom_algo(
         "DUP_ALGO",
@@ -157,14 +157,14 @@ TEST_F(ExecutionEngineExtendedTest, DISABLED_RegisterCustomAlgoOverwritesSameNam
 
 // ===== submit_execution error paths =====
 
-TEST_F(ExecutionEngineExtendedTest, DISABLED_SubmitExecutionWithZeroQuantityHandled) {
+TEST_F(ExecutionEngineExtendedTest, SubmitExecutionWithZeroQuantityHandled) {
     Order o = make_order("AAPL", Side::BUY, 0.0, 150.0);
     auto sub = engine_->submit_execution(o, ExecutionAlgo::TWAP, basic_config());
     // Either rejected (preferred) or accepted but with no fills; both paths exercised.
     (void)sub;
 }
 
-TEST_F(ExecutionEngineExtendedTest, DISABLED_SubmitExecutionWithZeroTimeHorizonHandled) {
+TEST_F(ExecutionEngineExtendedTest, SubmitExecutionWithZeroTimeHorizonHandled) {
     auto cfg = basic_config();
     cfg.time_horizon = std::chrono::minutes(0);
     auto sub = engine_->submit_execution(make_order("AAPL", Side::BUY, 10, 150.0),
@@ -177,7 +177,7 @@ TEST_F(ExecutionEngineExtendedTest, DISABLED_SubmitExecutionWithZeroTimeHorizonH
 
 // ===== Multi-job tracking =====
 
-TEST_F(ExecutionEngineExtendedTest, DISABLED_RapidSubmissionsCollideOnJobIdAndOverwrite) {
+TEST_F(ExecutionEngineExtendedTest, RapidSubmissionsCollideOnJobIdAndOverwrite) {
     // FIXME: production bug — submit_execution generates a job ID that includes
     // a timestamp at coarse resolution, so two submissions in the same tick
     // produce identical IDs. The second submission silently overwrites the
@@ -197,7 +197,7 @@ TEST_F(ExecutionEngineExtendedTest, DISABLED_RapidSubmissionsCollideOnJobIdAndOv
     EXPECT_GE(jobs.value().size(), 1u);
 }
 
-TEST_F(ExecutionEngineExtendedTest, DISABLED_SpacedSubmissionsAreTrackedDistinctly) {
+TEST_F(ExecutionEngineExtendedTest, SpacedSubmissionsAreTrackedDistinctly) {
     // Sleep between submissions to dodge the same-tick ID collision.
     auto a = engine_->submit_execution(make_order("AAPL", Side::BUY, 10, 150.0),
                                          ExecutionAlgo::TWAP, basic_config());


### PR DESCRIPTION
Root cause of the long-standing execution-test crashes (the "5 failures + exit 139" several PRs reported): an ODR violation — two different classes both named `trade_ngin::ExecutionConfig` (loader's plain struct in config_loader.hpp vs the engine's polymorphic config). The linker kept one inline ctor binary-wide, so engine configs were constructed by the wrong type's constructor and destroyed reading uninitialized containers. Which copy won differed per build/OS — hence the cross-machine variability.

- Loader struct renamed `ExecutionSettingsConfig` (3 references; engine type kept its name — used across the execution subsystem and tests)
- `ExecutionEngine` now deactivates its MarketDataBus subscriptions (engine-wide + per-job ADAPTIVE_) on cancel/destruction — previously left this-capturing callbacks in a process-lifetime singleton (real production leak for any engine-churning process)
- All 25 `DISABLED_` execution tests re-enabled

Verification: 25-test execution filter 10/10 green under AddressSanitizer; full suite **1197/1197** on macOS Debug. Note: pre-rename, `AppConfig::execution` JSON round-trips could also have resolved to the wrong type's methods — any past oddity in saved execution settings may trace to this.