### PR TITLE
Main audit batch 2: sector-cap integrity, position-source unification, metrics guards, registry equity guard, migration-script safety, debug demotion

### DIFF
--- a/include/trade_ngin/strategy/trend_following.hpp
+++ b/include/trade_ngin/strategy/trend_following.hpp
@@ -218,7 +218,6 @@ private:
     std::unordered_map<std::string, InstrumentData> instrument_data_;
 
     // Previous day positions for PnL calculation
-    std::unordered_map<std::string, Position> previous_positions_;
 
     /**
      * @brief Calculate EWMA for a price series

--- a/include/trade_ngin/strategy/trend_following.hpp
+++ b/include/trade_ngin/strategy/trend_following.hpp
@@ -193,6 +193,13 @@ public:
      */
     int get_max_required_lookback() const;
 
+    /**
+     * @brief Get sector-budgeted symbol weights for position sizing
+     * @return Map of symbol to weight (sums to 1.0; per-symbol capped at 50% of
+     *         its sector allocation). Public so tests can pin the cap invariant.
+     */
+    std::unordered_map<std::string, double> get_weights() const;
+
 protected:
     /**
      * @brief Validate strategy configuration
@@ -292,12 +299,6 @@ private:
      */
     std::vector<double> get_scaled_combined_forecast(
         const std::vector<double>& raw_combined_forecast) const;
-
-    /**
-     * @brief Get weights for position sizing
-     * @return Map of symbol to weight
-     */
-    std::unordered_map<std::string, double> get_weights() const;
 
     /**
      * @brief Calculate position for a symbol

--- a/include/trade_ngin/strategy/trend_following_fast.hpp
+++ b/include/trade_ngin/strategy/trend_following_fast.hpp
@@ -208,7 +208,6 @@ private:
     std::unordered_map<std::string, TrendFollowingFastInstrumentData> instrument_data_;
 
     // Previous day positions for PnL calculation
-    std::unordered_map<std::string, Position> previous_positions_;
 
     /**
      * @brief Calculate EWMA for a price series

--- a/include/trade_ngin/strategy/trend_following_slow.hpp
+++ b/include/trade_ngin/strategy/trend_following_slow.hpp
@@ -202,7 +202,6 @@ private:
     std::unordered_map<std::string, TrendFollowingSlowInstrumentData> instrument_data_;
 
     // Previous day positions for PnL calculation
-    std::unordered_map<std::string, Position> previous_positions_;
 
     /**
      * @brief Calculate EWMA for a price series

--- a/migrations/001_add_portfolio_type_rollback.sql
+++ b/migrations/001_add_portfolio_type_rollback.sql
@@ -26,6 +26,19 @@ DECLARE
     qt_positions BIGINT;
     qt_equity    BIGINT;
 BEGIN
+    -- On an un-migrated DB the qt count queries below would abort with the
+    -- misleading 'column "portfolio_type" does not exist'; report the actual
+    -- state instead.
+    IF NOT EXISTS (
+        SELECT 1 FROM information_schema.columns
+        WHERE table_schema = 'trading' AND table_name = 'positions'
+          AND column_name = 'portfolio_type'
+    ) THEN
+        -- EXCEPTION, not NOTICE+RETURN: the ADD CONSTRAINT statements later in
+        -- this transaction would still fail confusingly on an un-migrated DB.
+        RAISE EXCEPTION 'Nothing to roll back: trading.positions has no portfolio_type column (migration 001 was never applied).';
+    END IF;
+
     SELECT count(*) INTO qt_positions FROM trading.positions    WHERE portfolio_type = 'qt';
     SELECT count(*) INTO qt_equity    FROM trading.equity_curve WHERE portfolio_type = 'qt';
 

--- a/migrations/test_001_migration.sh
+++ b/migrations/test_001_migration.sh
@@ -8,8 +8,27 @@
 #   2. it becomes possible afterwards, with existing rows untouched.
 #
 # Requires a running postgres reachable via PGHOST/PGPORT/PGUSER/PGPASSWORD.
+#
+# ⚠️ DESTRUCTIVE: the fixture begins with DROP SCHEMA trading CASCADE on
+# whatever those env vars point at. To run it you must name the scratch
+# database explicitly: export MIGRATION_TEST_DB=<dbname> with PGDATABASE set
+# to the same value. Anything else (including production) is refused.
 
-set -uo pipefail
+set -euo pipefail
+
+if [[ "${MIGRATION_TEST_DB:-}" == "" ]]; then
+    echo "REFUSING to run: this script DROPS SCHEMA trading CASCADE on the target DB." >&2
+    echo "Set MIGRATION_TEST_DB=<scratch dbname> AND PGDATABASE to the same value." >&2
+    exit 2
+fi
+if [[ "${PGDATABASE:-}" != "${MIGRATION_TEST_DB}" ]]; then
+    echo "REFUSING to run: PGDATABASE='${PGDATABASE:-}' != MIGRATION_TEST_DB='${MIGRATION_TEST_DB}'." >&2
+    exit 2
+fi
+if [[ "${MIGRATION_TEST_DB}" == "new_algo_data" ]]; then
+    echo "REFUSING to run against new_algo_data: that is the production database." >&2
+    exit 2
+fi
 
 PSQL="psql -v ON_ERROR_STOP=1 -q -X"
 pass=0

--- a/src/backtest/backtest_metrics_calculator.cpp
+++ b/src/backtest/backtest_metrics_calculator.cpp
@@ -12,7 +12,9 @@ namespace trade_ngin {
 // ========== Return Calculations ==========
 
 double BacktestMetricsCalculator::calculate_total_return(double start_value, double end_value) const {
-    if (start_value <= 0.0) {
+    // !(x > 0) instead of (x <= 0): NaN compares false to everything, so the
+    // old form let a NaN start value through to the division.
+    if (!(start_value > 0.0) || !std::isfinite(end_value)) {
         return 0.0;
     }
     return (end_value - start_value) / start_value;
@@ -36,7 +38,9 @@ std::vector<double> BacktestMetricsCalculator::calculate_returns_from_equity(
 
     returns.reserve(equity_curve.size() - 1);
     for (size_t i = 1; i < equity_curve.size(); ++i) {
-        if (equity_curve[i - 1].second > 0.0) {
+        // prev > 0.0 already excludes NaN prev; the current point must also be
+        // finite or the computed return itself is NaN.
+        if (equity_curve[i - 1].second > 0.0 && std::isfinite(equity_curve[i].second)) {
             double ret = (equity_curve[i].second - equity_curve[i - 1].second) /
                         equity_curve[i - 1].second;
             returns.push_back(ret);
@@ -120,7 +124,13 @@ double BacktestMetricsCalculator::calculate_volatility(const std::vector<double>
     // collapse it to a clean 0 so the `volatility <= 0` guard in
     // calculate_sharpe_ratio treats the degenerate case as such instead of
     // dividing by dust and reporting an absurd Sharpe.
-    return volatility < 1e-12 ? 0.0 : volatility;
+    if (volatility > 0.0 && volatility < 1e-12) {
+        WARN("Volatility collapsed to 0 (rounding dust; constant or near-constant "
+             "series of " + std::to_string(returns.size()) +
+             " returns); Sharpe will report 0 -- distinguish flat from broken data upstream");
+        return 0.0;
+    }
+    return volatility;
 }
 
 double BacktestMetricsCalculator::calculate_downside_volatility(
@@ -142,7 +152,17 @@ double BacktestMetricsCalculator::calculate_downside_volatility(
     }
 
     // Annualize using sqrt(252)
-    return std::sqrt(downside_sum / downside_count) * std::sqrt(252.0);
+    double downside_vol = std::sqrt(downside_sum / downside_count) * std::sqrt(252.0);
+
+    // Same rounding-dust collapse calculate_volatility applies: returns sitting a
+    // hair below target otherwise leave a ~1e-17 denominator and Sortino explodes
+    // to an absurd finite value instead of hitting its degenerate-case sentinel.
+    if (downside_vol > 0.0 && downside_vol < 1e-12) {
+        WARN("Downside volatility collapsed to 0 (rounding dust " +
+             std::to_string(downside_vol) + "); Sortino will report its degenerate-case value");
+        return 0.0;
+    }
+    return downside_vol;
 }
 
 // ========== Drawdown Metrics ==========
@@ -381,9 +401,11 @@ std::unordered_map<std::string, double> BacktestMetricsCalculator::calculate_mon
     std::unordered_map<std::string, double> monthly_returns;
 
     for (size_t i = 1; i < equity_curve.size(); ++i) {
-        // Skip non-positive equity points, matching calculate_returns_from_equity:
-        // dividing by 0 would silently inject inf/NaN into the monthly totals.
-        if (equity_curve[i - 1].second <= 0.0) {
+        // Skip non-positive OR non-finite equity points, matching
+        // calculate_returns_from_equity. !(x > 0) instead of (x <= 0): NaN
+        // compares false to everything, so the old form let NaN through into
+        // the monthly totals.
+        if (!(equity_curve[i - 1].second > 0.0) || !std::isfinite(equity_curve[i].second)) {
             continue;
         }
 

--- a/src/instruments/instrument_registry.cpp
+++ b/src/instruments/instrument_registry.cpp
@@ -37,10 +37,18 @@ std::shared_ptr<Instrument> InstrumentRegistry::get_instrument(const std::string
 
     // Strip variant suffix (e.g., "ZC.v.0" -> "ZC", "ES.v.0" -> "ES") before any lookup or remap
     auto v_pos = cleaned_symbol.find(".v.");
-    if (v_pos != std::string::npos) {
+    const bool had_variant_suffix = v_pos != std::string::npos;
+    if (had_variant_suffix) {
         cleaned_symbol = cleaned_symbol.substr(0, v_pos);
     }
 
+    // An exact match wins before any micro-futures remap: bare equity tickers
+    // collide with futures roots (NYSE "ES" is Eversource Energy). A .v.
+    // variant suffix marks a futures continuous series, so suffixed symbols
+    // still remap unconditionally.
+    if (!had_variant_suffix && instruments_.count(cleaned_symbol) > 0) {
+        // fall through to the map lookup below with no remap
+    } else
     // Handle special cases for micro futures
     if (cleaned_symbol == "ES") {
         cleaned_symbol = "MES";
@@ -226,10 +234,18 @@ bool InstrumentRegistry::has_instrument(const std::string& symbol) const {
 
     // Strip variant suffix (e.g., "ZC.v.0" -> "ZC", "ES.v.0" -> "ES") before any lookup or remap
     auto v_pos = cleaned_symbol.find(".v.");
-    if (v_pos != std::string::npos) {
+    const bool had_variant_suffix = v_pos != std::string::npos;
+    if (had_variant_suffix) {
         cleaned_symbol = cleaned_symbol.substr(0, v_pos);
     }
 
+    // An exact match wins before any micro-futures remap: bare equity tickers
+    // collide with futures roots (NYSE "ES" is Eversource Energy). A .v.
+    // variant suffix marks a futures continuous series, so suffixed symbols
+    // still remap unconditionally.
+    if (!had_variant_suffix && instruments_.count(cleaned_symbol) > 0) {
+        // fall through to the map lookup below with no remap
+    } else
     // Handle special cases for micro futures
     if (cleaned_symbol == "ES") {
         cleaned_symbol = "MES";

--- a/src/portfolio/portfolio_manager.cpp
+++ b/src/portfolio/portfolio_manager.cpp
@@ -414,7 +414,7 @@ Result<void> PortfolioManager::process_market_data(const std::vector<Bar>& data,
                     } else {
                         source = "UNCLASSIFIED";
                     }
-                    INFO("CHOP_SOURCE: symbol=" + sym + " source=" + source +
+                    DEBUG("CHOP_SOURCE: symbol=" + sym + " source=" + source +
                          " prev=" + std::to_string(prev_q) +
                          " strat=" + std::to_string(strat_q) +
                          " qp=" + std::to_string(qp_q) +
@@ -1021,7 +1021,7 @@ Result<void> PortfolioManager::optimize_positions() {
             for (const auto& [strat_id, info] : strategies_) {
                 if (!info.use_optimization)
                     continue;
-                INFO("PRE_OPTIMIZER_TRACE: strat=" + strat_id +
+                DEBUG("PRE_OPTIMIZER_TRACE: strat=" + strat_id +
                      " current_positions_size=" +
                      std::to_string(info.current_positions.size()) +
                      " target_positions_size=" +

--- a/src/risk/risk_manager.cpp
+++ b/src/risk/risk_manager.cpp
@@ -175,7 +175,7 @@ Result<RiskResult> RiskManager::process_positions(
         // Surface both forms each cycle so anyone investigating a divergence
         // between the displayed "Volatility" and the gate's behavior can see
         // them side-by-side along with the per-instrument weights and σᵢ.
-        INFO("VAR_DEBUG: gate_sigma=" + std::to_string(gate_sigma) +
+        DEBUG("VAR_DEBUG: gate_sigma=" + std::to_string(gate_sigma) +
              " reported_sigma=" + std::to_string(result.portfolio_var) +
              " var_limit=" + std::to_string(config_.var_limit) +
              " portfolio_mult=" + std::to_string(result.portfolio_multiplier));
@@ -188,7 +188,7 @@ Result<RiskResult> RiskManager::process_positions(
                 const std::string& sym = i < market_data.ordered_symbols.size()
                                              ? market_data.ordered_symbols[i]
                                              : std::string("?");
-                INFO("VAR_DEBUG:   " + sym +
+                DEBUG("VAR_DEBUG:   " + sym +
                      " w_true=" + std::to_string(weights[i]) +
                      " w_vol=" + std::to_string(vol_weights[i]) +
                      " sigma_i=" + std::to_string(sigma_i));

--- a/src/strategy/trend_following.cpp
+++ b/src/strategy/trend_following.cpp
@@ -1109,6 +1109,10 @@ std::unordered_map<std::string, double> TrendFollowingStrategy::get_weights() co
     // Maximum weight any single symbol can have within its sector (50% of sector weight)
     const double MAX_SYMBOL_TO_SECTOR_RATIO = 0.50;
 
+    // Symbols capped below their equal share; the closing normalization must not
+    // re-inflate them.
+    std::unordered_set<std::string> capped_symbols;
+
     for (const auto& [sector, symbols] : sector_to_symbols) {
         int num_symbols = static_cast<int>(symbols.size());
         if (num_symbols == 0)
@@ -1125,6 +1129,7 @@ std::unordered_map<std::string, double> TrendFollowingStrategy::get_weights() co
 
             // Log when a symbol's weight is capped
             if (capped_weight < per_symbol_weight) {
+                capped_symbols.insert(symbol);
                 INFO("Symbol " + symbol + " in sector " + sector +
                      " weight capped from " + std::to_string(per_symbol_weight * 100.0) +
                      "% to " + std::to_string(capped_weight * 100.0) +
@@ -1133,14 +1138,29 @@ std::unordered_map<std::string, double> TrendFollowingStrategy::get_weights() co
         }
     }
 
-    // Normalize weights to sum to 100% (compensates for capping leakage)
-    double weight_sum = 0.0;
+    // Normalize weights to sum to 100%. Scale only the uncapped symbols over the
+    // budget the caps freed; scaling everything re-inflates capped symbols past
+    // MAX_SYMBOL_TO_SECTOR_RATIO of their sector allocation.
+    double capped_sum = 0.0;
+    double uncapped_sum = 0.0;
     for (const auto& [symbol, weight] : symbol_weights) {
-        weight_sum += weight;
+        (capped_symbols.count(symbol) ? capped_sum : uncapped_sum) += weight;
     }
+    const double weight_sum = capped_sum + uncapped_sum;
     if (weight_sum > 0.0 && std::abs(weight_sum - 1.0) > 0.001) {
-        for (auto& [symbol, weight] : symbol_weights) {
-            weight /= weight_sum;
+        if (uncapped_sum > 0.0 && capped_sum < 1.0) {
+            const double scale = (1.0 - capped_sum) / uncapped_sum;
+            for (auto& [symbol, weight] : symbol_weights) {
+                if (capped_symbols.count(symbol) == 0) {
+                    weight *= scale;
+                }
+            }
+        } else {
+            // Every symbol capped (all sectors single-symbol): plain scaling is the
+            // only way back to a fully-invested portfolio.
+            for (auto& [symbol, weight] : symbol_weights) {
+                weight /= weight_sum;
+            }
         }
     }
 

--- a/src/strategy/trend_following.cpp
+++ b/src/strategy/trend_following.cpp
@@ -453,27 +453,18 @@ Result<void> TrendFollowingStrategy::on_data(const std::vector<Bar>& data) {
             // Get current market price
             double current_price = static_cast<double>(symbol_bars.back().close);
 
-            // Get previous position for PnL calculation
-            // First try previous_positions_ (DB data for live trading first day)
-            // Then fall back to positions_ (in-memory data for backtest/subsequent days)
-            auto prev_pos_it = previous_positions_.find(symbol);
+            // Get previous position for PnL calculation from positions_: seeded via
+            // seed_positions() on live first day, maintained by update_position()
+            // on every prior bar.
             double previous_quantity = 0.0;
             double previous_avg_price = current_price;
             double previous_realized_pnl = 0.0;
 
-            if (prev_pos_it != previous_positions_.end()) {
-                // Use DB-loaded previous positions (live trading first day)
-                previous_quantity = static_cast<double>(prev_pos_it->second.quantity);
-                previous_avg_price = static_cast<double>(prev_pos_it->second.average_price);
-                previous_realized_pnl = static_cast<double>(prev_pos_it->second.realized_pnl);
-            } else {
-                // Fallback to in-memory positions (backtest or subsequent live days)
-                auto pos_it = positions_.find(symbol);
-                if (pos_it != positions_.end()) {
-                    previous_quantity = static_cast<double>(pos_it->second.quantity);
-                    previous_avg_price = static_cast<double>(pos_it->second.average_price);
-                    previous_realized_pnl = static_cast<double>(pos_it->second.realized_pnl);
-                }
+            auto pos_it = positions_.find(symbol);
+            if (pos_it != positions_.end()) {
+                previous_quantity = static_cast<double>(pos_it->second.quantity);
+                previous_avg_price = static_cast<double>(pos_it->second.average_price);
+                previous_realized_pnl = static_cast<double>(pos_it->second.realized_pnl);
             }
 
             // Calculate realized PnL from position changes
@@ -598,10 +589,6 @@ Result<void> TrendFollowingStrategy::on_data(const std::vector<Bar>& data) {
                 WARN("Failed to update position for " + symbol + ": " + pos_result.error()->what());
                 // Continue processing despite position update failure
             }
-
-            // Update previous_positions_ for next iteration
-            // This ensures PnL accumulates correctly in backtests and subsequent live days
-            previous_positions_[symbol] = pos;
 
             instrument_data.last_update = symbol_bars.back().timestamp;
         }

--- a/src/strategy/trend_following.cpp
+++ b/src/strategy/trend_following.cpp
@@ -1368,9 +1368,9 @@ double TrendFollowingStrategy::apply_position_buffer(const std::string& symbol, 
         decision = "KEEP";
     }
 
-    // TEMP-DEBUG (BUFFER_TRACE): empirical proof of buffer-state-restart bug.
+    // BUFFER_TRACE: per-symbol buffer-state diagnostic (DEBUG level).
     // Logs full buffer state per call so we can diagnose churn root cause.
-    INFO("BUFFER_TRACE: sym=" + symbol +
+    DEBUG("BUFFER_TRACE: sym=" + symbol +
          " pos_found=" + std::string(pos_found ? "Y" : "N") +
          " current=" + std::to_string(current_position) +
          " raw=" + std::to_string(raw_position) +

--- a/src/strategy/trend_following_fast.cpp
+++ b/src/strategy/trend_following_fast.cpp
@@ -139,28 +139,6 @@ Result<void> TrendFollowingFastStrategy::on_data(const std::vector<Bar>& data) {
         logged_total = true;
     }
 
-    // Load previous positions if not already loaded (only once per run)
-    static bool previous_positions_loaded = false;
-    if (!previous_positions_loaded && previous_positions_.empty() && db_) {
-        // Use the data's timestamp (not current time) to handle historical runs correctly
-        // Get the timestamp from the first bar to determine the processing date
-        auto data_time = data.empty() ? std::chrono::system_clock::now() : data[0].timestamp;
-        auto previous_date = data_time - std::chrono::hours(24);
-        auto previous_positions_result =
-            db_->load_positions_by_date(id_, "", "", previous_date, "trading.positions");
-
-        if (previous_positions_result.is_ok()) {
-            const auto& previous_positions = previous_positions_result.value();
-            INFO("Loaded " + std::to_string(previous_positions.size()) +
-                 " previous day positions for PnL calculation");
-            previous_positions_ = previous_positions;
-        } else {
-            INFO("No previous day positions found (first run or no data): " +
-                 std::string(previous_positions_result.error()->what()));
-        }
-        previous_positions_loaded = true;
-    }
-
     // CRITICAL FIX: Update price history BEFORE base class processing
     // This ensures price data is always updated even if leverage checks fail
     // in BaseStrategy::on_data(), preventing stuck prices in final_positions table
@@ -461,27 +439,18 @@ Result<void> TrendFollowingFastStrategy::on_data(const std::vector<Bar>& data) {
             // Get current market price
             double current_price = static_cast<double>(symbol_bars.back().close);
 
-            // Get previous position for PnL calculation
-            // First try previous_positions_ (DB data for live trading first day)
-            // Then fall back to positions_ (in-memory data for backtest/subsequent days)
-            auto prev_pos_it = previous_positions_.find(symbol);
+            // Get previous position for PnL calculation from positions_: seeded via
+            // seed_positions() on live first day, maintained by update_position()
+            // on every prior bar.
             double previous_quantity = 0.0;
             double previous_avg_price = current_price;
             double previous_realized_pnl = 0.0;
 
-            if (prev_pos_it != previous_positions_.end()) {
-                // Use DB-loaded previous positions (live trading first day)
-                previous_quantity = static_cast<double>(prev_pos_it->second.quantity);
-                previous_avg_price = static_cast<double>(prev_pos_it->second.average_price);
-                previous_realized_pnl = static_cast<double>(prev_pos_it->second.realized_pnl);
-            } else {
-                // Fallback to in-memory positions (backtest or subsequent live days)
-                auto pos_it = positions_.find(symbol);
-                if (pos_it != positions_.end()) {
-                    previous_quantity = static_cast<double>(pos_it->second.quantity);
-                    previous_avg_price = static_cast<double>(pos_it->second.average_price);
-                    previous_realized_pnl = static_cast<double>(pos_it->second.realized_pnl);
-                }
+            auto pos_it = positions_.find(symbol);
+            if (pos_it != positions_.end()) {
+                previous_quantity = static_cast<double>(pos_it->second.quantity);
+                previous_avg_price = static_cast<double>(pos_it->second.average_price);
+                previous_realized_pnl = static_cast<double>(pos_it->second.realized_pnl);
             }
 
             // Calculate realized PnL from position changes
@@ -606,10 +575,6 @@ Result<void> TrendFollowingFastStrategy::on_data(const std::vector<Bar>& data) {
                 WARN("Failed to update position for " + symbol + ": " + pos_result.error()->what());
                 // Continue processing despite position update failure
             }
-
-            // Update previous_positions_ for next iteration
-            // This ensures PnL accumulates correctly in backtests and subsequent live days
-            previous_positions_[symbol] = pos;
 
             instrument_data.last_update = symbol_bars.back().timestamp;
         }

--- a/src/strategy/trend_following_fast.cpp
+++ b/src/strategy/trend_following_fast.cpp
@@ -1113,6 +1113,10 @@ std::unordered_map<std::string, double> TrendFollowingFastStrategy::get_weights(
     // Maximum weight any single symbol can have within its sector (50% of sector weight)
     const double MAX_SYMBOL_TO_SECTOR_RATIO = 0.50;
 
+    // Symbols capped below their equal share; the closing normalization must not
+    // re-inflate them.
+    std::unordered_set<std::string> capped_symbols;
+
     for (const auto& [sector, symbols] : sector_to_symbols) {
         int num_symbols = static_cast<int>(symbols.size());
         if (num_symbols == 0)
@@ -1129,6 +1133,7 @@ std::unordered_map<std::string, double> TrendFollowingFastStrategy::get_weights(
 
             // Log when a symbol's weight is capped
             if (capped_weight < per_symbol_weight) {
+                capped_symbols.insert(symbol);
                 INFO("Symbol " + symbol + " in sector " + sector +
                      " weight capped from " + std::to_string(per_symbol_weight * 100.0) +
                      "% to " + std::to_string(capped_weight * 100.0) +
@@ -1137,14 +1142,29 @@ std::unordered_map<std::string, double> TrendFollowingFastStrategy::get_weights(
         }
     }
 
-    // Normalize weights to sum to 100%
-    double weight_sum = 0.0;
+    // Normalize weights to sum to 100%. Scale only the uncapped symbols over the
+    // budget the caps freed; scaling everything re-inflates capped symbols past
+    // MAX_SYMBOL_TO_SECTOR_RATIO of their sector allocation.
+    double capped_sum = 0.0;
+    double uncapped_sum = 0.0;
     for (const auto& [symbol, weight] : symbol_weights) {
-        weight_sum += weight;
+        (capped_symbols.count(symbol) ? capped_sum : uncapped_sum) += weight;
     }
+    const double weight_sum = capped_sum + uncapped_sum;
     if (weight_sum > 0.0 && std::abs(weight_sum - 1.0) > 0.001) {
-        for (auto& [symbol, weight] : symbol_weights) {
-            weight /= weight_sum;
+        if (uncapped_sum > 0.0 && capped_sum < 1.0) {
+            const double scale = (1.0 - capped_sum) / uncapped_sum;
+            for (auto& [symbol, weight] : symbol_weights) {
+                if (capped_symbols.count(symbol) == 0) {
+                    weight *= scale;
+                }
+            }
+        } else {
+            // Every symbol capped (all sectors single-symbol): plain scaling is the
+            // only way back to a fully-invested portfolio.
+            for (auto& [symbol, weight] : symbol_weights) {
+                weight /= weight_sum;
+            }
         }
     }
 

--- a/src/strategy/trend_following_slow.cpp
+++ b/src/strategy/trend_following_slow.cpp
@@ -1102,6 +1102,10 @@ std::unordered_map<std::string, double> TrendFollowingSlowStrategy::get_weights(
     // Maximum weight any single symbol can have within its sector (50% of sector weight)
     const double MAX_SYMBOL_TO_SECTOR_RATIO = 0.50;
 
+    // Symbols capped below their equal share; the closing normalization must not
+    // re-inflate them.
+    std::unordered_set<std::string> capped_symbols;
+
     for (const auto& [sector, symbols] : sector_to_symbols) {
         int num_symbols = static_cast<int>(symbols.size());
         if (num_symbols == 0)
@@ -1118,6 +1122,7 @@ std::unordered_map<std::string, double> TrendFollowingSlowStrategy::get_weights(
 
             // Log when a symbol's weight is capped
             if (capped_weight < per_symbol_weight) {
+                capped_symbols.insert(symbol);
                 INFO("Symbol " + symbol + " in sector " + sector +
                      " weight capped from " + std::to_string(per_symbol_weight * 100.0) +
                      "% to " + std::to_string(capped_weight * 100.0) +
@@ -1126,14 +1131,29 @@ std::unordered_map<std::string, double> TrendFollowingSlowStrategy::get_weights(
         }
     }
 
-    // Normalize weights to sum to 100%
-    double weight_sum = 0.0;
+    // Normalize weights to sum to 100%. Scale only the uncapped symbols over the
+    // budget the caps freed; scaling everything re-inflates capped symbols past
+    // MAX_SYMBOL_TO_SECTOR_RATIO of their sector allocation.
+    double capped_sum = 0.0;
+    double uncapped_sum = 0.0;
     for (const auto& [symbol, weight] : symbol_weights) {
-        weight_sum += weight;
+        (capped_symbols.count(symbol) ? capped_sum : uncapped_sum) += weight;
     }
+    const double weight_sum = capped_sum + uncapped_sum;
     if (weight_sum > 0.0 && std::abs(weight_sum - 1.0) > 0.001) {
-        for (auto& [symbol, weight] : symbol_weights) {
-            weight /= weight_sum;
+        if (uncapped_sum > 0.0 && capped_sum < 1.0) {
+            const double scale = (1.0 - capped_sum) / uncapped_sum;
+            for (auto& [symbol, weight] : symbol_weights) {
+                if (capped_symbols.count(symbol) == 0) {
+                    weight *= scale;
+                }
+            }
+        } else {
+            // Every symbol capped (all sectors single-symbol): plain scaling is the
+            // only way back to a fully-invested portfolio.
+            for (auto& [symbol, weight] : symbol_weights) {
+                weight /= weight_sum;
+            }
         }
     }
 

--- a/src/strategy/trend_following_slow.cpp
+++ b/src/strategy/trend_following_slow.cpp
@@ -139,28 +139,6 @@ Result<void> TrendFollowingSlowStrategy::on_data(const std::vector<Bar>& data) {
         logged_total = true;
     }
 
-    // Load previous positions if not already loaded (only once per run)
-    static bool previous_positions_loaded = false;
-    if (!previous_positions_loaded && previous_positions_.empty() && db_) {
-        // Use the data's timestamp (not current time) to handle historical runs correctly
-        // Get the timestamp from the first bar to determine the processing date
-        auto data_time = data.empty() ? std::chrono::system_clock::now() : data[0].timestamp;
-        auto previous_date = data_time - std::chrono::hours(24);
-        auto previous_positions_result =
-            db_->load_positions_by_date(id_, "", "", previous_date, "trading.positions");
-
-        if (previous_positions_result.is_ok()) {
-            const auto& previous_positions = previous_positions_result.value();
-            INFO("Loaded " + std::to_string(previous_positions.size()) +
-                 " previous day positions for PnL calculation");
-            previous_positions_ = previous_positions;
-        } else {
-            INFO("No previous day positions found (first run or no data): " +
-                 std::string(previous_positions_result.error()->what()));
-        }
-        previous_positions_loaded = true;
-    }
-
     // CRITICAL FIX: Update price history BEFORE base class processing
     // This ensures price data is always updated even if leverage checks fail
     // in BaseStrategy::on_data(), preventing stuck prices in final_positions table
@@ -461,27 +439,18 @@ Result<void> TrendFollowingSlowStrategy::on_data(const std::vector<Bar>& data) {
             // Get current market price
             double current_price = static_cast<double>(symbol_bars.back().close);
 
-            // Get previous position for PnL calculation
-            // First try previous_positions_ (DB data for live trading first day)
-            // Then fall back to positions_ (in-memory data for backtest/subsequent days)
-            auto prev_pos_it = previous_positions_.find(symbol);
+            // Get previous position for PnL calculation from positions_: seeded via
+            // seed_positions() on live first day, maintained by update_position()
+            // on every prior bar.
             double previous_quantity = 0.0;
             double previous_avg_price = current_price;
             double previous_realized_pnl = 0.0;
 
-            if (prev_pos_it != previous_positions_.end()) {
-                // Use DB-loaded previous positions (live trading first day)
-                previous_quantity = static_cast<double>(prev_pos_it->second.quantity);
-                previous_avg_price = static_cast<double>(prev_pos_it->second.average_price);
-                previous_realized_pnl = static_cast<double>(prev_pos_it->second.realized_pnl);
-            } else {
-                // Fallback to in-memory positions (backtest or subsequent live days)
-                auto pos_it = positions_.find(symbol);
-                if (pos_it != positions_.end()) {
-                    previous_quantity = static_cast<double>(pos_it->second.quantity);
-                    previous_avg_price = static_cast<double>(pos_it->second.average_price);
-                    previous_realized_pnl = static_cast<double>(pos_it->second.realized_pnl);
-                }
+            auto pos_it = positions_.find(symbol);
+            if (pos_it != positions_.end()) {
+                previous_quantity = static_cast<double>(pos_it->second.quantity);
+                previous_avg_price = static_cast<double>(pos_it->second.average_price);
+                previous_realized_pnl = static_cast<double>(pos_it->second.realized_pnl);
             }
 
             // Calculate realized PnL from position changes
@@ -606,10 +575,6 @@ Result<void> TrendFollowingSlowStrategy::on_data(const std::vector<Bar>& data) {
                 WARN("Failed to update position for " + symbol + ": " + pos_result.error()->what());
                 // Continue processing despite position update failure
             }
-
-            // Update previous_positions_ for next iteration
-            // This ensures PnL accumulates correctly in backtests and subsequent live days
-            previous_positions_[symbol] = pos;
 
             instrument_data.last_update = symbol_bars.back().timestamp;
         }

--- a/tests/backtesting/test_backtest_metrics_calculator.cpp
+++ b/tests/backtesting/test_backtest_metrics_calculator.cpp
@@ -364,3 +364,52 @@ TEST_F(BacktestMetricsCalculatorTest, AllMetricsPopulatesNonZeroFields) {
     EXPECT_FALSE(r.drawdown_curve.empty());
     EXPECT_GE(r.max_drawdown, 0.0);
 }
+
+// ===== NaN / degeneracy guards (batch-2 metrics hardening) =====
+
+TEST_F(BacktestMetricsCalculatorTest, NanEquityPointExcludedFromMonthlyReturns) {
+    // NaN in the middle of the curve: neither the NaN-as-current nor the
+    // NaN-as-previous transition may contribute. Pre-fix, `prev <= 0.0` was
+    // false for NaN and a NaN period_return poisoned the month's total.
+    std::vector<std::pair<Timestamp, double>> curve = {
+        {date_at(2024, 3, 1), 100.0},
+        {date_at(2024, 3, 4), 110.0},
+        {date_at(2024, 3, 5), std::numeric_limits<double>::quiet_NaN()},
+        {date_at(2024, 3, 6), 120.0},
+        {date_at(2024, 3, 7), 126.0}};
+    auto monthly = calc_.calculate_monthly_returns(curve);
+    ASSERT_EQ(monthly.size(), 1u);
+    const double total = monthly.at("2024-03");
+    EXPECT_TRUE(std::isfinite(total));
+    // Surviving transitions: 100->110 (+10%) and 120->126 (+5%).
+    EXPECT_NEAR(total, 0.10 + 0.05, 1e-12);
+}
+
+TEST_F(BacktestMetricsCalculatorTest, NanEquityPointExcludedFromReturnSeries) {
+    std::vector<std::pair<Timestamp, double>> curve = {
+        {date_at(2024, 3, 1), 100.0},
+        {date_at(2024, 3, 4), std::numeric_limits<double>::quiet_NaN()},
+        {date_at(2024, 3, 5), 100.0},
+        {date_at(2024, 3, 6), 105.0}};
+    auto returns = calc_.calculate_returns_from_equity(curve);
+    ASSERT_EQ(returns.size(), 1u);
+    EXPECT_NEAR(returns[0], 0.05, 1e-12);
+}
+
+TEST_F(BacktestMetricsCalculatorTest, TotalReturnNanInputsReturnZero) {
+    const double nan = std::numeric_limits<double>::quiet_NaN();
+    EXPECT_DOUBLE_EQ(calc_.calculate_total_return(nan, 110.0), 0.0);
+    EXPECT_DOUBLE_EQ(calc_.calculate_total_return(100.0, nan), 0.0);
+}
+
+TEST_F(BacktestMetricsCalculatorTest, SortinoNearTargetDustHitsSentinelNotAbsurdValue) {
+    // Returns an epsilon below target leave ~1e-17 downside "dust". Pre-fix,
+    // Sortino divided by the dust and reported an absurd finite magnitude;
+    // post-fix the dust collapses to 0 and the degenerate-case sentinel applies.
+    std::vector<double> returns(100, -1e-18);
+    const double sortino =
+        calc_.calculate_sortino_ratio(returns, /*trading_days=*/100, /*mar=*/0.0);
+    EXPECT_LE(std::abs(sortino), 999.0);
+    const double downside = calc_.calculate_downside_volatility(returns, 0.0);
+    EXPECT_DOUBLE_EQ(downside, 0.0);
+}

--- a/tests/instruments/test_instrument_registry.cpp
+++ b/tests/instruments/test_instrument_registry.cpp
@@ -133,6 +133,24 @@ TEST_F(InstrumentRegistryTest, HasInstrumentRespectsMicroSymbolMapping) {
     EXPECT_FALSE(r.has_instrument("UNKNOWN"));
 }
 
+TEST_F(InstrumentRegistryTest, ExactEquitySymbolWinsOverMicroRemap) {
+    auto& r = InstrumentRegistry::instance();
+    auto es_equity = make_equity("ES");  // NYSE "ES" = Eversource Energy
+    auto mes = make_futures("MES");
+    r.instruments_["ES"] = es_equity;
+    r.instruments_["MES"] = mes;
+    // A registered bare symbol must win over the ES->MES micro remap; pre-fix
+    // the remap fired unconditionally and handed back the futures contract.
+    EXPECT_EQ(r.get_instrument("ES"), es_equity);
+    EXPECT_TRUE(r.has_instrument("ES"));
+    // A .v. variant suffix marks a futures continuous series: still remaps
+    // even with the equity registered.
+    EXPECT_EQ(r.get_instrument("ES.v.0"), mes);
+    EXPECT_TRUE(r.has_instrument("ES.v.0"));
+    // Micro remap unchanged when no bare registration exists.
+    EXPECT_EQ(r.get_instrument("NQ"), nullptr);
+}
+
 TEST_F(InstrumentRegistryTest, GetFuturesInstrumentReturnsNullForNonFutures) {
     auto& r = InstrumentRegistry::instance();
     r.instruments_["AAPL"] = make_equity("AAPL");

--- a/tests/strategy/test_trend_following.cpp
+++ b/tests/strategy/test_trend_following.cpp
@@ -294,6 +294,77 @@ TEST(TrendFollowingConfigDefaults, CarverBufferConstantsArePinned) {
                      cfg.carver_buffer_floor);
 }
 
+namespace {
+
+// Mock DB whose contract metadata contains a single-symbol sector, so the
+// 50%-of-sector cap in get_weights() actually fires.
+class SectorMetadataMockDb : public MockPostgresDatabase {
+public:
+    using MockPostgresDatabase::MockPostgresDatabase;
+
+    Result<std::shared_ptr<arrow::Table>> get_contract_metadata() const override {
+        arrow::StringBuilder sector_b;
+        arrow::StringBuilder symbol_b;
+        const std::vector<std::pair<std::string, std::string>> rows = {
+            {"Metals", "GC"}, {"Metals", "SI"}, {"Metals", "HG"}, {"Crypto", "MBT"}};
+        for (const auto& [sec, sym] : rows) {
+            (void)sector_b.Append(sec);
+            (void)symbol_b.Append(sym);
+        }
+        std::shared_ptr<arrow::Array> sector_arr;
+        std::shared_ptr<arrow::Array> symbol_arr;
+        (void)sector_b.Finish(&sector_arr);
+        (void)symbol_b.Finish(&symbol_arr);
+        auto schema = arrow::schema({arrow::field("Sector", arrow::utf8()),
+                                     arrow::field("Databento Symbol", arrow::utf8())});
+        return Result<std::shared_ptr<arrow::Table>>(
+            arrow::Table::Make(schema, {sector_arr, symbol_arr}));
+    }
+
+    Result<std::vector<std::string>> get_symbols(AssetClass asset_class, DataFrequency freq,
+                                                 const std::string& data_type) override {
+        (void)asset_class;
+        (void)freq;
+        (void)data_type;
+        return Result<std::vector<std::string>>({"GC.v.0", "SI.v.0", "HG.v.0", "MBT.v.0"});
+    }
+};
+
+}  // namespace
+
+// The sector cap must survive normalization: a single-symbol sector is capped to
+// 50% of its sector budget and the freed weight goes to OTHER symbols only.
+// Pre-fix, the closing renormalization re-inflated the capped symbol (MBT landed
+// at 1/3 instead of 1/4).
+TEST(TrendFollowingWeights, SectorCapSurvivesNormalization) {
+    StateManager::reset_instance();
+    auto db = std::make_shared<SectorMetadataMockDb>("mock://sector");
+    ASSERT_TRUE(db->connect().is_ok());
+
+    StrategyConfig cfg;
+    cfg.capital_allocation = 1000000.0;
+    cfg.asset_classes = {AssetClass::FUTURES};
+    cfg.frequencies = {DataFrequency::DAILY};
+    TrendFollowingConfig tf;
+    TrendFollowingStrategy strat("TEST_WEIGHTS_CAP", cfg, tf, db);
+
+    auto weights = strat.get_weights();
+    ASSERT_EQ(weights.size(), 4u);
+
+    double sum = 0.0;
+    for (const auto& [sym, w] : weights) {
+        sum += w;
+    }
+    EXPECT_NEAR(sum, 1.0, 1e-9);
+
+    // 2 sectors -> sector budget 0.5 each. MBT alone in Crypto: capped at 0.25.
+    EXPECT_NEAR(weights.at("MBT"), 0.25, 1e-9)
+        << "capped symbol was re-inflated by normalization";
+    for (const auto* metal : {"GC", "SI", "HG"}) {
+        EXPECT_NEAR(weights.at(metal), 0.25, 1e-9);
+    }
+}
+
 // Test initialization and valid configuration
 TEST_F(TrendFollowingTest, ValidConfiguration) {
     EXPECT_EQ(strategy_->get_state(), StrategyState::INITIALIZED);


### PR DESCRIPTION
Six audited fixes from the main commit-by-commit audit (docs/MAIN_AUDIT_2026-08-27.md), one commit each, each with a regression test:

1. **Sector cap survives normalization** — renormalization now scales only uncapped symbols over the freed budget; previously it re-inflated the very symbol the 50%-of-sector cap had just limited. All three trend variants.
2. **One prior-position mechanism** — deletes the orphaned `previous_positions_` member + the stale DB loaders `_fast`/`_slow` still carried; `positions_` (seed_positions/update_position) is the single source across variants.
3. **Metrics guards** — NaN-input exclusion in return/monthly loops (NaN compares false to `<= 0.0`), downside-vol dust floor (Sortino can no longer divide by ~0), WARN on floor triggers so flat vs broken is distinguishable.
4. **Registry equity guard** — exact symbol registration now wins over the ES/YM/NQ→micro remap for bare symbols; `.v.`-suffixed lookups (futures by definition) remap as before. Prevents a future equity 'ES' (Eversource) silently resolving to MES futures.
5. **Migration test-script safety** — `test_001_migration.sh` refuses to run without explicit scratch-DB authorization (it opens with DROP SCHEMA CASCADE); `new_algo_data` hard-blocked; rollback script now reports 'never applied' instead of a confusing column error.
6. **Debug traces INFO→DEBUG** — BUFFER_TRACE/VAR_DEBUG/CHOP_SOURCE/PRE_OPTIMIZER_TRACE were logging per-symbol-per-cycle at INFO in production paths.

Verification: clean rebuild (header layout changed), full suite **1178/1178** (main baseline + 6 new tests). Behavioral note for reviewers: item 1 intentionally changes portfolio weights when a sector cap binds — this is the audited intended behavior of the cap; the change is covered by the post-batch integration validation gate (first-10-days baseline comparison) before anything ships further.