### PR TITLE
equities: wave 2 fixes

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -139,6 +139,7 @@ set(TRADE_NGIN_SOURCES
     src/live/live_price_manager.cpp
     src/live/live_pnl_manager.cpp
     src/live/execution_manager.cpp
+    src/live/execution_price_resolver.cpp
     src/live/margin_manager.cpp
     src/live/csv_exporter.cpp
     src/live/corporate_actions_applier.cpp

--- a/apps/strategies/live_equity_mean_reversion.cpp
+++ b/apps/strategies/live_equity_mean_reversion.cpp
@@ -868,8 +868,10 @@ int main(int argc, char* argv[]) {
                     if (closes_result.is_error()) {
                         ERROR("Could not load raw closes for the dividend denominator: " +
                               std::string(closes_result.error()->what()) +
-                              ". Dividend adjustments would use a missing denominator and "
-                              "leave cost basis permanently wrong.");
+                              ". Every dividend in this window is therefore SKIPPED and left "
+                              "unapplied; none is recorded in trading.corp_action_applied, so "
+                              "all of them are retried on a later run. Cost bases are stale "
+                              "until then, not wrong.");
                     } else {
                         size_t added = 0;
                         for (const auto& [sym, by_date] : closes_result.value()) {
@@ -898,8 +900,10 @@ int main(int argc, char* argv[]) {
                             }
                             ERROR("No price history exists for held symbol(s): " +
                                   sym_list +
-                                  ". Corporate actions on them cannot be applied at all "
-                                  "-- reconcile these positions before continuing.");
+                                  ". Dividends on them are SKIPPED and left unapplied (no "
+                                  "dedup record is written, so they are retried once price "
+                                  "history covers the ex-date). Splits and renames, which "
+                                  "need no close, still apply. Reconcile these positions.");
                         }
                     }
                 }
@@ -1002,13 +1006,29 @@ int main(int argc, char* argv[]) {
                             c = close_before(row.ticker, row.date_str);
                         }
                         if (c <= 0.0) {
-                            auto p_it = previous_day_close_prices.find(row.ticker);
-                            c = (p_it != previous_day_close_prices.end()) ? p_it->second : 0.0;
-                            if (c > 0.0) {
-                                WARN("No historical close for " + row.ticker +
-                                     " before ex_date " + row.date_str +
-                                     " -- using today's T-1 close as a fallback");
-                            }
+                            // Deliberately NO fallback to today's T-1 close. The
+                            // denominator has to be the close as at the ex-date: the
+                            // ratio is 1 + dividend / close_at_ex_date, so a close from
+                            // a different date yields a different ratio, and the result
+                            // is written into average_price and then stamped in
+                            // trading.corp_action_applied, which stops the event ever
+                            // being reconsidered. DD's 2025-11-03 dividend of 47.50
+                            // against its ex-date close of 34.69 is a ratio of 2.3693;
+                            // against a later close of 136.98 it is 1.3468, and a true
+                            // basis of 100.00 is persisted as 175.92 forever.
+                            //
+                            // Leaving c at 0.0 makes CorporateActionsApplier skip the
+                            // event (it rejects a non-positive close), which produces no
+                            // PositionAdjustment, so no dedup row is recorded and the
+                            // dividend is reconsidered on a later run once the closes
+                            // are available. An unapplied adjustment is recoverable; a
+                            // wrongly applied one is not.
+                            ERROR("No close at or before ex_date " + row.date_str +
+                                  " for " + row.ticker +
+                                  " -- the dividend denominator cannot be established, so "
+                                  "this event is SKIPPED and left unapplied. It carries no "
+                                  "dedup record and will be retried once price history "
+                                  "covers the ex-date.");
                         }
                         ev.close_at_ex_date = c;
                         // bug_021: prefer qty at ex_date - 1; fall back to
@@ -2078,8 +2098,14 @@ int main(int argc, char* argv[]) {
                             INFO("✓ Valid portfolio value for Day T-1: $" + std::to_string(portfolio_value));
 
                             // Create a temporary LiveResultsManager for Day T-1 equity update
+                            // portfolio_id is NOT defaultable here: LiveResultsManager
+                            // falls back to "BASE_PORTFOLIO", the futures book, so
+                            // omitting it files this portfolio's equity curve under a
+                            // portfolio it does not belong to while EQUITY_MR_PORTFOLIO
+                            // gets no row at all. live_portfolio_conservative.cpp:2217
+                            // passes it at the byte-identical call site.
                             auto yesterday_manager = std::make_unique<LiveResultsManager>(
-                                db, true, "LIVE_EQUITY_MEAN_REVERSION"
+                                db, true, kEquityStrategyId, portfolio_id, kEquityStrategyName
                             );
                             yesterday_manager->set_equity(portfolio_value);
 

--- a/apps/strategies/live_equity_mean_reversion.cpp
+++ b/apps/strategies/live_equity_mean_reversion.cpp
@@ -24,6 +24,7 @@
 #include "trade_ngin/live/corporate_actions_lifecycle.hpp"
 #include "trade_ngin/live/corp_action_window.hpp"
 #include "trade_ngin/live/corporate_actions_audit_log.hpp"
+#include "trade_ngin/live/live_daily_cycle.hpp"
 #include "trade_ngin/portfolio/portfolio_manager.hpp"
 #include "trade_ngin/strategy/mean_reversion.hpp"
 #include "trade_ngin/strategy/equity_strategy_builder.hpp"
@@ -542,29 +543,6 @@ int main(int argc, char* argv[]) {
                 .register_equity_costs_from_bars(symbols, bars_by_symbol);
         }
 
-        // Pre-warm strategy state so portfolio can pull price history for optimization/risk
-        INFO("Preprocessing data in strategy to populate price history...");
-        auto strat_prewarm = mr_strategy->on_data(all_bars);
-        if (strat_prewarm.is_error()) {
-            std::cerr << "Failed to preprocess data in strategy: "
-                      << strat_prewarm.error()->what() << std::endl;
-            return 1;
-        }
-
-        // Process data through portfolio pipeline (optimization + risk), mirroring backtest
-        INFO("Processing data through portfolio manager (optimization + risk)...");
-        auto port_process_result = portfolio->process_market_data(all_bars);
-        if (port_process_result.is_error()) {
-            std::cerr << "Failed to process data in portfolio manager: "
-                      << port_process_result.error()->what() << std::endl;
-            return 1;
-        }
-        INFO("Portfolio processing completed");
-
-        // Get optimized portfolio positions (integer-rounded after optimization/risk)
-        INFO("Retrieving optimized portfolio positions...");
-        auto positions = portfolio->get_portfolio_positions();
-        
         // ========================================
         // NON-TRADING DAY DETECTION
         // Find the actual previous trading day (skip weekends and holidays)
@@ -1277,6 +1255,36 @@ int main(int argc, char* argv[]) {
             }
         }
 
+        // Seed the strategy with the previous day's holdings, then generate the day's
+        // signals. Both the ordering and the placement of this block are load-bearing:
+        // MeanReversionStrategy::generate_signal() branches on what it currently holds,
+        // so a live process -- which starts with an empty positions_ every session --
+        // has to be handed the book back first, and it has to be the book as restated
+        // by the corporate-action blocks above, since a split changes quantity and a
+        // dividend changes cost basis. See LiveDailyCycle::prepare_strategy_for_signals.
+        INFO("Seeding strategy with previous-day book and generating signals...");
+        auto strat_prewarm = LiveDailyCycle::prepare_strategy_for_signals(
+            *mr_strategy, previous_positions, all_bars);
+        if (strat_prewarm.is_error()) {
+            std::cerr << "Failed to preprocess data in strategy: "
+                      << strat_prewarm.error()->what() << std::endl;
+            return 1;
+        }
+
+        // Process data through portfolio pipeline (optimization + risk), mirroring backtest
+        INFO("Processing data through portfolio manager (optimization + risk)...");
+        auto port_process_result = portfolio->process_market_data(all_bars);
+        if (port_process_result.is_error()) {
+            std::cerr << "Failed to process data in portfolio manager: "
+                      << port_process_result.error()->what() << std::endl;
+            return 1;
+        }
+        INFO("Portfolio processing completed");
+
+        // Get optimized portfolio positions (integer-rounded after optimization/risk)
+        INFO("Retrieving optimized portfolio positions...");
+        auto positions = portfolio->get_portfolio_positions();
+
         // Verify we have prices for all required symbols
         std::set<std::string> all_symbols;
         for (const auto& [symbol, position] : positions) {
@@ -1444,25 +1452,51 @@ int main(int argc, char* argv[]) {
 
         // Now update Day T positions with the corrected average_price from on_execution().
         // The strategy's positions now have correct cost basis from weighted averaging.
+        // Day-T positions open with average_price set to the previous close, because
+        // that same field is what ExecutionManager reads as the fill price. Now that
+        // executions have been generated and priced, the field goes back to meaning
+        // cost basis -- and a held position's basis is whatever it has always been,
+        // not today's mark. Before Wave 2 the basis was only restored for symbols the
+        // strategy knew about, and since positions_ was never seeded that meant only
+        // the symbols that traded today: every untraded holding kept the close it was
+        // initialised with and its basis drifted a day at a time.
         auto strategy_positions = mr_strategy->get_positions();
         for (auto& [symbol, current_position] : positions) {
             auto strat_it = strategy_positions.find(symbol);
+            double strategy_basis = 0.0;
             if (strat_it != strategy_positions.end()) {
-                double cost_basis = strat_it->second.average_price.as_double();
-                if (cost_basis > 0.0) {
-                    current_position.average_price = Decimal(cost_basis);
-                    // Recalculate unrealized PnL with correct cost basis
-                    double current_price = 0.0;
-                    if (previous_day_close_prices.find(symbol) != previous_day_close_prices.end()) {
-                        current_price = previous_day_close_prices[symbol];
-                    }
-                    if (current_price > 0.0 && current_position.quantity.as_double() != 0.0) {
-                        current_position.unrealized_pnl = Decimal(
-                            current_position.quantity.as_double() * (current_price - cost_basis));
-                    }
-                    // Carry realized PnL from strategy
-                    current_position.realized_pnl = strat_it->second.realized_pnl;
+                strategy_basis = strat_it->second.average_price.as_double();
+            }
+
+            // The carried book is post-corporate-action, so a split or dividend has
+            // already restated this basis.
+            double carried_basis = 0.0;
+            auto carried_it = previous_positions.find(symbol);
+            if (carried_it != previous_positions.end() &&
+                carried_it->second.quantity.as_double() != 0.0) {
+                carried_basis = carried_it->second.average_price.as_double();
+            }
+
+            double cost_basis = LivePnLManager::resolve_day_t_cost_basis(
+                strategy_basis, carried_basis);
+
+            if (cost_basis > 0.0) {
+                current_position.average_price = Decimal(cost_basis);
+                // Recalculate unrealized PnL with correct cost basis
+                double current_price = 0.0;
+                if (previous_day_close_prices.find(symbol) != previous_day_close_prices.end()) {
+                    current_price = previous_day_close_prices[symbol];
                 }
+                if (current_price > 0.0) {
+                    current_position.unrealized_pnl = Decimal(
+                        LivePnLManager::unrealized_from_cost_basis(
+                            current_position.quantity.as_double(), cost_basis, current_price));
+                }
+            }
+
+            // Carry realized PnL from strategy
+            if (strat_it != strategy_positions.end()) {
+                current_position.realized_pnl = strat_it->second.realized_pnl;
             }
         }
         // Log final Day T position state

--- a/apps/strategies/live_equity_mean_reversion.cpp
+++ b/apps/strategies/live_equity_mean_reversion.cpp
@@ -34,6 +34,7 @@
 #include "trade_ngin/live/live_metrics_calculator.hpp"
 #include "trade_ngin/live/live_trading_coordinator.hpp"
 #include "trade_ngin/live/live_price_manager.hpp"
+#include "trade_ngin/live/execution_price_resolver.hpp"
 #include "trade_ngin/live/live_pnl_manager.hpp"
 #include "trade_ngin/live/execution_manager.hpp"
 #include "trade_ngin/live/margin_manager.hpp"
@@ -1296,14 +1297,45 @@ int main(int argc, char* argv[]) {
             all_symbols.insert(symbol);
         }
 
+        // A held position with no T-1 close is not a warning any more. Downstream the
+        // execution path will refuse to price it from a cost basis, so it would either
+        // be silently skipped or -- before that refusal existed -- filled at zero. The
+        // widened lookup below rescues the ordinary cases (halts, thin names, the
+        // session after a holiday) from real older closes; anything it cannot rescue is
+        // a genuine data gap on a position carrying real risk, and the run must not
+        // quietly price around it.
+        std::vector<std::string> missing_t1_with_position;
         for (const auto& symbol : all_symbols) {
             if (previous_day_close_prices.find(symbol) == previous_day_close_prices.end()) {
-                WARN("Missing T-1 price for symbol: " + symbol);
+                bool holds_risk = false;
+                auto pos_it = positions.find(symbol);
+                if (pos_it != positions.end() && pos_it->second.quantity.as_double() != 0.0) {
+                    holds_risk = true;
+                }
+                auto prev_it = previous_positions.find(symbol);
+                if (prev_it != previous_positions.end() &&
+                    prev_it->second.quantity.as_double() != 0.0) {
+                    holds_risk = true;
+                }
+                if (holds_risk) {
+                    missing_t1_with_position.push_back(symbol);
+                } else {
+                    WARN("Missing T-1 price for symbol: " + symbol + " (no position - ignored)");
+                }
             }
             if (two_days_ago_close_prices.find(symbol) == two_days_ago_close_prices.end() &&
                 previous_positions.find(symbol) != previous_positions.end()) {
                 WARN("Missing T-2 price for symbol: " + symbol + " (needed for PnL finalization)");
             }
+        }
+        if (!missing_t1_with_position.empty()) {
+            std::sort(missing_t1_with_position.begin(), missing_t1_with_position.end());
+            for (const auto& symbol : missing_t1_with_position) {
+                ERROR("Missing T-1 price for symbol with a non-zero position: " + symbol);
+            }
+            INFO("Will attempt to price " + std::to_string(missing_t1_with_position.size()) +
+                 " position-carrying symbol(s) from their most recent real close; any that "
+                 "cannot be priced will not trade.");
         }
 
         // ========================================
@@ -1420,21 +1452,40 @@ int main(int argc, char* argv[]) {
                 << std::setw(2) << now_tm->tm_mday;
         std::string date_str = date_ss.str();
 
-        auto execution_result = execution_manager->generate_daily_executions(
-            positions,
-            previous_positions,
-            previous_day_close_prices,
-            now
-        );
+        // Price, execute, and roll back anything that could not be priced. The rules
+        // and their rationale live in LiveDailyCycle::execute_day_t so that the runner
+        // and its tests exercise one implementation rather than two that can drift.
+        auto day_t_exec = LiveDailyCycle::execute_day_t(
+            *execution_manager, positions, previous_positions, previous_day_close_prices,
+            all_bars, now, app_config.live.execution_price_max_staleness_days);
 
-        std::vector<ExecutionReport> daily_executions;
-        if (execution_result.is_ok()) {
-            daily_executions = execution_result.value();
-            INFO("ExecutionManager generated " + std::to_string(daily_executions.size()) + " executions");
-        } else {
-            ERROR("ExecutionManager failed: " + std::string(execution_result.error()->what()));
+        if (day_t_exec.is_error()) {
+            ERROR("ExecutionManager failed: " + std::string(day_t_exec.error()->what()));
             // No fallback - component is required to work
             throw std::runtime_error("ExecutionManager failed");
+        }
+
+        auto exec_outcome = day_t_exec.value();
+        std::vector<ExecutionReport> daily_executions = exec_outcome.executions;
+        INFO("ExecutionManager generated " + std::to_string(daily_executions.size()) +
+             " executions");
+
+        for (const auto& entry : exec_outcome.widened_prices) {
+            INFO("BASIS TRACE | price widened | " + entry +
+                 " (no T-1 close; used most recent real session)");
+        }
+        for (const auto& symbol : exec_outcome.unpriced) {
+            ERROR("BASIS TRACE | unpriced | " + symbol + " has no close within " +
+                  std::to_string(app_config.live.execution_price_max_staleness_days) +
+                  " days - it did not trade today");
+        }
+        for (const auto& symbol : exec_outcome.rolled_back) {
+            auto prev_it = previous_positions.find(symbol);
+            double carried =
+                prev_it != previous_positions.end() ? prev_it->second.quantity.as_double() : 0.0;
+            ERROR("BASIS TRACE | rolled back | " + symbol +
+                  " day-T target discarded, book restored to carried quantity " +
+                  std::to_string(carried) + " (unpriced, no execution)");
         }
 
         // Feed executions back to strategy for cost basis tracking.
@@ -1450,55 +1501,39 @@ int main(int argc, char* argv[]) {
             }
         }
 
-        // Now update Day T positions with the corrected average_price from on_execution().
-        // The strategy's positions now have correct cost basis from weighted averaging.
-        // Day-T positions open with average_price set to the previous close, because
-        // that same field is what ExecutionManager reads as the fill price. Now that
-        // executions have been generated and priced, the field goes back to meaning
-        // cost basis -- and a held position's basis is whatever it has always been,
-        // not today's mark. Before Wave 2 the basis was only restored for symbols the
-        // strategy knew about, and since positions_ was never seeded that meant only
-        // the symbols that traded today: every untraded holding kept the close it was
-        // initialised with and its basis drifted a day at a time.
+        // Now resolve each day-T position's cost basis. The rules -- strategy basis
+        // from on_execution, else the carried (post-corporate-action) basis, and never
+        // a mark -- and the handling of the residual live in
+        // LiveDailyCycle::resolve_and_apply_basis, so the runner and its tests share
+        // one implementation. Marks come from the same widened price map the fills were
+        // priced at, so unrealized PnL and the executions agree on what a symbol was
+        // worth today.
         auto strategy_positions = mr_strategy->get_positions();
-        for (auto& [symbol, current_position] : positions) {
+        for (const auto& [symbol, pos] : positions) {
+            if (pos.quantity.as_double() == 0.0) continue;
             auto strat_it = strategy_positions.find(symbol);
-            double strategy_basis = 0.0;
-            if (strat_it != strategy_positions.end()) {
-                strategy_basis = strat_it->second.average_price.as_double();
-            }
-
-            // The carried book is post-corporate-action, so a split or dividend has
-            // already restated this basis.
-            double carried_basis = 0.0;
             auto carried_it = previous_positions.find(symbol);
-            if (carried_it != previous_positions.end() &&
-                carried_it->second.quantity.as_double() != 0.0) {
-                carried_basis = carried_it->second.average_price.as_double();
-            }
-
-            double cost_basis = LivePnLManager::resolve_day_t_cost_basis(
-                strategy_basis, carried_basis);
-
-            if (cost_basis > 0.0) {
-                current_position.average_price = Decimal(cost_basis);
-                // Recalculate unrealized PnL with correct cost basis
-                double current_price = 0.0;
-                if (previous_day_close_prices.find(symbol) != previous_day_close_prices.end()) {
-                    current_price = previous_day_close_prices[symbol];
-                }
-                if (current_price > 0.0) {
-                    current_position.unrealized_pnl = Decimal(
-                        LivePnLManager::unrealized_from_cost_basis(
-                            current_position.quantity.as_double(), cost_basis, current_price));
-                }
-            }
-
-            // Carry realized PnL from strategy
-            if (strat_it != strategy_positions.end()) {
-                current_position.realized_pnl = strat_it->second.realized_pnl;
-            }
+            DEBUG("BASIS TRACE | inputs | " + symbol + " strategy=" +
+                  (strat_it != strategy_positions.end()
+                       ? std::to_string(strat_it->second.average_price.as_double())
+                       : std::string("none")) +
+                  " carried=" +
+                  (carried_it != previous_positions.end()
+                       ? std::to_string(carried_it->second.average_price.as_double())
+                       : std::string("none")));
         }
+
+        auto unresolved_basis = LiveDailyCycle::resolve_and_apply_basis(
+            positions, strategy_positions, previous_positions, exec_outcome.execution_prices);
+
+        for (const auto& symbol : unresolved_basis) {
+            ERROR("BASIS TRACE | UNRESOLVED | " + symbol +
+                  " holds a non-zero quantity with no cost basis from either the strategy "
+                  "or the carried book. Recorded basis 0 and zero unrealized PnL rather "
+                  "than substituting today's close. This is an upstream invariant "
+                  "failure - investigate.");
+        }
+
         // Log final Day T position state
         for (const auto& [symbol, pos] : positions) {
             if (pos.quantity.as_double() != 0.0) {

--- a/docs/AVERAGE_PRICE_LIFECYCLE.md
+++ b/docs/AVERAGE_PRICE_LIFECYCLE.md
@@ -1,0 +1,160 @@
+# `Position::average_price` — lifecycle, meanings, and the rules that keep them apart
+
+**Status:** current as of the E1 residual fix (2026-08-31). Branch `equities_integration`.
+
+This document exists because four separate defects — F-D, F-E, the Wave 2 residual, and
+the zero-price chain — were all the same underlying mistake: **`average_price` carries
+more than one meaning, and code written against one meaning read a value written under
+another.** Mapping it out is what stops the next one.
+
+---
+
+## 1. The three meanings
+
+| Meaning | What it is | Who is entitled to write it |
+|---|---|---|
+| **COST BASIS** | Volume-weighted price actually paid. The anchor for realized P&L, unrealized P&L, and the mean-reversion stop-loss. | `BaseStrategy::on_execution()` — sole legitimate writer. Corporate actions restate it. |
+| **MARK** | What the position is worth right now (a close). | Risk/margin read it this way. Nothing should *write* a mark here. |
+| **FILL PRICE** | The price a synthetic execution is booked at. | Historic misuse. **Eliminated** — `ExecutionManager` now takes prices explicitly. |
+
+A basis is *what it cost*. A mark is *what it is worth*. Substituting one for the other
+is the root defect; every rule below exists to enforce the distinction.
+
+---
+
+## 2. One live day, in order
+
+Equity runner: `apps/strategies/live_equity_mean_reversion.cpp`.
+
+| # | Step | Reads | Writes | Meaning in force |
+|---|---|---|---|---|
+| 1 | Load `previous_positions` from `trading.positions` | DB | — | COST BASIS (carried) |
+| 2 | Corporate actions restate the carried book | `previous_positions` | `previous_positions` (in place, non-const ref) | COST BASIS |
+| 3 | `LiveDailyCycle::prepare_strategy_for_signals` — seed `positions_`, then `on_data` | post-action `previous_positions` | strategy `positions_` | COST BASIS |
+| 4 | Optimizer / risk produce day-T targets | — | `positions` | *(undefined — see §4)* |
+| 5 | **Day-T placeholder** writes the T-1 close into `average_price` | `previous_day_close_prices` | `positions[*].average_price` | **MARK written into a basis field** |
+| 6 | `LiveDailyCycle::execute_day_t` — resolve prices, generate fills, roll back the unpriceable | explicit price map | `positions` (rollback only) | FILL PRICE, from a **separate map** |
+| 7 | `on_execution()` feeds fills back | executions | strategy `positions_` | COST BASIS |
+| 8 | `LiveDailyCycle::resolve_and_apply_basis` | strategy + carried basis | `positions[*].average_price`, `unrealized_pnl` | COST BASIS restored |
+| 9 | Persist | `positions` | `trading.positions` | COST BASIS |
+
+**Steps 5 → 8 are the danger window.** Between them `average_price` holds a *mark*.
+Anything reading it as a basis in that window reads a lie. Step 8 is what ends the
+window, and it must run before any persistence or basis-dependent logic.
+
+---
+
+## 3. Every reader, and which meaning it assumes
+
+| Site | Assumes | Safe? |
+|---|---|---|
+| `mean_reversion.cpp:391` (stop-loss) | COST BASIS | Yes — reads the strategy's own `positions_`, never the day-T map |
+| `LivePnLManager::unrealized_from_cost_basis` | COST BASIS | Yes — guards `average_price <= 0` |
+| `risk_manager.cpp:64,236,243` | MARK | Reachable only via dead callers (see §5) |
+| `margin_manager.cpp:30,165` | MARK | Same |
+| `execution_manager.cpp` (removed) | FILL PRICE | **Deleted** — was the root cause |
+
+---
+
+## 4. The rules
+
+1. **A fill is priced from a real close, or it is not priced at all.**
+   `ExecutionManager` has no fallback. Absent or non-positive price ⇒ ERROR, skip, and
+   report the symbol. It never reads `average_price`.
+
+2. **A missing T-1 close is not automatically fatal.**
+   `ExecutionPriceResolver` substitutes the most recent *real* close within a staleness
+   bound (`live.execution_price_max_staleness_days`, default 5 — a three-day weekend plus
+   a further holiday reaches Wednesday, the longest ordinary gap). Substitutions are
+   logged with the date they came from. A present T-1 close always wins, so the normal
+   path is unchanged.
+
+3. **A symbol that could not be priced did not trade.**
+   Its day-T target is rolled back to the carried quantity, or dropped if never held.
+   Otherwise the runner persists a position no execution supports — a phantom that reads
+   back next session as real.
+
+4. **A basis comes from the strategy or the carried book. Never from a mark.**
+   `resolve_day_t_cost_basis`: strategy → carried → unresolved.
+
+5. **The residual is loud and inert, never silent.**
+   Unresolved ⇒ ERROR naming the symbol, basis 0, unrealized 0. Previously the guard
+   `if (cost_basis > 0.0)` *skipped the write*, leaving step 5's mark in place — so the
+   one path that could not find a basis was the one path that substituted a mark for it.
+
+6. **Marks and fills come from the same map.**
+   `ExecutionOutcome::execution_prices` is returned and reused for marking, so P&L and
+   executions cannot disagree about what a symbol was worth.
+
+---
+
+## 5. Why seeding did not blow up risk
+
+Seeding (F-B) makes `positions_` non-empty in live where it was *always* empty. Risk and
+margin read `average_price` as a **mark**, so this was live blast radius. It is contained
+only because:
+
+- `portfolio_manager.cpp:1579` `get_positions_internal()` has two callers, **both dead** —
+  `:195` is documented in-tree as having no production consumer, and `:1509` sits inside
+  `get_portfolio_value(const map&)`, which has no callers anywhere.
+- `MeanReversionStrategy` **overrides** `get_target_positions()`, building from
+  `inst_data.target_position`. The base returns `positions_`; had it not overridden,
+  seeding would have become the day's targets directly.
+
+**This is a narrow escape resting on dead code.** If either caller is revived, or a
+strategy without that override is seeded, risk will start reading cost bases as marks.
+Pin this before adding a seeded strategy.
+
+---
+
+## 6. Traceability
+
+Every basis decision emits a `BASIS TRACE` line, so one symbol can be followed end to end:
+
+```
+BASIS TRACE | price widened | THIN @ 2026-08-27 (2 days stale) (no T-1 close; used most recent real session)
+BASIS TRACE | unpriced      | DELISTED has no close within 5 days - it did not trade today
+BASIS TRACE | rolled back   | DELISTED day-T target discarded, book restored to carried quantity 10.0
+BASIS TRACE | inputs        | AAPL strategy=150.25 carried=148.10
+BASIS TRACE | resolved      | AAPL basis=150.25 from strategy(on_execution)
+BASIS TRACE | UNRESOLVED    | ORPHAN holds a non-zero quantity with no cost basis ...
+```
+
+`grep 'BASIS TRACE.*<SYMBOL>'` reconstructs one symbol's full day.
+
+---
+
+## 7. What only a real run can settle
+
+Unit tests fix the *shape* of these rules. They do not prove the following, which belong
+to E2:
+
+- Whether any symbol in the 852-name universe actually lacks a T-1 close, and how often.
+- Whether 5 days is the right bound against the real equity calendar.
+- Whether the widened path fires on real data at a plausible rate (silence would suggest
+  it is not wired; constant firing would suggest a feed problem).
+- Whether `BASIS TRACE` reconciles against `trading.positions` row-for-row.
+- Whether the futures agricultural-Monday path (§8) ever reaches the skip in production.
+
+---
+
+## 8. Futures exposure
+
+`execution_manager.cpp` is shared. Removing the fallback is reachable for futures.
+
+**Not reachable** in the main agricultural-Monday case: the futures runners revert the
+position to Friday's quantity, so `current_qty == prev_qty`, the delta check fails, and no
+execution is generated — the fallback is never consulted. That logic is untouched.
+
+**Reachable** in one narrow branch: agricultural symbol, Monday, no T-1 price, *and no
+previous position* (`"No Sunday data and no previous position - keeping current"`). There
+the delta is non-zero and an execution is generated. Previously it was priced at
+`average_price`; now it is skipped with an ERROR.
+
+**This is an improvement, not a regression** — that execution was being booked at a cost
+basis, which for a new position is 0. Futures was silently exposed to the same
+zero-price defect. But it *is* a behaviour change on the futures path, and the futures
+runners were deliberately **not** given the widened lookup (equity-branch scope). Wiring
+`ExecutionPriceResolver` into the futures runners would convert that skip into a correct
+Friday-close fill and is the right follow-up — **merge-time, with a futures regression
+run**, not on this branch.

--- a/include/trade_ngin/core/config_loader.hpp
+++ b/include/trade_ngin/core/config_loader.hpp
@@ -167,11 +167,18 @@ struct LiveSpecificConfig {
     // as running on stale data. WARNs in historical-replay mode, ERRORs in true-live
     // mode (review T2.9). Default absorbs a weekend plus a holiday.
     int data_staleness_tolerance_days{4};
+    // How old (calendar days) a substituted close may be when a symbol has no T-1
+    // print and is about to trade. Five covers every ordinary session gap -- a
+    // three-day weekend plus a further holiday reaches Wednesday -- so anything
+    // beyond it means the symbol is halted or missing from the feed, not merely
+    // between sessions. Symbols exceeding the bound are not traded.
+    int execution_price_max_staleness_days{5};
 
     nlohmann::json to_json() const {
         nlohmann::json j;
         j["historical_days"] = historical_days;
         j["data_staleness_tolerance_days"] = data_staleness_tolerance_days;
+        j["execution_price_max_staleness_days"] = execution_price_max_staleness_days;
         return j;
     }
 
@@ -180,6 +187,9 @@ struct LiveSpecificConfig {
             historical_days = j.at("historical_days").get<int>();
         if (j.contains("data_staleness_tolerance_days"))
             data_staleness_tolerance_days = j.at("data_staleness_tolerance_days").get<int>();
+        if (j.contains("execution_price_max_staleness_days"))
+            execution_price_max_staleness_days =
+                j.at("execution_price_max_staleness_days").get<int>();
     }
 };
 

--- a/include/trade_ngin/live/execution_manager.hpp
+++ b/include/trade_ngin/live/execution_manager.hpp
@@ -30,6 +30,29 @@ namespace trade_ngin {
  * refactor. The "live" prefix is preserved for path stability; this
  * docstring is the authoritative description of the role.
  */
+
+/**
+ * How generate_daily_executions() prices a fill when market_prices has no usable
+ * entry for the symbol.
+ *
+ * The distinction exists because Position::average_price does not mean the same
+ * thing in every strategy. Futures trend-following assigns it the latest mark
+ * (trend_following.cpp:623, matching REALIZED_ONLY daily settlement), so falling
+ * back to it yields a real price. Equity mean reversion maintains it as a weighted
+ * cost basis, which for a position opened today is 0.00 until the fill being priced
+ * is itself processed -- so the same fallback books the trade at zero.
+ */
+enum class PricingPolicy {
+    /// Fall back to Position::average_price. Correct where that field holds a mark.
+    /// This is the historical behaviour and the default, so existing callers are
+    /// unaffected.
+    MARK_FALLBACK,
+
+    /// Never invent a price: skip the symbol with an ERROR and report it through
+    /// unpriced_out. For callers whose average_price is a cost basis.
+    STRICT
+};
+
 class ExecutionManager {
 private:
     // Transaction cost model (single source of truth)
@@ -52,13 +75,25 @@ public:
      *
      * @param current_positions Current day's positions
      * @param previous_positions Previous day's positions
-     * @param market_prices Market prices (typically T-1 close prices). MUST contain a
-     *        positive price for every symbol whose position changes. There is no
-     *        fallback: a symbol absent here, or priced <= 0, is SKIPPED with an ERROR
-     *        and generates no execution. Widen the map with ExecutionPriceResolver
-     *        before calling if legitimate session gaps are expected.
+     * @param market_prices Market prices (typically T-1 close prices).
      * @param timestamp Execution timestamp
-     * @param unpriced_out Optional. Receives the symbols that were skipped for want of
+     * @param pricing How to handle a symbol with no usable price in market_prices.
+     *
+     *        MARK_FALLBACK (default) is the long-standing behaviour and is CORRECT for
+     *        futures: TrendFollowingStrategy sets Position::average_price to
+     *        price_history.back() -- the latest mark, by design, matching REALIZED_ONLY
+     *        daily settlement (trend_following.cpp:623). Falling back to it prices the
+     *        fill at a real, one-session-stale close.
+     *
+     *        STRICT is for callers whose average_price is a weighted COST BASIS rather
+     *        than a mark -- equity mean reversion. There, a position opened today has no
+     *        basis until the very fill being priced is processed, so the fallback books
+     *        the trade at 0.00, which then persists as the new basis. Such a symbol is
+     *        skipped with an ERROR and reported through unpriced_out.
+     *
+     *        The same field means opposite things by asset class; this parameter is the
+     *        seam. See docs/AVERAGE_PRICE_LIFECYCLE.md.
+     * @param unpriced_out Optional, STRICT only. Receives the symbols skipped for want of
      *        a price. A skip is not a flat position and not a fill -- the caller must
      *        reconcile these before persisting, or the book will silently disagree with
      *        the executions.
@@ -69,6 +104,7 @@ public:
         const std::unordered_map<std::string, Position>& previous_positions,
         const std::unordered_map<std::string, double>& market_prices,
         const Timestamp& timestamp,
+        PricingPolicy pricing = PricingPolicy::MARK_FALLBACK,
         std::vector<std::string>* unpriced_out = nullptr);
 
     /**

--- a/include/trade_ngin/live/execution_manager.hpp
+++ b/include/trade_ngin/live/execution_manager.hpp
@@ -52,15 +52,24 @@ public:
      *
      * @param current_positions Current day's positions
      * @param previous_positions Previous day's positions
-     * @param market_prices Market prices (typically T-1 close prices)
+     * @param market_prices Market prices (typically T-1 close prices). MUST contain a
+     *        positive price for every symbol whose position changes. There is no
+     *        fallback: a symbol absent here, or priced <= 0, is SKIPPED with an ERROR
+     *        and generates no execution. Widen the map with ExecutionPriceResolver
+     *        before calling if legitimate session gaps are expected.
      * @param timestamp Execution timestamp
+     * @param unpriced_out Optional. Receives the symbols that were skipped for want of
+     *        a price. A skip is not a flat position and not a fill -- the caller must
+     *        reconcile these before persisting, or the book will silently disagree with
+     *        the executions.
      * @return Vector of execution reports
      */
     Result<std::vector<ExecutionReport>> generate_daily_executions(
         const std::unordered_map<std::string, Position>& current_positions,
         const std::unordered_map<std::string, Position>& previous_positions,
         const std::unordered_map<std::string, double>& market_prices,
-        const Timestamp& timestamp);
+        const Timestamp& timestamp,
+        std::vector<std::string>* unpriced_out = nullptr);
 
     /**
      * Generate a single execution report

--- a/include/trade_ngin/live/execution_price_resolver.hpp
+++ b/include/trade_ngin/live/execution_price_resolver.hpp
@@ -1,0 +1,97 @@
+#pragma once
+
+#include "trade_ngin/core/types.hpp"
+#include <map>
+#include <set>
+#include <string>
+#include <unordered_map>
+#include <vector>
+
+namespace trade_ngin {
+
+/**
+ * ExecutionPriceResolver - supplies a REAL close for every symbol about to trade.
+ *
+ * A synthetic execution has to be priced at something. Before this existed the
+ * answer, when the T-1 close was missing, was Position::average_price -- a cost
+ * basis. That is a category error: the basis is what a position cost, not what it
+ * is worth, and for a position opened today the basis is 0 until its fill has been
+ * processed. Pricing a fill off it books the trade at zero, persists the zero as the
+ * new basis, and reloads it the next session as a carried basis of zero.
+ *
+ * The fix is to widen the search rather than invent a number. A symbol with no T-1
+ * close usually has a perfectly good older one -- a halt, a thin name that did not
+ * print, an agricultural future with no Sunday session -- and that older close is a
+ * real price the position genuinely traded at. This resolver finds it in the bars the
+ * runner has already loaded, so it costs no extra query, and it reports how old the
+ * price is so the caller can refuse one that has gone stale.
+ *
+ * Symbols it cannot price are returned as unpriced. The caller must NOT trade them:
+ * no price means no execution, never a guessed one.
+ */
+class ExecutionPriceResolver {
+public:
+    /**
+     * Default bound on how old a substituted close may be, in calendar days.
+     *
+     * Five days covers every ordinary gap in a US session calendar: a three-day
+     * weekend (Fri -> Tue) plus one further holiday reaches Wednesday, which is the
+     * longest run the NYSE/CME calendars produce. It also covers the agricultural
+     * futures Sunday gap that the futures runners handle explicitly. Anything older
+     * means the symbol is not merely between sessions -- it is halted, delisted, or
+     * missing from the feed -- and a stale mark must not be presented as a live one.
+     */
+    static constexpr int kDefaultMaxStalenessDays = 5;
+
+    /** A close that was actually observed, with the session it came from. */
+    struct ResolvedClose {
+        double price = 0.0;
+        Timestamp as_of{};
+    };
+
+    /** What fill_missing() did, so the caller can log it and act on failures. */
+    struct FillReport {
+        /** Symbols priced from an older session: "SYM @ YYYY-MM-DD (N days stale)". */
+        std::vector<std::string> widened;
+        /** Symbols with no usable close at all. These must not be traded. */
+        std::vector<std::string> unpriced;
+
+        bool all_priced() const { return unpriced.empty(); }
+    };
+
+    /**
+     * Most recent close at or before `as_of`, per symbol, from already-loaded bars.
+     *
+     * Bars after `as_of` are ignored: an execution priced at T-1 must not reach
+     * forward into the session it is being generated for.
+     */
+    static std::unordered_map<std::string, ResolvedClose> latest_close_at_or_before(
+        const std::vector<Bar>& bars,
+        const Timestamp& as_of);
+
+    /**
+     * Fill gaps in `prices` for the symbols in `needed`, from `fallback`.
+     *
+     * Only symbols absent from `prices` are touched -- a present T-1 close always
+     * wins, so the normal path is bit-identical to not calling this at all. A
+     * fallback older than `max_staleness_days`, or a non-positive one, is refused and
+     * the symbol is reported unpriced rather than being silently substituted.
+     *
+     * @param prices  [in,out] symbol -> close. Modified in place.
+     * @param fallback  from latest_close_at_or_before().
+     * @param needed  symbols that are about to trade and therefore must be priced.
+     * @param as_of  the reference session, for computing staleness.
+     * @param max_staleness_days  bound; see kDefaultMaxStalenessDays.
+     */
+    static FillReport fill_missing(
+        std::unordered_map<std::string, double>& prices,
+        const std::unordered_map<std::string, ResolvedClose>& fallback,
+        const std::set<std::string>& needed,
+        const Timestamp& as_of,
+        int max_staleness_days = kDefaultMaxStalenessDays);
+
+    /** Whole calendar days between two timestamps, floored at 0. */
+    static long staleness_days(const Timestamp& as_of, const Timestamp& observed);
+};
+
+}  // namespace trade_ngin

--- a/include/trade_ngin/live/live_daily_cycle.hpp
+++ b/include/trade_ngin/live/live_daily_cycle.hpp
@@ -129,8 +129,12 @@ public:
         outcome.widened_prices = fill.widened;
         outcome.execution_prices = execution_prices;
 
+        // STRICT: mean reversion's average_price is a weighted cost basis, so the
+        // mark fallback would price a new position's fill at 0.00. Futures callers
+        // keep MARK_FALLBACK, where that field holds a mark and the fallback is right.
         auto exec_result = execution_manager.generate_daily_executions(
-            positions, previous_positions, execution_prices, now, &outcome.unpriced);
+            positions, previous_positions, execution_prices, now,
+            PricingPolicy::STRICT, &outcome.unpriced);
         if (exec_result.is_error()) {
             return make_error<ExecutionOutcome>(exec_result.error()->code(),
                                                 exec_result.error()->what(),

--- a/include/trade_ngin/live/live_daily_cycle.hpp
+++ b/include/trade_ngin/live/live_daily_cycle.hpp
@@ -1,11 +1,16 @@
 // include/trade_ngin/live/live_daily_cycle.hpp
 #pragma once
 
-#include <unordered_map>
+#include <algorithm>
+#include <set>
 #include <string>
+#include <unordered_map>
 #include <vector>
 
 #include "trade_ngin/core/error.hpp"
+#include "trade_ngin/live/execution_manager.hpp"
+#include "trade_ngin/live/execution_price_resolver.hpp"
+#include "trade_ngin/live/live_pnl_manager.hpp"
 #include "trade_ngin/strategy/base_strategy.hpp"
 
 namespace trade_ngin {
@@ -54,6 +59,163 @@ public:
         auto seeded = strategy.seed_positions(previous_positions);
         if (seeded.is_error()) return seeded;
         return strategy.on_data(bars);
+    }
+
+    /** What one day's execution step did, beyond the fills themselves. */
+    struct ExecutionOutcome {
+        std::vector<ExecutionReport> executions;
+        /** Symbols priced from an older real session: "SYM @ date (N days stale)". */
+        std::vector<std::string> widened_prices;
+        /** Symbols with no usable price. These did not trade. */
+        std::vector<std::string> unpriced;
+        /** Symbols whose day-T target was rolled back because they did not trade. */
+        std::vector<std::string> rolled_back;
+        /**
+         * The prices the fills were actually generated at, T-1 closes plus any
+         * widened substitutes. Returned so the caller marks positions with the same
+         * numbers it traded at: marking from a different map than the one that priced
+         * the executions is how a log-versus-DB disagreement starts.
+         */
+        std::unordered_map<std::string, double> execution_prices;
+    };
+
+    /**
+     * @brief Price the day's trades, generate them, and keep the book honest about
+     *        what did not happen.
+     *
+     * Three rules, in order, each of which was learned from a defect:
+     *
+     * 1. A fill is priced from a REAL close or it is not priced at all. The previous
+     *    behaviour fell back to Position::average_price -- a cost basis, and 0 for a
+     *    position opened today -- which booked fills at zero, persisted the zero as
+     *    the new basis, and reloaded it the next session as a carried basis of zero.
+     *
+     * 2. A missing T-1 close is not automatically fatal. Halts, thin names and the
+     *    session after a holiday leave a symbol without a print but with a perfectly
+     *    good older close, and that close is a real price. It is substituted only
+     *    within a staleness bound and only when T-1 is genuinely absent.
+     *
+     * 3. A symbol that could not be priced did not trade, so the day-T book must not
+     *    claim it did. Its target is rolled back to the carried quantity (or dropped
+     *    if it was never held). Without this the runner persists a position no
+     *    execution supports -- a phantom that reads back next session as real.
+     *
+     * @param positions [in,out] the day-T target book. Rolled back in place for any
+     *        symbol that could not be priced.
+     */
+    static Result<ExecutionOutcome> execute_day_t(
+        ExecutionManager& execution_manager,
+        std::unordered_map<std::string, Position>& positions,
+        const std::unordered_map<std::string, Position>& previous_positions,
+        const std::unordered_map<std::string, double>& t1_closes,
+        const std::vector<Bar>& bars,
+        const Timestamp& now,
+        int max_staleness_days = ExecutionPriceResolver::kDefaultMaxStalenessDays) {
+
+        ExecutionOutcome outcome;
+
+        std::set<std::string> needed;
+        for (const auto& [symbol, position] : positions) {
+            if (position.quantity.as_double() != 0.0) needed.insert(symbol);
+        }
+        for (const auto& [symbol, position] : previous_positions) {
+            if (position.quantity.as_double() != 0.0) needed.insert(symbol);
+        }
+
+        std::unordered_map<std::string, double> execution_prices = t1_closes;
+        auto widened = ExecutionPriceResolver::latest_close_at_or_before(bars, now);
+        auto fill = ExecutionPriceResolver::fill_missing(execution_prices, widened, needed, now,
+                                                         max_staleness_days);
+        outcome.widened_prices = fill.widened;
+        outcome.execution_prices = execution_prices;
+
+        auto exec_result = execution_manager.generate_daily_executions(
+            positions, previous_positions, execution_prices, now, &outcome.unpriced);
+        if (exec_result.is_error()) {
+            return make_error<ExecutionOutcome>(exec_result.error()->code(),
+                                                exec_result.error()->what(),
+                                                "LiveDailyCycle::execute_day_t");
+        }
+        outcome.executions = exec_result.value();
+
+        // Rule 3: the book must not record a trade that did not happen.
+        for (const auto& symbol : outcome.unpriced) {
+            auto prev_it = previous_positions.find(symbol);
+            if (prev_it != previous_positions.end() &&
+                prev_it->second.quantity.as_double() != 0.0) {
+                positions[symbol] = prev_it->second;
+                positions[symbol].last_update = now;
+            } else {
+                positions.erase(symbol);
+            }
+            outcome.rolled_back.push_back(symbol);
+        }
+
+        return Result<ExecutionOutcome>(outcome);
+    }
+
+    /**
+     * @brief The cost basis to persist for each day-T position, and why.
+     *
+     * Runs AFTER executions have been fed back through on_execution(), which is what
+     * gives a symbol that traded today its weighted-average basis. Everything else is
+     * a carried holding whose basis came from the seeded book.
+     *
+     * The residual -- a held position neither source knows -- should be unreachable.
+     * It is handled rather than ignored because the previous code ignored it, and
+     * "ignore" meant leaving the day-T placeholder in place. That placeholder was the
+     * previous close, so the one path that could not find a basis was the one path
+     * that silently substituted a mark for it.
+     *
+     * @param positions [in,out] day-T book; average_price and unrealized_pnl written.
+     * @return symbols that hit the residual, for the caller to log loudly.
+     */
+    static std::vector<std::string> resolve_and_apply_basis(
+        std::unordered_map<std::string, Position>& positions,
+        const std::unordered_map<std::string, Position>& strategy_positions,
+        const std::unordered_map<std::string, Position>& previous_positions,
+        const std::unordered_map<std::string, double>& marks) {
+
+        std::vector<std::string> unresolved;
+
+        for (auto& [symbol, position] : positions) {
+            double strategy_basis = 0.0;
+            auto strat_it = strategy_positions.find(symbol);
+            if (strat_it != strategy_positions.end()) {
+                strategy_basis = strat_it->second.average_price.as_double();
+            }
+
+            double carried_basis = 0.0;
+            auto carried_it = previous_positions.find(symbol);
+            if (carried_it != previous_positions.end() &&
+                carried_it->second.quantity.as_double() != 0.0) {
+                carried_basis = carried_it->second.average_price.as_double();
+            }
+
+            double basis = LivePnLManager::resolve_day_t_cost_basis(strategy_basis, carried_basis);
+
+            if (basis > 0.0) {
+                position.average_price = Decimal(basis);
+                double mark = 0.0;
+                auto mark_it = marks.find(symbol);
+                if (mark_it != marks.end()) mark = mark_it->second;
+                if (mark > 0.0) {
+                    position.unrealized_pnl = Decimal(LivePnLManager::unrealized_from_cost_basis(
+                        position.quantity.as_double(), basis, mark));
+                }
+            } else if (position.quantity.as_double() != 0.0) {
+                position.average_price = Decimal(0.0);
+                position.unrealized_pnl = Decimal(0.0);
+                unresolved.push_back(symbol);
+            }
+
+            if (strat_it != strategy_positions.end()) {
+                position.realized_pnl = strat_it->second.realized_pnl;
+            }
+        }
+
+        std::sort(unresolved.begin(), unresolved.end());
+        return unresolved;
     }
 };
 

--- a/include/trade_ngin/live/live_daily_cycle.hpp
+++ b/include/trade_ngin/live/live_daily_cycle.hpp
@@ -1,0 +1,60 @@
+// include/trade_ngin/live/live_daily_cycle.hpp
+#pragma once
+
+#include <unordered_map>
+#include <string>
+#include <vector>
+
+#include "trade_ngin/core/error.hpp"
+#include "trade_ngin/strategy/base_strategy.hpp"
+
+namespace trade_ngin {
+
+/**
+ * @brief Ordering rules for one live trading day.
+ *
+ * These live in a named place because they are ordering constraints, not
+ * computations: getting them wrong produces a runner that reads correctly
+ * line by line and is still silently wrong. Extracted from
+ * apps/strategies/live_equity_mean_reversion.cpp so they can be tested
+ * without standing up a database and a full trading day.
+ */
+class LiveDailyCycle {
+public:
+    /**
+     * @brief Put a live strategy into the state signal generation assumes,
+     *        then generate the day's signals.
+     *
+     * A live runner is a fresh process every session: BaseStrategy::positions_
+     * starts empty and on_execution() -- its only writer -- does not run until
+     * AFTER targets have been extracted. A strategy whose signal depends on what
+     * it currently holds therefore sees an empty book on every bar of every
+     * session unless the previous day's holdings are seeded back in first.
+     *
+     * MeanReversionStrategy::generate_signal() is exactly such a strategy: it
+     * branches on positions_ to choose between its entry rule and its exit rule.
+     * Unseeded it takes the entry branch forever, so a held position is
+     * liquidated as soon as its z-score leaves the entry zone -- at the ENTRY
+     * threshold rather than the (much closer to zero) EXIT threshold -- and the
+     * stop-loss, which measures from Position::average_price, can never fire
+     * because there is no position to measure. Backtests are unaffected: one
+     * process runs the whole history, so positions_ accumulates through
+     * on_execution() and is never empty at the wrong moment.
+     *
+     * @param previous_positions The previous day's book AFTER corporate actions
+     *        have been applied. Order matters here too: splits restate quantity
+     *        and dividends restate cost basis, so seeding the pre-adjustment
+     *        snapshot would anchor the strategy to a book that no longer exists.
+     * @param bars The day's market data.
+     */
+    static Result<void> prepare_strategy_for_signals(
+        BaseStrategy& strategy,
+        const std::unordered_map<std::string, Position>& previous_positions,
+        const std::vector<Bar>& bars) {
+        auto seeded = strategy.seed_positions(previous_positions);
+        if (seeded.is_error()) return seeded;
+        return strategy.on_data(bars);
+    }
+};
+
+}  // namespace trade_ngin

--- a/include/trade_ngin/live/live_pnl_manager.hpp
+++ b/include/trade_ngin/live/live_pnl_manager.hpp
@@ -84,12 +84,23 @@ public:
      * @param carried_basis The basis the same symbol carries in the previous day's
      *        book, AFTER corporate actions have restated it. <= 0 when the symbol
      *        is not a carried-over holding.
-     * @return the basis to record, or 0.0 when neither source knows one. A new
-     *         position genuinely has no basis until its fill is processed, and
-     *         unrealized_from_cost_basis() reads 0.0 as "no PnL to report" rather
-     *         than booking the whole notional. A mark is deliberately never a
-     *         candidate: the day's close is what the position is worth, not what
-     *         it cost, and substituting one for the other is the bug above.
+     * @return the basis to record, or 0.0 when neither source knows one. A mark is
+     *         deliberately never a candidate: the day's close is what the position is
+     *         worth, not what it cost, and substituting one for the other is the bug
+     *         above.
+     *
+     * On the 0.0 return: it means "no basis is known", and it is the CALLER's job to
+     * decide what that means for a row it is about to persist. Do not read it as a
+     * price and do not skip the write and leave the day-T placeholder in place -- that
+     * placeholder is the previous close, so skipping reinstates the very mark-as-basis
+     * substitution this function exists to prevent. The equity runner treats it as an
+     * upstream invariant failure: it logs the symbol and records a zero basis with zero
+     * unrealized PnL, so the row reads as incomplete rather than as a plausible lie.
+     *
+     * In normal flow it should be unreachable for a held position. Every holding has a
+     * basis -- it either traded today, in which case on_execution() set one from a fill
+     * that ExecutionManager refused to price without a real close, or it was carried,
+     * in which case the seeded book supplied one.
      */
     static double resolve_day_t_cost_basis(double strategy_basis, double carried_basis) {
         if (strategy_basis > 0.0) return strategy_basis;

--- a/include/trade_ngin/live/live_pnl_manager.hpp
+++ b/include/trade_ngin/live/live_pnl_manager.hpp
@@ -65,6 +65,39 @@ public:
     }
 
     /**
+     * @brief The cost basis to record against a position on day T.
+     *
+     * A basis is established when a position is opened and has to survive every
+     * day it is held: realized PnL on exit, unrealized PnL while held, and the
+     * mean-reversion stop-loss are all measured from it. The equity runner used to
+     * seed every day-T position's average_price with the previous session's close
+     * and then correct only the symbols the strategy knew about -- which, because
+     * positions_ was never seeded, meant only the symbols that traded that day. A
+     * held-but-untraded position therefore had its basis re-anchored to the latest
+     * close every session: it always looked flat, its unrealized PnL was always
+     * ~0, and its stop-loss measured from yesterday rather than from what it cost.
+     *
+     * @param strategy_basis The weighted average BaseStrategy::on_execution()
+     *        maintains. Authoritative when set: a symbol that traded today has a
+     *        basis that already accounts for today's fills. <= 0 when the strategy
+     *        has no record of the symbol.
+     * @param carried_basis The basis the same symbol carries in the previous day's
+     *        book, AFTER corporate actions have restated it. <= 0 when the symbol
+     *        is not a carried-over holding.
+     * @return the basis to record, or 0.0 when neither source knows one. A new
+     *         position genuinely has no basis until its fill is processed, and
+     *         unrealized_from_cost_basis() reads 0.0 as "no PnL to report" rather
+     *         than booking the whole notional. A mark is deliberately never a
+     *         candidate: the day's close is what the position is worth, not what
+     *         it cost, and substituting one for the other is the bug above.
+     */
+    static double resolve_day_t_cost_basis(double strategy_basis, double carried_basis) {
+        if (strategy_basis > 0.0) return strategy_basis;
+        if (carried_basis > 0.0) return carried_basis;
+        return 0.0;
+    }
+
+    /**
      * Finalization result structure for Day T-1
      */
     struct FinalizationResult {

--- a/src/live/execution_manager.cpp
+++ b/src/live/execution_manager.cpp
@@ -12,6 +12,7 @@ Result<std::vector<ExecutionReport>> ExecutionManager::generate_daily_executions
     const std::unordered_map<std::string, Position>& previous_positions,
     const std::unordered_map<std::string, double>& market_prices,
     const Timestamp& timestamp,
+    PricingPolicy pricing,
     std::vector<std::string>* unpriced_out) {
 
     INFO("Generating execution reports for position changes...");
@@ -37,16 +38,19 @@ Result<std::vector<ExecutionReport>> ExecutionManager::generate_daily_executions
         if (std::abs(current_qty - prev_qty) > 1e-6) {
             double trade_size = current_qty - prev_qty;
 
-            // Market price (Day T-1 close for Day T execution). There is deliberately
-            // no fallback: average_price is a COST BASIS, and pricing a fill off it
-            // books the trade at what the position cost -- 0 for a position opened
-            // today, whose basis is not established until this very execution is
-            // processed. That zero then persists as the new basis and reloads the next
-            // session as a carried basis of zero. A symbol we cannot price is a symbol
-            // we must not trade; the caller widens the price search before getting
-            // here (see ExecutionPriceResolver) and is told what remains unpriced.
+            // Market price (Day T-1 close for Day T execution). What happens when the
+            // map has no usable entry depends on what average_price means to THIS
+            // caller -- see PricingPolicy. Futures assigns it the latest mark, so the
+            // fallback yields a real price; equity mean reversion maintains it as a
+            // cost basis, which is 0.00 for a position opened today.
             auto price_it = market_prices.find(symbol);
-            if (price_it == market_prices.end() || price_it->second <= 0.0) {
+            double market_price = 0.0;
+            if (price_it != market_prices.end() && price_it->second > 0.0) {
+                market_price = price_it->second;
+            } else if (pricing == PricingPolicy::MARK_FALLBACK) {
+                market_price = current_position.average_price.as_double();
+                WARN("No market price for " + symbol + ", using average price");
+            } else {
                 ERROR("No usable market price for " + symbol +
                       " - skipping execution for a position change of " +
                       std::to_string(trade_size) +
@@ -54,7 +58,6 @@ Result<std::vector<ExecutionReport>> ExecutionManager::generate_daily_executions
                 unpriced_symbols.push_back(symbol);
                 continue;
             }
-            double market_price = price_it->second;
 
             // Generate execution
             ExecutionReport exec = generate_execution(
@@ -75,18 +78,24 @@ Result<std::vector<ExecutionReport>> ExecutionManager::generate_daily_executions
             // This position was completely closed
             double prev_qty = prev_position.quantity.as_double();
 
-            // Same rule as the position-change path above: a close-out priced at the
-            // position's own cost basis books a fill at what it cost rather than what
-            // it is worth, which silently reports zero realized PnL on the exit.
+            // Same rule as the position-change path above; see PricingPolicy. Under
+            // STRICT, a close-out priced at the position's own cost basis would book
+            // the exit at what it cost rather than what it is worth, silently
+            // reporting zero realized PnL.
             auto price_it = market_prices.find(symbol);
-            if (price_it == market_prices.end() || price_it->second <= 0.0) {
+            double market_price = 0.0;
+            if (price_it != market_prices.end() && price_it->second > 0.0) {
+                market_price = price_it->second;
+            } else if (pricing == PricingPolicy::MARK_FALLBACK) {
+                market_price = prev_position.average_price.as_double();
+                WARN("No market price for closed position " + symbol + ", using average price");
+            } else {
                 ERROR("No usable market price to close " + symbol + " (quantity " +
                       std::to_string(prev_qty) +
-                      ") - skipping execution. The position remains OPEN today.");
+                      ") - skipping execution. The caller must reconcile this symbol.");
                 unpriced_symbols.push_back(symbol);
                 continue;
             }
-            double market_price = price_it->second;
 
             // Generate execution for closing (opposite side of position)
             double trade_size = -prev_qty; // Negative because we're closing

--- a/src/live/execution_manager.cpp
+++ b/src/live/execution_manager.cpp
@@ -1,5 +1,6 @@
 #include "trade_ngin/live/execution_manager.hpp"
 #include "trade_ngin/core/logger.hpp"
+#include <algorithm>
 #include <cmath>
 #include <sstream>
 #include <iomanip>
@@ -10,10 +11,12 @@ Result<std::vector<ExecutionReport>> ExecutionManager::generate_daily_executions
     const std::unordered_map<std::string, Position>& current_positions,
     const std::unordered_map<std::string, Position>& previous_positions,
     const std::unordered_map<std::string, double>& market_prices,
-    const Timestamp& timestamp) {
+    const Timestamp& timestamp,
+    std::vector<std::string>* unpriced_out) {
 
     INFO("Generating execution reports for position changes...");
     std::vector<ExecutionReport> daily_executions;
+    std::vector<std::string> unpriced_symbols;
 
     // Handle existing positions that changed
     for (const auto& [symbol, current_position] : current_positions) {
@@ -34,14 +37,24 @@ Result<std::vector<ExecutionReport>> ExecutionManager::generate_daily_executions
         if (std::abs(current_qty - prev_qty) > 1e-6) {
             double trade_size = current_qty - prev_qty;
 
-            // Get market price (Day T-1 close price for Day T execution)
-            double market_price = current_position.average_price.as_double();
+            // Market price (Day T-1 close for Day T execution). There is deliberately
+            // no fallback: average_price is a COST BASIS, and pricing a fill off it
+            // books the trade at what the position cost -- 0 for a position opened
+            // today, whose basis is not established until this very execution is
+            // processed. That zero then persists as the new basis and reloads the next
+            // session as a carried basis of zero. A symbol we cannot price is a symbol
+            // we must not trade; the caller widens the price search before getting
+            // here (see ExecutionPriceResolver) and is told what remains unpriced.
             auto price_it = market_prices.find(symbol);
-            if (price_it != market_prices.end()) {
-                market_price = price_it->second;
-            } else {
-                WARN("No market price for " + symbol + ", using average price");
+            if (price_it == market_prices.end() || price_it->second <= 0.0) {
+                ERROR("No usable market price for " + symbol +
+                      " - skipping execution for a position change of " +
+                      std::to_string(trade_size) +
+                      ". This symbol will NOT be traded today.");
+                unpriced_symbols.push_back(symbol);
+                continue;
             }
+            double market_price = price_it->second;
 
             // Generate execution
             ExecutionReport exec = generate_execution(
@@ -62,14 +75,18 @@ Result<std::vector<ExecutionReport>> ExecutionManager::generate_daily_executions
             // This position was completely closed
             double prev_qty = prev_position.quantity.as_double();
 
-            // Get market price (Day T-1 close price for closing on Day T)
-            double market_price = prev_position.average_price.as_double(); // Default fallback
+            // Same rule as the position-change path above: a close-out priced at the
+            // position's own cost basis books a fill at what it cost rather than what
+            // it is worth, which silently reports zero realized PnL on the exit.
             auto price_it = market_prices.find(symbol);
-            if (price_it != market_prices.end()) {
-                market_price = price_it->second;
-            } else {
-                WARN("No market price for closed position " + symbol + ", using average price");
+            if (price_it == market_prices.end() || price_it->second <= 0.0) {
+                ERROR("No usable market price to close " + symbol + " (quantity " +
+                      std::to_string(prev_qty) +
+                      ") - skipping execution. The position remains OPEN today.");
+                unpriced_symbols.push_back(symbol);
+                continue;
             }
+            double market_price = price_it->second;
 
             // Generate execution for closing (opposite side of position)
             double trade_size = -prev_qty; // Negative because we're closing
@@ -85,6 +102,22 @@ Result<std::vector<ExecutionReport>> ExecutionManager::generate_daily_executions
     }
 
     INFO("Generated " + std::to_string(daily_executions.size()) + " execution reports");
+
+    if (!unpriced_symbols.empty()) {
+        std::sort(unpriced_symbols.begin(), unpriced_symbols.end());
+        unpriced_symbols.erase(std::unique(unpriced_symbols.begin(), unpriced_symbols.end()),
+                               unpriced_symbols.end());
+        std::string joined;
+        for (const auto& s : unpriced_symbols) {
+            if (!joined.empty()) joined += ", ";
+            joined += s;
+        }
+        ERROR("Skipped " + std::to_string(unpriced_symbols.size()) +
+              " symbol(s) with no usable market price: " + joined +
+              ". Their intended position changes did NOT execute.");
+    }
+    if (unpriced_out) *unpriced_out = unpriced_symbols;
+
     return Result<std::vector<ExecutionReport>>(daily_executions);
 }
 

--- a/src/live/execution_price_resolver.cpp
+++ b/src/live/execution_price_resolver.cpp
@@ -1,0 +1,100 @@
+#include "trade_ngin/live/execution_price_resolver.hpp"
+
+#include <algorithm>
+#include <chrono>
+#include <ctime>
+#include <iomanip>
+#include <sstream>
+
+namespace trade_ngin {
+
+namespace {
+
+/** UTC YYYY-MM-DD, matching the date convention the equity path settled on. */
+std::string format_utc_date(const Timestamp& ts) {
+    std::time_t t = std::chrono::system_clock::to_time_t(ts);
+    std::tm tm_utc{};
+#ifdef _WIN32
+    gmtime_s(&tm_utc, &t);
+#else
+    gmtime_r(&t, &tm_utc);
+#endif
+    std::ostringstream os;
+    os << std::put_time(&tm_utc, "%Y-%m-%d");
+    return os.str();
+}
+
+}  // namespace
+
+long ExecutionPriceResolver::staleness_days(const Timestamp& as_of, const Timestamp& observed) {
+    if (observed >= as_of) return 0;
+    auto gap = std::chrono::duration_cast<std::chrono::hours>(as_of - observed).count();
+    return static_cast<long>(gap / 24);
+}
+
+std::unordered_map<std::string, ExecutionPriceResolver::ResolvedClose>
+ExecutionPriceResolver::latest_close_at_or_before(const std::vector<Bar>& bars,
+                                                  const Timestamp& as_of) {
+    std::unordered_map<std::string, ResolvedClose> out;
+    out.reserve(bars.size() / 4 + 1);
+
+    for (const auto& bar : bars) {
+        // Never reach forward into the session being generated.
+        if (bar.timestamp > as_of) continue;
+
+        double close = bar.close.as_double();
+        // A non-positive close is not a price. Skip rather than record it, so a bad
+        // row cannot become the "most recent" observation and mask a good older one.
+        if (close <= 0.0) continue;
+
+        auto it = out.find(bar.symbol);
+        if (it == out.end()) {
+            out.emplace(bar.symbol, ResolvedClose{close, bar.timestamp});
+        } else if (bar.timestamp > it->second.as_of) {
+            it->second.price = close;
+            it->second.as_of = bar.timestamp;
+        }
+    }
+
+    return out;
+}
+
+ExecutionPriceResolver::FillReport ExecutionPriceResolver::fill_missing(
+    std::unordered_map<std::string, double>& prices,
+    const std::unordered_map<std::string, ResolvedClose>& fallback,
+    const std::set<std::string>& needed,
+    const Timestamp& as_of,
+    int max_staleness_days) {
+
+    FillReport report;
+
+    for (const auto& symbol : needed) {
+        auto existing = prices.find(symbol);
+        if (existing != prices.end() && existing->second > 0.0) {
+            // A real T-1 close is already present: leave it exactly as it was.
+            continue;
+        }
+
+        auto fb = fallback.find(symbol);
+        if (fb == fallback.end() || fb->second.price <= 0.0) {
+            report.unpriced.push_back(symbol);
+            continue;
+        }
+
+        long stale = staleness_days(as_of, fb->second.as_of);
+        if (stale > max_staleness_days) {
+            report.unpriced.push_back(symbol);
+            continue;
+        }
+
+        prices[symbol] = fb->second.price;
+        report.widened.push_back(symbol + " @ " + format_utc_date(fb->second.as_of) + " (" +
+                                 std::to_string(stale) + " days stale)");
+    }
+
+    std::sort(report.widened.begin(), report.widened.end());
+    std::sort(report.unpriced.begin(), report.unpriced.end());
+    return report;
+}
+
+}  // namespace trade_ngin

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -84,6 +84,7 @@ set(TEST_SOURCES
     strategy/test_live_bt_signal_consistency.cpp
     strategy/test_volatility_size_1_nan_guard.cpp
     strategy/test_stale_unrealized_pnl_zero_avg_price.cpp
+    strategy/test_live_daily_cycle_seeding.cpp
     statistics/test_normalizer.cpp
     statistics/test_pca.cpp
     statistics/test_adf.cpp

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -67,6 +67,7 @@ set(TEST_SOURCES
     live/test_live_price_manager.cpp
     live/test_live_trading_coordinator_keying.cpp
     live/test_execution_manager.cpp
+    live/test_execution_price_integrity.cpp
     live/test_margin_manager.cpp
     live/test_live_metrics_calculator.cpp
     live/test_live_pnl_manager.cpp

--- a/tests/live/corp_actions/test_applier.cpp
+++ b/tests/live/corp_actions/test_applier.cpp
@@ -529,3 +529,65 @@ TEST(CorpActionsUltrareviewFixes, DividendFallsBackToCurrentQtyWhenExDateQtyUnse
 // $0.50/share, total_cash should be $100, not $50.
 
 }  // namespace applier_ex_date_qty
+
+namespace unresolvable_denominator {
+using namespace applier_core;
+
+// A dividend whose ex-date close could not be established must be SKIPPED, and
+// the skip must leave NO PositionAdjustment behind.
+//
+// This is load-bearing, not cosmetic. The runner used to fall back to today's
+// T-1 close when no historical close was available, which sails past the
+// applier's positive-close guard and applies the dividend against the wrong
+// denominator: DD's 2025-11-03 dividend of $47.50 against its ex-date close of
+// $34.69 is a ratio of 2.3693, but against a later close of $136.98 it is
+// 1.3468 -- a true basis of $100 persisted as $175.92. The fix removes that
+// fallback so the close arrives here as 0.0 and the event is skipped.
+//
+// The skip is only recoverable because CorporateActionsAuditLog::record() takes
+// a PositionAdjustment: no adjustment means no trading.corp_action_applied row,
+// which means is_applied() does not block the event and a later run retries it
+// once price history covers the ex-date. If the applier ever starts emitting an
+// adjustment for a skipped event, the dedup row would pin an unapplied dividend
+// permanently -- so these assertions guard the mechanism, not just the arithmetic.
+
+TEST(CorpActionsApplierTest, DividendWithNoEstablishedCloseIsSkippedAndLeavesNoAdjustment) {
+    std::unordered_map<std::string, Position> positions;
+    positions["DD"] = make_position("DD", 100.0, 100.0);
+
+    auto log = CorporateActionsApplier::apply(
+        positions, {dividend_event("DD", "2025-11-03", 47.50, /*close_tm1=*/0.0)});
+
+    EXPECT_TRUE(log.empty())
+        << "a skipped dividend must produce no adjustment, or the dedup row would "
+           "pin it as applied and it could never be retried";
+    EXPECT_DOUBLE_EQ(positions["DD"].average_price.as_double(), 100.0)
+        << "cost basis must be left untouched, not rescaled by a fabricated ratio";
+    EXPECT_DOUBLE_EQ(positions["DD"].quantity.as_double(), 100.0);
+}
+
+// The specific corruption the fix prevents, stated as arithmetic: had the
+// runner's old fallback supplied a later close, the basis would have been
+// rescaled by the wrong ratio. Pins the correct denominator's result so a
+// regression shows up as a number, not a philosophy.
+TEST(CorpActionsApplierTest, DividendUsesTheExDateCloseNotALaterOne) {
+    std::unordered_map<std::string, Position> correct;
+    correct["DD"] = make_position("DD", 100.0, 100.0);
+    CorporateActionsApplier::apply(
+        correct, {dividend_event("DD", "2025-11-03", 47.50, /*ex-date close=*/34.69)});
+
+    std::unordered_map<std::string, Position> wrong;
+    wrong["DD"] = make_position("DD", 100.0, 100.0);
+    CorporateActionsApplier::apply(
+        wrong, {dividend_event("DD", "2025-11-03", 47.50, /*a later close=*/136.98)});
+
+    // 100 / (1 + 47.50/34.69) = 42.207 ; 100 / (1 + 47.50/136.98) = 74.252
+    EXPECT_NEAR(correct["DD"].average_price.as_double(), 42.21, 0.01);
+    EXPECT_NEAR(wrong["DD"].average_price.as_double(), 74.252, 0.01);
+    EXPECT_GT(std::abs(wrong["DD"].average_price.as_double() -
+                       correct["DD"].average_price.as_double()),
+              30.0)
+        << "the denominator's date is worth ~76% of the cost basis on this event";
+}
+
+}  // namespace unresolvable_denominator

--- a/tests/live/test_execution_manager.cpp
+++ b/tests/live/test_execution_manager.cpp
@@ -104,15 +104,73 @@ TEST_F(ExecutionManagerTest, ClosedShortPositionGeneratesBuyExecution) {
     EXPECT_EQ(r.value()[0].side, Side::BUY);
 }
 
-TEST_F(ExecutionManagerTest, MissingMarketPriceFallsBackToAveragePrice) {
+// This test used to be MissingMarketPriceFallsBackToAveragePrice and asserted that a
+// symbol with no market price was filled at its average_price. That fallback was the
+// bug: average_price is a COST BASIS, and for a position opened today it is 0 until
+// the fill being priced has been processed -- so the fallback booked fills at zero,
+// persisted the zero as the new basis, and reloaded it the next session as a carried
+// basis of zero. The old assertion passed only because the fixture handed it a
+// pre-set basis of 4500.0, which production does not have for a new position.
+//
+// A symbol we cannot price is a symbol we must not trade.
+TEST_F(ExecutionManagerTest, MissingMarketPriceSkipsTheExecutionRatherThanPricingItFromBasis) {
     ExecutionManager em;
     std::unordered_map<std::string, Position> curr{{"ES", make_position("ES", 2.0, 4500.0)}};
     std::unordered_map<std::string, Position> prev;
     std::unordered_map<std::string, double> prices;  // no price for ES
+    std::vector<std::string> unpriced;
+    auto r = em.generate_daily_executions(curr, prev, prices, std::chrono::system_clock::now(),
+                                          &unpriced);
+    ASSERT_TRUE(r.is_ok());
+    EXPECT_TRUE(r.value().empty()) << "an unpriceable symbol must not generate an execution";
+    ASSERT_EQ(unpriced.size(), 1u);
+    EXPECT_EQ(unpriced[0], "ES");
+}
+
+// A brand-new position has no basis at all. This is the production shape the old
+// fallback actually met, and the one that made the zero self-sustaining.
+TEST_F(ExecutionManagerTest, MissingMarketPriceOnAZeroBasisPositionDoesNotFillAtZero) {
+    ExecutionManager em;
+    std::unordered_map<std::string, Position> curr{{"ES", make_position("ES", 2.0, 0.0)}};
+    std::unordered_map<std::string, Position> prev;
+    std::unordered_map<std::string, double> prices;
     auto r = em.generate_daily_executions(curr, prev, prices, std::chrono::system_clock::now());
     ASSERT_TRUE(r.is_ok());
-    ASSERT_EQ(r.value().size(), 1u);
-    EXPECT_DOUBLE_EQ(r.value()[0].fill_price.as_double(), 4500.0);
+    for (const auto& e : r.value()) {
+        EXPECT_GT(e.fill_price.as_double(), 0.0) << "fill booked at a non-positive price";
+    }
+    EXPECT_TRUE(r.value().empty());
+}
+
+// A price that is present but non-positive is not a price either.
+TEST_F(ExecutionManagerTest, NonPositiveMarketPriceIsRefused) {
+    ExecutionManager em;
+    std::unordered_map<std::string, Position> curr{{"ES", make_position("ES", 2.0, 4500.0)}};
+    std::unordered_map<std::string, Position> prev;
+    std::unordered_map<std::string, double> prices{{"ES", 0.0}};
+    std::vector<std::string> unpriced;
+    auto r = em.generate_daily_executions(curr, prev, prices, std::chrono::system_clock::now(),
+                                          &unpriced);
+    ASSERT_TRUE(r.is_ok());
+    EXPECT_TRUE(r.value().empty());
+    ASSERT_EQ(unpriced.size(), 1u);
+    EXPECT_EQ(unpriced[0], "ES");
+}
+
+// A close-out with no price must not book a fill at the position's own basis, which
+// would silently report zero realized PnL on the exit.
+TEST_F(ExecutionManagerTest, MissingMarketPriceOnCloseOutSkipsRatherThanUsingBasis) {
+    ExecutionManager em;
+    std::unordered_map<std::string, Position> curr;
+    std::unordered_map<std::string, Position> prev{{"ES", make_position("ES", 3.0, 4500.0)}};
+    std::unordered_map<std::string, double> prices;  // no price for ES
+    std::vector<std::string> unpriced;
+    auto r = em.generate_daily_executions(curr, prev, prices, std::chrono::system_clock::now(),
+                                          &unpriced);
+    ASSERT_TRUE(r.is_ok());
+    EXPECT_TRUE(r.value().empty());
+    ASSERT_EQ(unpriced.size(), 1u);
+    EXPECT_EQ(unpriced[0], "ES");
 }
 
 // ===== generate_execution =====

--- a/tests/live/test_execution_manager.cpp
+++ b/tests/live/test_execution_manager.cpp
@@ -120,7 +120,7 @@ TEST_F(ExecutionManagerTest, MissingMarketPriceSkipsTheExecutionRatherThanPricin
     std::unordered_map<std::string, double> prices;  // no price for ES
     std::vector<std::string> unpriced;
     auto r = em.generate_daily_executions(curr, prev, prices, std::chrono::system_clock::now(),
-                                          &unpriced);
+                                          PricingPolicy::STRICT, &unpriced);
     ASSERT_TRUE(r.is_ok());
     EXPECT_TRUE(r.value().empty()) << "an unpriceable symbol must not generate an execution";
     ASSERT_EQ(unpriced.size(), 1u);
@@ -134,7 +134,8 @@ TEST_F(ExecutionManagerTest, MissingMarketPriceOnAZeroBasisPositionDoesNotFillAt
     std::unordered_map<std::string, Position> curr{{"ES", make_position("ES", 2.0, 0.0)}};
     std::unordered_map<std::string, Position> prev;
     std::unordered_map<std::string, double> prices;
-    auto r = em.generate_daily_executions(curr, prev, prices, std::chrono::system_clock::now());
+    auto r = em.generate_daily_executions(curr, prev, prices, std::chrono::system_clock::now(),
+                                          PricingPolicy::STRICT);
     ASSERT_TRUE(r.is_ok());
     for (const auto& e : r.value()) {
         EXPECT_GT(e.fill_price.as_double(), 0.0) << "fill booked at a non-positive price";
@@ -150,7 +151,7 @@ TEST_F(ExecutionManagerTest, NonPositiveMarketPriceIsRefused) {
     std::unordered_map<std::string, double> prices{{"ES", 0.0}};
     std::vector<std::string> unpriced;
     auto r = em.generate_daily_executions(curr, prev, prices, std::chrono::system_clock::now(),
-                                          &unpriced);
+                                          PricingPolicy::STRICT, &unpriced);
     ASSERT_TRUE(r.is_ok());
     EXPECT_TRUE(r.value().empty());
     ASSERT_EQ(unpriced.size(), 1u);
@@ -166,7 +167,7 @@ TEST_F(ExecutionManagerTest, MissingMarketPriceOnCloseOutSkipsRatherThanUsingBas
     std::unordered_map<std::string, double> prices;  // no price for ES
     std::vector<std::string> unpriced;
     auto r = em.generate_daily_executions(curr, prev, prices, std::chrono::system_clock::now(),
-                                          &unpriced);
+                                          PricingPolicy::STRICT, &unpriced);
     ASSERT_TRUE(r.is_ok());
     EXPECT_TRUE(r.value().empty());
     ASSERT_EQ(unpriced.size(), 1u);
@@ -216,4 +217,65 @@ TEST_F(ExecutionManagerTest, UpdateMarketDataDoesNotThrow) {
     ExecutionManager em;
     EXPECT_NO_THROW(em.update_market_data("ES", 1000.0, 4500.0));
     EXPECT_NO_THROW(em.update_market_data("ES", 1100.0, 4510.0));
+}
+
+// ---------------------------------------------------------------------------
+// Futures behaviour preservation.
+//
+// TrendFollowingStrategy sets Position::average_price to price_history.back() --
+// the latest mark, by design (trend_following.cpp:623, REALIZED_ONLY daily
+// settlement). So for futures the mark fallback prices the fill at a real,
+// one-session-stale close, and removing it would replace a correct fill with a
+// skip. MARK_FALLBACK is the default precisely so the two futures runners, which
+// pass no policy argument, keep the behaviour they have always had.
+// ---------------------------------------------------------------------------
+
+TEST_F(ExecutionManagerTest, MarkFallbackPricesFuturesFillFromTheLatestMark) {
+    ExecutionManager em;
+    // ZC on a Monday with no Sunday print: average_price holds Friday's close.
+    std::unordered_map<std::string, Position> curr{{"ZC", make_position("ZC", 10.0, 450.25)}};
+    std::unordered_map<std::string, Position> prev;
+    std::unordered_map<std::string, double> prices;  // no T-1 print
+
+    auto r = em.generate_daily_executions(curr, prev, prices, std::chrono::system_clock::now());
+
+    ASSERT_TRUE(r.is_ok());
+    ASSERT_EQ(r.value().size(), 1u) << "futures must still generate the execution";
+    EXPECT_DOUBLE_EQ(r.value()[0].fill_price.as_double(), 450.25)
+        << "fill must be priced at the mark, exactly as before the STRICT policy existed";
+    EXPECT_DOUBLE_EQ(r.value()[0].filled_quantity.as_double(), 10.0);
+}
+
+TEST_F(ExecutionManagerTest, MarkFallbackClosesFuturesPositionAtTheLatestMark) {
+    ExecutionManager em;
+    std::unordered_map<std::string, Position> curr;
+    std::unordered_map<std::string, Position> prev{{"ZC", make_position("ZC", 10.0, 450.25)}};
+    std::unordered_map<std::string, double> prices;
+
+    auto r = em.generate_daily_executions(curr, prev, prices, std::chrono::system_clock::now());
+
+    ASSERT_TRUE(r.is_ok());
+    ASSERT_EQ(r.value().size(), 1u) << "the close-out must still be generated for futures";
+    EXPECT_DOUBLE_EQ(r.value()[0].fill_price.as_double(), 450.25);
+}
+
+// The default must remain MARK_FALLBACK. If this flips, both futures runners
+// silently change behaviour without their call sites being touched.
+TEST_F(ExecutionManagerTest, DefaultPolicyIsMarkFallbackSoFuturesCallersAreUnaffected) {
+    ExecutionManager em;
+    std::unordered_map<std::string, Position> curr{{"ES", make_position("ES", 1.0, 4500.0)}};
+    std::unordered_map<std::string, Position> prev;
+    std::unordered_map<std::string, double> prices;
+
+    auto defaulted = em.generate_daily_executions(curr, prev, prices,
+                                                  std::chrono::system_clock::now());
+    auto explicit_mark = em.generate_daily_executions(curr, prev, prices,
+                                                      std::chrono::system_clock::now(),
+                                                      PricingPolicy::MARK_FALLBACK);
+    ASSERT_TRUE(defaulted.is_ok());
+    ASSERT_TRUE(explicit_mark.is_ok());
+    ASSERT_EQ(defaulted.value().size(), explicit_mark.value().size());
+    ASSERT_EQ(defaulted.value().size(), 1u);
+    EXPECT_DOUBLE_EQ(defaulted.value()[0].fill_price.as_double(),
+                     explicit_mark.value()[0].fill_price.as_double());
 }

--- a/tests/live/test_execution_price_integrity.cpp
+++ b/tests/live/test_execution_price_integrity.cpp
@@ -1,0 +1,377 @@
+// tests/live/test_execution_price_integrity.cpp
+//
+// The zero-price chain, and the invariants that now break it.
+//
+// A synthetic fill has to be priced at something. When the T-1 close was missing the
+// answer used to be Position::average_price -- a COST BASIS. That is a category error
+// with a self-sustaining failure mode:
+//
+//   missing T-1 close
+//     -> day-T placeholder leaves average_price at its incoming value (0 for a new
+//        position, whose basis is not established until the fill is processed)
+//     -> ExecutionManager prices the fill off average_price          => fill at 0
+//     -> on_execution records cost basis 0 from that fill
+//     -> carried_basis is also 0, so resolve_day_t_cost_basis returns 0
+//     -> the runner's `if (cost_basis > 0)` guard SKIPS the write, leaving the
+//        placeholder -- the previous close -- masquerading as a cost basis
+//     -> that persists and reloads next session as a carried basis of 0
+//
+// These tests exercise the chain through LiveDailyCycle, which is the same code the
+// runner calls, rather than through the individual helpers in isolation. That
+// distinction matters: Wave 2 tested resolve_day_t_cost_basis as a pure function and
+// left the runner's guard around it with no coverage at all, which is exactly where
+// the residual defect was hiding.
+
+#include <gtest/gtest.h>
+
+#include <chrono>
+#include <string>
+#include <unordered_map>
+#include <vector>
+
+#include "trade_ngin/core/types.hpp"
+#include "trade_ngin/live/execution_manager.hpp"
+#include "trade_ngin/live/execution_price_resolver.hpp"
+#include "trade_ngin/live/live_daily_cycle.hpp"
+
+using namespace trade_ngin;
+
+namespace {
+
+constexpr int kDay = 24;
+
+Timestamp days_before(const Timestamp& t, int n) {
+    return t - std::chrono::hours(kDay * n);
+}
+
+Position held(const std::string& symbol, double qty, double basis) {
+    Position p;
+    p.symbol = symbol;
+    p.quantity = Quantity(qty);
+    p.average_price = Decimal(basis);
+    p.unrealized_pnl = Decimal(0.0);
+    p.realized_pnl = Decimal(0.0);
+    p.last_update = std::chrono::system_clock::now();
+    return p;
+}
+
+Bar bar_at(const std::string& symbol, const Timestamp& ts, double close) {
+    return Bar(ts, close, close, close, close, 1000.0, symbol);
+}
+
+const ExecutionReport* find_exec(const std::vector<ExecutionReport>& execs,
+                                 const std::string& symbol) {
+    for (const auto& e : execs) {
+        if (e.symbol == symbol) return &e;
+    }
+    return nullptr;
+}
+
+class ExecutionPriceIntegrity : public ::testing::Test {
+protected:
+    Timestamp now_ = std::chrono::system_clock::now();
+    ExecutionManager em_;
+};
+
+// ---------------------------------------------------------------------------
+// The poisoned chain, end to end.
+// ---------------------------------------------------------------------------
+
+// PRE-FIX: fill_price = 0, because average_price (0 for a brand-new position) was
+// used as the market price. This is the defect in one assertion.
+TEST_F(ExecutionPriceIntegrity, NewPositionWithNoPriceIsNeverFilledAtZero) {
+    std::unordered_map<std::string, Position> positions;
+    positions["NEWCO"] = held("NEWCO", 100.0, 0.0);  // opened today: no basis yet
+    std::unordered_map<std::string, Position> previous;
+
+    std::unordered_map<std::string, double> t1;  // deliberately empty
+    std::vector<Bar> bars;                       // no history either
+
+    auto r = LiveDailyCycle::execute_day_t(em_, positions, previous, t1, bars, now_);
+    ASSERT_TRUE(r.is_ok());
+
+    for (const auto& e : r.value().executions) {
+        EXPECT_GT(e.fill_price.as_double(), 0.0) << "a fill was booked at a non-positive price";
+    }
+    EXPECT_EQ(find_exec(r.value().executions, "NEWCO"), nullptr)
+        << "an unpriceable symbol must not generate an execution at all";
+}
+
+// The phantom: a target we could not price must not survive into the persisted book.
+TEST_F(ExecutionPriceIntegrity, UnpriceableNewTargetIsRolledOutOfTheBook) {
+    std::unordered_map<std::string, Position> positions;
+    positions["NEWCO"] = held("NEWCO", 100.0, 0.0);
+    std::unordered_map<std::string, Position> previous;
+
+    auto r = LiveDailyCycle::execute_day_t(em_, positions, previous, {}, {}, now_);
+    ASSERT_TRUE(r.is_ok());
+
+    EXPECT_EQ(positions.count("NEWCO"), 0u)
+        << "a position that never executed was left in the day-T book";
+    ASSERT_EQ(r.value().unpriced.size(), 1u);
+    EXPECT_EQ(r.value().unpriced[0], "NEWCO");
+}
+
+// A held position we cannot price keeps the quantity it actually has -- not the
+// target the optimizer wanted and not zero.
+TEST_F(ExecutionPriceIntegrity, UnpriceableHeldPositionRevertsToCarriedQuantity) {
+    std::unordered_map<std::string, Position> previous;
+    previous["HALTED"] = held("HALTED", 50.0, 120.0);
+
+    std::unordered_map<std::string, Position> positions;
+    positions["HALTED"] = held("HALTED", 200.0, 0.0);  // optimizer wants to add
+
+    auto r = LiveDailyCycle::execute_day_t(em_, positions, previous, {}, {}, now_);
+    ASSERT_TRUE(r.is_ok());
+
+    ASSERT_EQ(positions.count("HALTED"), 1u);
+    EXPECT_DOUBLE_EQ(positions["HALTED"].quantity.as_double(), 50.0)
+        << "book must show what we hold, not what we wanted";
+    EXPECT_DOUBLE_EQ(positions["HALTED"].average_price.as_double(), 120.0)
+        << "the carried basis must survive a day with no execution";
+    EXPECT_EQ(find_exec(r.value().executions, "HALTED"), nullptr);
+}
+
+// A close-out we cannot price must not book a fill at the position's own basis,
+// which would report zero realized PnL on the exit.
+TEST_F(ExecutionPriceIntegrity, UnpriceableCloseOutDoesNotFillAtCostBasis) {
+    std::unordered_map<std::string, Position> previous;
+    previous["GONE"] = held("GONE", 40.0, 88.0);
+    std::unordered_map<std::string, Position> positions;  // target: flat
+
+    auto r = LiveDailyCycle::execute_day_t(em_, positions, previous, {}, {}, now_);
+    ASSERT_TRUE(r.is_ok());
+
+    const auto* exec = find_exec(r.value().executions, "GONE");
+    EXPECT_EQ(exec, nullptr) << "closed at its own cost basis rather than a market price";
+}
+
+// ---------------------------------------------------------------------------
+// The widened path: a real older close, not an invented one.
+// ---------------------------------------------------------------------------
+
+TEST_F(ExecutionPriceIntegrity, MissingT1IsPricedFromTheMostRecentRealClose) {
+    std::unordered_map<std::string, Position> previous;
+    previous["THIN"] = held("THIN", 10.0, 45.0);
+    std::unordered_map<std::string, Position> positions;
+    positions["THIN"] = held("THIN", 30.0, 45.0);
+
+    // No T-1 print, but the symbol traded two sessions ago at 51.25.
+    std::vector<Bar> bars{
+        bar_at("THIN", days_before(now_, 4), 49.00),
+        bar_at("THIN", days_before(now_, 2), 51.25),
+    };
+
+    auto r = LiveDailyCycle::execute_day_t(em_, positions, previous, {}, bars, now_);
+    ASSERT_TRUE(r.is_ok());
+
+    const auto* exec = find_exec(r.value().executions, "THIN");
+    ASSERT_NE(exec, nullptr) << "a symbol with a usable older close must still trade";
+    EXPECT_DOUBLE_EQ(exec->fill_price.as_double(), 51.25) << "must use the most recent close, not the oldest";
+    ASSERT_EQ(r.value().widened_prices.size(), 1u);
+    EXPECT_NE(r.value().widened_prices[0].find("THIN"), std::string::npos);
+    EXPECT_NE(r.value().widened_prices[0].find("2 days stale"), std::string::npos)
+        << "the substitution must record how old the price is: " << r.value().widened_prices[0];
+}
+
+TEST_F(ExecutionPriceIntegrity, WidenedCloseBeyondTheStalenessBoundIsRefused) {
+    std::unordered_map<std::string, Position> previous;
+    previous["DELISTED"] = held("DELISTED", 10.0, 45.0);
+    std::unordered_map<std::string, Position> positions;
+    positions["DELISTED"] = held("DELISTED", 30.0, 45.0);
+
+    std::vector<Bar> bars{bar_at("DELISTED", days_before(now_, 40), 51.25)};
+
+    auto r = LiveDailyCycle::execute_day_t(em_, positions, previous, {}, bars, now_);
+    ASSERT_TRUE(r.is_ok());
+
+    EXPECT_EQ(find_exec(r.value().executions, "DELISTED"), nullptr)
+        << "a 40-day-old close must not be presented as today's market price";
+    ASSERT_EQ(r.value().unpriced.size(), 1u);
+    EXPECT_EQ(r.value().unpriced[0], "DELISTED");
+    EXPECT_DOUBLE_EQ(positions["DELISTED"].quantity.as_double(), 10.0);
+}
+
+// A real T-1 close always wins. This is the control that bounds the blast radius:
+// the normal path must be untouched by any of the above.
+TEST_F(ExecutionPriceIntegrity, PresentT1CloseIsUsedUnchanged) {
+    std::unordered_map<std::string, Position> previous;
+    previous["AAPL"] = held("AAPL", 10.0, 150.0);
+    std::unordered_map<std::string, Position> positions;
+    positions["AAPL"] = held("AAPL", 25.0, 150.0);
+
+    std::unordered_map<std::string, double> t1{{"AAPL", 190.0}};
+    // An older bar exists too and must be ignored in favour of the T-1 close.
+    std::vector<Bar> bars{bar_at("AAPL", days_before(now_, 3), 177.0)};
+
+    auto r = LiveDailyCycle::execute_day_t(em_, positions, previous, t1, bars, now_);
+    ASSERT_TRUE(r.is_ok());
+
+    const auto* exec = find_exec(r.value().executions, "AAPL");
+    ASSERT_NE(exec, nullptr);
+    EXPECT_DOUBLE_EQ(exec->fill_price.as_double(), 190.0);
+    EXPECT_TRUE(r.value().widened_prices.empty()) << "T-1 was present; nothing should widen";
+    EXPECT_TRUE(r.value().unpriced.empty());
+    EXPECT_TRUE(r.value().rolled_back.empty());
+    EXPECT_DOUBLE_EQ(positions["AAPL"].quantity.as_double(), 25.0) << "normal path must be intact";
+}
+
+// A bar dated after the reference session must never price today's fill.
+TEST_F(ExecutionPriceIntegrity, FutureBarsAreNotUsedAsPrices) {
+    std::unordered_map<std::string, Position> positions;
+    positions["FWD"] = held("FWD", 10.0, 0.0);
+    std::unordered_map<std::string, Position> previous;
+
+    std::vector<Bar> bars{bar_at("FWD", now_ + std::chrono::hours(48), 99.0)};
+
+    auto r = LiveDailyCycle::execute_day_t(em_, positions, previous, {}, bars, now_);
+    ASSERT_TRUE(r.is_ok());
+    EXPECT_EQ(find_exec(r.value().executions, "FWD"), nullptr)
+        << "a fill was priced from a session that has not happened yet";
+}
+
+// A non-positive close in the feed is not a price and must not mask a good older one.
+TEST_F(ExecutionPriceIntegrity, NonPositiveCloseDoesNotMaskAnOlderGoodClose) {
+    std::unordered_map<std::string, Position> positions;
+    positions["BADROW"] = held("BADROW", 10.0, 0.0);
+    std::unordered_map<std::string, Position> previous;
+
+    std::vector<Bar> bars{
+        bar_at("BADROW", days_before(now_, 3), 62.50),
+        bar_at("BADROW", days_before(now_, 1), 0.0),  // bad row, more recent
+    };
+
+    auto r = LiveDailyCycle::execute_day_t(em_, positions, previous, {}, bars, now_);
+    ASSERT_TRUE(r.is_ok());
+
+    const auto* exec = find_exec(r.value().executions, "BADROW");
+    ASSERT_NE(exec, nullptr);
+    EXPECT_DOUBLE_EQ(exec->fill_price.as_double(), 62.50);
+}
+
+// A T-1 entry that is present but zero is not a usable price either.
+TEST_F(ExecutionPriceIntegrity, ZeroValuedT1EntryIsTreatedAsMissing) {
+    std::unordered_map<std::string, Position> positions;
+    positions["ZED"] = held("ZED", 10.0, 0.0);
+    std::unordered_map<std::string, Position> previous;
+
+    std::unordered_map<std::string, double> t1{{"ZED", 0.0}};
+    std::vector<Bar> bars{bar_at("ZED", days_before(now_, 2), 33.0)};
+
+    auto r = LiveDailyCycle::execute_day_t(em_, positions, previous, t1, bars, now_);
+    ASSERT_TRUE(r.is_ok());
+
+    const auto* exec = find_exec(r.value().executions, "ZED");
+    ASSERT_NE(exec, nullptr) << "a zero T-1 entry should fall through to the widened close";
+    EXPECT_DOUBLE_EQ(exec->fill_price.as_double(), 33.0);
+}
+
+// ---------------------------------------------------------------------------
+// The basis residual -- the branch Wave 2 left uncovered.
+// ---------------------------------------------------------------------------
+
+// PRE-FIX: the runner's `if (cost_basis > 0)` guard skipped the write, so
+// average_price kept the day-T placeholder (the previous close) and a MARK was
+// persisted as a COST BASIS.
+TEST_F(ExecutionPriceIntegrity, UnresolvableBasisIsNotSilentlyLeftAsAMark) {
+    std::unordered_map<std::string, Position> positions;
+    // The placeholder has already written yesterday's close into average_price.
+    positions["ORPHAN"] = held("ORPHAN", 100.0, 250.0);
+
+    std::unordered_map<std::string, Position> strategy;   // no record
+    std::unordered_map<std::string, Position> previous;   // not carried
+    std::unordered_map<std::string, double> marks{{"ORPHAN", 250.0}};
+
+    auto unresolved =
+        LiveDailyCycle::resolve_and_apply_basis(positions, strategy, previous, marks);
+
+    ASSERT_EQ(unresolved.size(), 1u) << "the residual must be reported, not swallowed";
+    EXPECT_EQ(unresolved[0], "ORPHAN");
+    EXPECT_DOUBLE_EQ(positions["ORPHAN"].average_price.as_double(), 0.0)
+        << "250.0 is today's mark, not what the position cost";
+    EXPECT_DOUBLE_EQ(positions["ORPHAN"].unrealized_pnl.as_double(), 0.0);
+}
+
+// The two legitimate sources still win, and in the right order.
+TEST_F(ExecutionPriceIntegrity, StrategyBasisWinsAndCarriedBasisBacksItUp) {
+    std::unordered_map<std::string, Position> positions;
+    positions["TRADED"] = held("TRADED", 10.0, 999.0);  // placeholder mark
+    positions["HELD"] = held("HELD", 20.0, 999.0);      // placeholder mark
+
+    std::unordered_map<std::string, Position> strategy;
+    strategy["TRADED"] = held("TRADED", 10.0, 101.0);
+
+    std::unordered_map<std::string, Position> previous;
+    previous["HELD"] = held("HELD", 20.0, 55.0);
+
+    std::unordered_map<std::string, double> marks{{"TRADED", 110.0}, {"HELD", 60.0}};
+
+    auto unresolved =
+        LiveDailyCycle::resolve_and_apply_basis(positions, strategy, previous, marks);
+
+    EXPECT_TRUE(unresolved.empty());
+    EXPECT_DOUBLE_EQ(positions["TRADED"].average_price.as_double(), 101.0);
+    EXPECT_DOUBLE_EQ(positions["HELD"].average_price.as_double(), 55.0);
+    // Unrealized must be measured from the basis, not from the placeholder.
+    EXPECT_DOUBLE_EQ(positions["TRADED"].unrealized_pnl.as_double(), 10.0 * (110.0 - 101.0));
+    EXPECT_DOUBLE_EQ(positions["HELD"].unrealized_pnl.as_double(), 20.0 * (60.0 - 55.0));
+}
+
+// A flat row must not be reported as an unresolved holding.
+TEST_F(ExecutionPriceIntegrity, FlatPositionIsNotReportedUnresolved) {
+    std::unordered_map<std::string, Position> positions;
+    positions["FLAT"] = held("FLAT", 0.0, 0.0);
+
+    auto unresolved = LiveDailyCycle::resolve_and_apply_basis(positions, {}, {}, {});
+    EXPECT_TRUE(unresolved.empty());
+}
+
+// ---------------------------------------------------------------------------
+// Marks and fills must come from the same map.
+// ---------------------------------------------------------------------------
+
+TEST_F(ExecutionPriceIntegrity, MarksMatchThePricesTheFillsUsed) {
+    std::unordered_map<std::string, Position> previous;
+    previous["THIN"] = held("THIN", 10.0, 40.0);
+    std::unordered_map<std::string, Position> positions;
+    positions["THIN"] = held("THIN", 10.0, 40.0);  // unchanged: no execution
+
+    std::vector<Bar> bars{bar_at("THIN", days_before(now_, 2), 47.0)};
+
+    auto r = LiveDailyCycle::execute_day_t(em_, positions, previous, {}, bars, now_);
+    ASSERT_TRUE(r.is_ok());
+
+    ASSERT_EQ(r.value().execution_prices.count("THIN"), 1u)
+        << "the widened price must be exposed so marking uses the same number";
+    EXPECT_DOUBLE_EQ(r.value().execution_prices.at("THIN"), 47.0);
+
+    auto unresolved = LiveDailyCycle::resolve_and_apply_basis(
+        positions, {}, previous, r.value().execution_prices);
+    EXPECT_TRUE(unresolved.empty());
+    EXPECT_DOUBLE_EQ(positions["THIN"].average_price.as_double(), 40.0);
+    EXPECT_DOUBLE_EQ(positions["THIN"].unrealized_pnl.as_double(), 10.0 * (47.0 - 40.0));
+}
+
+// ---------------------------------------------------------------------------
+// Resolver units -- the staleness arithmetic the bound depends on.
+// ---------------------------------------------------------------------------
+
+TEST_F(ExecutionPriceIntegrity, StalenessIsWholeCalendarDaysAndNeverNegative) {
+    EXPECT_EQ(ExecutionPriceResolver::staleness_days(now_, now_), 0);
+    EXPECT_EQ(ExecutionPriceResolver::staleness_days(now_, days_before(now_, 3)), 3);
+    EXPECT_EQ(ExecutionPriceResolver::staleness_days(now_, now_ + std::chrono::hours(48)), 0)
+        << "a future observation must not produce a negative age";
+}
+
+TEST_F(ExecutionPriceIntegrity, LatestCloseIgnoresOtherSymbols) {
+    std::vector<Bar> bars{
+        bar_at("A", days_before(now_, 1), 10.0),
+        bar_at("B", days_before(now_, 1), 20.0),
+    };
+    auto m = ExecutionPriceResolver::latest_close_at_or_before(bars, now_);
+    ASSERT_EQ(m.size(), 2u);
+    EXPECT_DOUBLE_EQ(m.at("A").price, 10.0);
+    EXPECT_DOUBLE_EQ(m.at("B").price, 20.0);
+}
+
+}  // namespace

--- a/tests/strategy/test_live_daily_cycle_seeding.cpp
+++ b/tests/strategy/test_live_daily_cycle_seeding.cpp
@@ -1,0 +1,384 @@
+#include <gtest/gtest.h>
+
+#include <chrono>
+#include <cmath>
+#include <memory>
+#include <unordered_map>
+#include <vector>
+
+#include "../core/test_base.hpp"
+#include "../data/test_db_utils.hpp"
+#include "trade_ngin/live/live_daily_cycle.hpp"
+#include "trade_ngin/live/live_pnl_manager.hpp"
+#include "trade_ngin/strategy/mean_reversion.hpp"
+
+using namespace trade_ngin;
+using namespace trade_ngin::testing;
+
+// Wave 2 regression tests.
+//
+// F-B: the live equity runner never seeded the strategy's positions_ from the
+//      previous day's book, so MeanReversionStrategy::generate_signal() took its
+//      flat-book ENTRY branch on every bar of every session. A held position was
+//      liquidated the moment its z-score left the entry zone (|z| < 2.0) instead
+//      of being held to the exit threshold (|z| < 0.5), and the stop-loss -- which
+//      measures from Position::average_price -- could never fire at all.
+//
+// F-E: a held-but-untraded holding had its average_price overwritten with the
+//      previous session's close every day, so the basis every PnL figure and the
+//      stop-loss measure from drifted to the latest price and the position always
+//      looked flat.
+//
+// The two are one defect in two places and are tested together: seeding is what
+// puts a basis in front of the stop-loss, and retaining the basis is what makes
+// that stop-loss measure from the truth.
+class LiveDailyCycleSeedingTest : public TestBase {
+protected:
+    void SetUp() override {
+        TestBase::SetUp();
+        StateManager::reset_instance();
+
+        db_ = std::make_shared<MockPostgresDatabase>("mock://testdb");
+        ASSERT_TRUE(db_->connect().is_ok());
+
+        strategy_config_.capital_allocation = 100000.0;
+        strategy_config_.max_leverage = 2.0;
+        strategy_config_.asset_classes = {AssetClass::EQUITIES};
+        strategy_config_.frequencies = {DataFrequency::DAILY};
+        for (const auto& symbol : {"AAPL", "MSFT"}) {
+            strategy_config_.trading_params[symbol] = 1.0;
+            strategy_config_.position_limits[symbol] = 100000.0;
+        }
+
+        mr_config_.lookback_period = 20;
+        mr_config_.vol_lookback = 20;
+        mr_config_.entry_threshold = 2.0;
+        mr_config_.exit_threshold = 0.5;
+        mr_config_.risk_target = 0.15;
+        mr_config_.position_size = 0.1;
+        mr_config_.use_stop_loss = true;
+        mr_config_.stop_loss_pct = 0.05;
+        mr_config_.allow_fractional_shares = true;
+
+        risk_limits_.max_position_size = 100000.0;
+        risk_limits_.max_notional_value = 1e9;
+        risk_limits_.max_drawdown = 0.9;
+        risk_limits_.max_leverage = 10.0;
+    }
+
+    void TearDown() override {
+        if (db_) {
+            db_->disconnect();
+            db_.reset();
+        }
+        TestBase::TearDown();
+    }
+
+    std::unique_ptr<MeanReversionStrategy> create_strategy() {
+        static int test_id = 0;
+        auto strategy = std::make_unique<MeanReversionStrategy>(
+            "TEST_MR_SEED_" + std::to_string(++test_id),
+            strategy_config_, mr_config_, db_);
+        EXPECT_TRUE(strategy->initialize().is_ok());
+        EXPECT_TRUE(strategy->update_risk_limits(risk_limits_).is_ok());
+        EXPECT_TRUE(strategy->start().is_ok());
+        return strategy;
+    }
+
+    // A deterministic series whose closing bar sits in the HOLD band: far enough
+    // from the mean that a held position is not yet told to exit (|z| > 0.5), but
+    // not far enough to open a new one (|z| < 2.0). That gap is precisely where
+    // the entry branch and the exit branch disagree, so it is where an unseeded
+    // strategy gives itself away.
+    std::vector<Bar> hold_band_series(const std::string& symbol,
+                                      double final_close = 98.5) const {
+        std::vector<Bar> bars;
+        auto now = std::chrono::system_clock::now();
+        const int kPre = 30;
+        for (int i = 0; i < kPre; ++i) {
+            bars.push_back(make_bar(symbol, (i % 2 == 0) ? 99.0 : 101.0,
+                                    now - std::chrono::hours(24 * (kPre + 1 - i))));
+        }
+        bars.push_back(make_bar(symbol, final_close, now));
+        return bars;
+    }
+
+    Bar make_bar(const std::string& symbol, double close, Timestamp ts) const {
+        Bar bar;
+        bar.symbol = symbol;
+        bar.timestamp = ts;
+        bar.open = close;
+        bar.high = close;
+        bar.low = close;
+        bar.close = close;
+        bar.volume = 1000000.0;
+        return bar;
+    }
+
+    Position held_long(const std::string& symbol, double quantity,
+                       double average_price) const {
+        Position pos;
+        pos.symbol = symbol;
+        pos.quantity = Quantity(quantity);
+        pos.average_price = Decimal(average_price);
+        pos.last_update = std::chrono::system_clock::now();
+        return pos;
+    }
+
+    std::shared_ptr<MockPostgresDatabase> db_;
+    StrategyConfig strategy_config_;
+    RiskLimits risk_limits_;
+    MeanReversionConfig mr_config_;
+};
+
+// ---------------------------------------------------------------------------
+// F-B
+// ---------------------------------------------------------------------------
+
+// The bug in one assertion: same bars, same strategy, same day -- the only
+// difference is whether the previous day's book was handed back. Without it the
+// position is thrown away inside the hold band.
+TEST_F(LiveDailyCycleSeedingTest, SeededLongIsHeldInsideTheHoldBand) {
+    auto bars = hold_band_series("AAPL");
+
+    auto flat = create_strategy();
+    ASSERT_TRUE(LiveDailyCycle::prepare_strategy_for_signals(*flat, {}, bars).is_ok());
+
+    const double z = flat->get_z_score("AAPL");
+    ASSERT_LT(z, -mr_config_.exit_threshold)
+        << "series precondition: z must be beyond the exit threshold";
+    ASSERT_GT(z, -mr_config_.entry_threshold)
+        << "series precondition: z must be inside the entry threshold (z=" << z << ")";
+
+    // A genuinely flat book has nothing to hold, so it stays flat. Unchanged by
+    // this fix, and the control the next assertion is measured against.
+    EXPECT_DOUBLE_EQ(flat->get_position("AAPL"), 0.0);
+
+    auto seeded = create_strategy();
+    std::unordered_map<std::string, Position> previous{
+        {"AAPL", held_long("AAPL", 100.0, 98.0)}};
+    ASSERT_TRUE(
+        LiveDailyCycle::prepare_strategy_for_signals(*seeded, previous, bars).is_ok());
+
+    EXPECT_GT(seeded->get_position("AAPL"), 0.0)
+        << "a held long inside the hold band must be kept, not liquidated at the "
+           "entry threshold";
+}
+
+// The exit threshold has to be the thing that closes the position -- not the
+// entry threshold wearing its clothes.
+TEST_F(LiveDailyCycleSeedingTest, SeededLongExitsOnlyOnceInsideTheExitThreshold) {
+    // 100.0 sits at the series mean, so |z| collapses below the exit threshold.
+    auto bars = hold_band_series("AAPL", 100.0);
+
+    auto seeded = create_strategy();
+    std::unordered_map<std::string, Position> previous{
+        {"AAPL", held_long("AAPL", 100.0, 98.0)}};
+    ASSERT_TRUE(
+        LiveDailyCycle::prepare_strategy_for_signals(*seeded, previous, bars).is_ok());
+
+    ASSERT_LT(std::abs(seeded->get_z_score("AAPL")), mr_config_.exit_threshold)
+        << "series precondition: z must be inside the exit threshold";
+    EXPECT_DOUBLE_EQ(seeded->get_position("AAPL"), 0.0)
+        << "mean reversion is complete -- the position must be closed";
+}
+
+// Unseeded, the stop-loss is unreachable: generate_signal() returns from the
+// entry branch before it ever looks at average_price.
+TEST_F(LiveDailyCycleSeedingTest, StopLossFiresFromTheSeededCostBasis) {
+    auto bars = hold_band_series("AAPL");  // closes at 98.5, inside the hold band
+
+    // Bought at 200, now marked 98.5: more than 50% underwater, far past the 5% stop.
+    auto seeded = create_strategy();
+    std::unordered_map<std::string, Position> previous{
+        {"AAPL", held_long("AAPL", 100.0, 200.0)}};
+    ASSERT_TRUE(
+        LiveDailyCycle::prepare_strategy_for_signals(*seeded, previous, bars).is_ok());
+
+    EXPECT_DOUBLE_EQ(seeded->get_position("AAPL"), 0.0)
+        << "a position 50% underwater must be stopped out";
+
+    // Same bars, same z-score, same hold band -- only the basis differs. This one
+    // is barely underwater, so the stop must NOT fire. Together the two cases show
+    // the stop is driven by the cost basis rather than by the z-score.
+    auto healthy = create_strategy();
+    std::unordered_map<std::string, Position> healthy_book{
+        {"AAPL", held_long("AAPL", 100.0, 99.0)}};
+    ASSERT_TRUE(
+        LiveDailyCycle::prepare_strategy_for_signals(*healthy, healthy_book, bars).is_ok());
+
+    EXPECT_GT(healthy->get_position("AAPL"), 0.0)
+        << "a position 0.5% underwater is inside the 5% stop and must be held";
+}
+
+// ---------------------------------------------------------------------------
+// F-B x F-E -- the reason the two fixes ship together
+// ---------------------------------------------------------------------------
+
+// If the runner re-anchors a held position's basis to the previous close (F-E),
+// then seeding it (F-B) hands the stop-loss a basis that is always ~= the current
+// price. The stop silently never fires, and the fix reads as if it worked.
+TEST_F(LiveDailyCycleSeedingTest, StopLossMeasuresFromRetainedBasisNotPreviousClose) {
+    const double kPreviousClose = 98.5;  // what the pre-Wave-2 runner wrote as basis
+    const double kTrueBasis = 200.0;     // what the position actually cost
+    auto bars = hold_band_series("AAPL", kPreviousClose);
+
+    // The defect being guarded against: basis re-anchored to the previous close.
+    auto reanchored = create_strategy();
+    std::unordered_map<std::string, Position> reanchored_book{
+        {"AAPL", held_long("AAPL", 100.0, kPreviousClose)}};
+    ASSERT_TRUE(
+        LiveDailyCycle::prepare_strategy_for_signals(*reanchored, reanchored_book, bars)
+            .is_ok());
+    ASSERT_GT(reanchored->get_position("AAPL"), 0.0)
+        << "sanity: against a re-anchored basis the stop cannot fire -- this is the "
+           "silent failure F-E would leave behind";
+
+    // The same position with the basis it actually has.
+    auto retained = create_strategy();
+    std::unordered_map<std::string, Position> retained_book{
+        {"AAPL", held_long("AAPL", 100.0, kTrueBasis)}};
+    ASSERT_TRUE(
+        LiveDailyCycle::prepare_strategy_for_signals(*retained, retained_book, bars)
+            .is_ok());
+    EXPECT_DOUBLE_EQ(retained->get_position("AAPL"), 0.0)
+        << "the stop must measure from the retained cost basis";
+}
+
+// ---------------------------------------------------------------------------
+// F-E -- the basis rule itself
+// ---------------------------------------------------------------------------
+
+TEST_F(LiveDailyCycleSeedingTest, UntradedHoldingRetainsItsCostBasisAcrossTheDay) {
+    const double kEstablishedBasis = 150.0;
+    const double kPreviousClose = 98.5;
+
+    // A holding the strategy knows about (seeded, untraded) keeps its basis. The
+    // previous close is not a candidate: it is a mark, not a cost.
+    EXPECT_DOUBLE_EQ(
+        LivePnLManager::resolve_day_t_cost_basis(kEstablishedBasis, kEstablishedBasis),
+        kEstablishedBasis);
+    EXPECT_NE(
+        LivePnLManager::resolve_day_t_cost_basis(kEstablishedBasis, kEstablishedBasis),
+        kPreviousClose);
+
+    // Repeating the day must not move it -- the drift was the bug.
+    double basis = kEstablishedBasis;
+    for (int day = 0; day < 5; ++day) {
+        basis = LivePnLManager::resolve_day_t_cost_basis(basis, basis);
+    }
+    EXPECT_DOUBLE_EQ(basis, kEstablishedBasis);
+}
+
+TEST_F(LiveDailyCycleSeedingTest, CarriedBasisSurvivesAStrategyThatHasNoRecord) {
+    // Defence in depth: if seeding were ever removed or a symbol were missing from
+    // the strategy, the basis still comes from the carried book rather than being
+    // reinvented from the day's price.
+    EXPECT_DOUBLE_EQ(LivePnLManager::resolve_day_t_cost_basis(0.0, 150.0), 150.0);
+}
+
+TEST_F(LiveDailyCycleSeedingTest, UnknownBasisIsZeroRatherThanAFabricatedPrice) {
+    // A genuinely new position has no basis until its fill is processed. Reporting
+    // 0.0 makes unrealized_from_cost_basis() report no PnL; substituting the day's
+    // close would have booked the position as instantly flat at a price it never paid.
+    EXPECT_DOUBLE_EQ(LivePnLManager::resolve_day_t_cost_basis(0.0, 0.0), 0.0);
+    EXPECT_DOUBLE_EQ(
+        LivePnLManager::unrealized_from_cost_basis(
+            100.0, LivePnLManager::resolve_day_t_cost_basis(0.0, 0.0), 98.5),
+        0.0);
+}
+
+TEST_F(LiveDailyCycleSeedingTest, StrategyBasisWinsOverTheCarriedBasisWhenBothExist) {
+    // A symbol that traded today has a freshly weighted average from on_execution();
+    // that is the current truth and must not be overwritten by yesterday's.
+    EXPECT_DOUBLE_EQ(LivePnLManager::resolve_day_t_cost_basis(120.0, 150.0), 120.0);
+}
+
+// ---------------------------------------------------------------------------
+// Blast radius
+// ---------------------------------------------------------------------------
+
+// Seeding an empty book must be indistinguishable from not seeding at all.
+TEST_F(LiveDailyCycleSeedingTest, EmptyBookIsInert) {
+    auto bars = hold_band_series("AAPL");
+
+    auto unseeded = create_strategy();
+    ASSERT_TRUE(unseeded->on_data(bars).is_ok());
+
+    auto seeded_empty = create_strategy();
+    ASSERT_TRUE(
+        LiveDailyCycle::prepare_strategy_for_signals(*seeded_empty, {}, bars).is_ok());
+
+    EXPECT_DOUBLE_EQ(seeded_empty->get_position("AAPL"), unseeded->get_position("AAPL"));
+    EXPECT_DOUBLE_EQ(seeded_empty->get_z_score("AAPL"), unseeded->get_z_score("AAPL"));
+}
+
+// Seeding must not move a symbol that is genuinely flat: the entry branch is
+// reached by exactly the symbols that reached it before.
+TEST_F(LiveDailyCycleSeedingTest, FlatSymbolIsUnaffectedByAnotherSymbolsSeed) {
+    std::vector<Bar> bars = hold_band_series("AAPL");
+    for (auto& bar : hold_band_series("MSFT")) bars.push_back(bar);
+
+    auto unseeded = create_strategy();
+    ASSERT_TRUE(unseeded->on_data(bars).is_ok());
+
+    auto seeded = create_strategy();
+    std::unordered_map<std::string, Position> previous{
+        {"AAPL", held_long("AAPL", 100.0, 98.0)}};
+    ASSERT_TRUE(
+        LiveDailyCycle::prepare_strategy_for_signals(*seeded, previous, bars).is_ok());
+
+    EXPECT_DOUBLE_EQ(seeded->get_position("MSFT"), unseeded->get_position("MSFT"))
+        << "MSFT was not seeded and must be unchanged";
+    EXPECT_GT(seeded->get_position("AAPL"), 0.0)
+        << "AAPL was seeded and must now be held";
+}
+
+// A position opened by an entry signal is still opened -- seeding restores held
+// positions, it does not suppress new ones.
+TEST_F(LiveDailyCycleSeedingTest, EntrySignalStillOpensANewPosition) {
+    // 94.0 drives z past the entry threshold.
+    auto bars = hold_band_series("AAPL", 94.0);
+
+    auto seeded = create_strategy();
+    ASSERT_TRUE(LiveDailyCycle::prepare_strategy_for_signals(*seeded, {}, bars).is_ok());
+
+    ASSERT_LT(seeded->get_z_score("AAPL"), -mr_config_.entry_threshold)
+        << "series precondition: z must be beyond the entry threshold";
+    EXPECT_GT(seeded->get_position("AAPL"), 0.0)
+        << "an oversold flat symbol must still be entered long";
+}
+
+// Backtest runs one process over the whole history, so positions_ accumulates
+// through on_execution() and never needed seeding. That must keep working.
+TEST_F(LiveDailyCycleSeedingTest, BacktestAccumulationPathIsUnchanged) {
+    auto bars = hold_band_series("AAPL");
+    auto strategy = create_strategy();
+
+    ASSERT_TRUE(strategy->on_data(bars).is_ok());
+    EXPECT_DOUBLE_EQ(strategy->get_position("AAPL"), 0.0)
+        << "flat book, hold band: nothing to hold";
+
+    // The backtest's own mechanism: a fill establishes the holding.
+    ExecutionReport fill;
+    fill.order_id = "BT_ORDER_1";
+    fill.exec_id = "BT_EXEC_1";
+    fill.symbol = "AAPL";
+    fill.side = Side::BUY;
+    fill.filled_quantity = Quantity(100.0);
+    fill.fill_price = Price(98.0);
+    fill.fill_time = std::chrono::system_clock::now();
+    ASSERT_TRUE(strategy->on_execution(fill).is_ok());
+
+    const auto& positions = strategy->get_positions();
+    auto it = positions.find("AAPL");
+    ASSERT_NE(it, positions.end()) << "on_execution must record the holding";
+    EXPECT_DOUBLE_EQ(it->second.quantity.as_double(), 100.0);
+    EXPECT_DOUBLE_EQ(it->second.average_price.as_double(), 98.0)
+        << "on_execution remains the sole writer of the cost basis";
+
+    // Re-running the day now takes the exit branch, with no seeding involved.
+    ASSERT_TRUE(strategy->on_data(bars).is_ok());
+    EXPECT_GT(strategy->get_position("AAPL"), 0.0)
+        << "the accumulated holding is held inside the hold band";
+}


### PR DESCRIPTION
Second fix wave: corp-action realized booked into the day-T aggregate, terminations recorded in the dedup log, portfolio-scoped stale-execution cleanup, refusal of unscoped position deletes, fail the run on a lost T-1 write.