### PR TITLE
equities: verification fixes

### DIFF
--- a/apps/backtest/bt_equity_mean_reversion.cpp
+++ b/apps/backtest/bt_equity_mean_reversion.cpp
@@ -248,6 +248,10 @@ int main() {
         // Build each enabled strategy. Dispatch on type (collect_enabled_equity_strategies
         // already validated that the type is recognized).
         std::vector<std::pair<std::shared_ptr<StrategyInterface>, double>> strategies;
+        // The optimizer/risk loop is portfolio-wide, so a fractional target is a
+        // legitimate end state for the portfolio as soon as any enabled strategy
+        // permits one.
+        bool any_fractional_shares = false;
         for (const auto& entry : strat_entries) {
             double weight = entry.allocation / total_allocation;
             StrategyConfig sc = base_strategy_config;
@@ -256,6 +260,7 @@ int main() {
             std::shared_ptr<StrategyInterface> strategy;
             if (entry.type == "MeanReversionStrategy") {
                 auto mr_config = trade_ngin::apps::build_mean_reversion_config(entry.def["config"]);
+                any_fractional_shares |= mr_config.allow_fractional_shares;
                 strategy = std::make_shared<MeanReversionStrategy>(
                     entry.id, sc, mr_config, db, registry_ptr);
             } else {
@@ -288,7 +293,10 @@ int main() {
         portfolio_config.reserve_capital = Decimal(initial_capital * app_config.reserve_capital_pct);
         portfolio_config.use_optimization = false;
         portfolio_config.use_risk_management = app_config.strategy_defaults.use_risk_management;
+        portfolio_config.allow_fractional_positions = any_fractional_shares;
         portfolio_config.risk_config = app_config.risk_config;
+        INFO(std::string("Fractional positions permitted: ") +
+             (any_fractional_shares ? "yes (from strategy allow_fractional_shares)" : "no"));
 
         auto portfolio = std::make_shared<PortfolioManager>(portfolio_config);
 

--- a/apps/backtest/bt_equity_mean_reversion.cpp
+++ b/apps/backtest/bt_equity_mean_reversion.cpp
@@ -332,6 +332,11 @@ int main() {
                     coordinator->get_execution_manager()
                         ->get_transaction_cost_manager()
                         .register_equity_costs_from_bars(symbols, bars_by_symbol);
+                    // E2-C9: PortfolioManager owns a SECOND, independent cost manager, and
+                    // it is the one whose numbers reach backtest.executions and the equity
+                    // curve -- the coordinator's only feeds the reported metrics. Registering
+                    // just one left a single run carrying two different cost bases.
+                    portfolio->register_equity_cost_configs(symbols, bars_by_symbol);
                 } else {
                     WARN("Failed to convert warmup bars: " +
                          std::string(warmup_bars_result.error()->what()) +

--- a/apps/backtest/bt_equity_validation.cpp
+++ b/apps/backtest/bt_equity_validation.cpp
@@ -609,28 +609,32 @@ int main() {
                       << std::setw(10) << "Volatility" << std::endl;
             std::cout << std::string(75, '-') << std::endl;
 
-            // BOD (Beginning-of-Day) model replication:
-            // Day 1: on_data() receives Day 1 bars (first time, no previous exists)
-            // Day 2: on_data() receives Day 1 bars (previous day's bars)
-            // Day 3: on_data() receives Day 2 bars
-            // ...
-            // Day N: on_data() receives Day N-1 bars
-            // After Day N: portfolio_previous_bars_ = Day N bars (NOT fed to strategy)
+            // Sequence of closes the strategy actually sees.
             //
-            // So the strategy receives: close[0], close[0], close[1], close[2], ..., close[N-2]
-            // (Day 1 appears twice, Day N-1 is last one fed, Day N is never fed)
+            // The coordinator feeds PREVIOUS-day bars for signal generation
+            // (backtest_coordinator.cpp: `bars_for_signals = portfolio_previous_bars_`),
+            // which lags the feed by one day but does NOT drop either end:
             //
-            // Build the actual sequence of closes the strategy sees:
-            std::vector<double> bod_closes;
-            std::vector<Timestamp> bod_timestamps;
-            // Day 1: first-time fallback, strategy sees Day 1
-            bod_closes.push_back(closes[0]);
-            bod_timestamps.push_back(timestamps[0]);
-            // Day 2 onwards: strategy sees previous day's bars
-            for (size_t i = 0; i < closes.size() - 1; i++) {
-                bod_closes.push_back(closes[i]);
-                bod_timestamps.push_back(timestamps[i]);
-            }
+            //  * Day 1 is not processed twice. The coordinator early-returns on the first
+            //    bar set, seeding portfolio_previous_bars_ and nothing else, so close[0]
+            //    reaches the strategy exactly once -- on day 2.
+            //  * The final bar is not skipped. The backtest range runs to end_date (today),
+            //    beyond the last bar with data, so the trailing iterations feed the last
+            //    bar as "previous bars". close[N-1] does reach the strategy.
+            //
+            // The net effect is a pure one-day lag, so the SET of closes the strategy sees
+            // is every close in order. Verified against a live run (E2-F4): for AMZN --
+            // chosen because it has no corporate action in the window, so raw == adjusted --
+            // the strategy's final state matches the 20 bars ending on the LAST bar
+            // (SMA 266.739500, StdDev 7.346419, vol 0.321135, z -0.042129) on all four
+            // metrics to six decimals.
+            //
+            // The previous model here duplicated close[0] and stopped at close[N-2]. Its
+            // window therefore ended one bar early, and it compared its 2026-08-27 state
+            // against the strategy's 2026-08-28 state -- 12 false failures, 3 symbols x
+            // 4 metrics, while both sides' arithmetic was individually correct.
+            std::vector<double> bod_closes = closes;
+            std::vector<Timestamp> bod_timestamps = timestamps;
 
             std::cout << "BOD sequence length: " << bod_closes.size()
                       << " (from " << closes.size() << " raw bars)" << std::endl;

--- a/apps/strategies/live_equity_mean_reversion.cpp
+++ b/apps/strategies/live_equity_mean_reversion.cpp
@@ -1817,7 +1817,22 @@ int main(int argc, char* argv[]) {
                 // These are updates to existing positions from the previous day
                 auto update_result = db->store_positions(finalized_to_store, kEquityStrategyId, kEquityStrategyName, portfolio_id, "trading.positions");
                 if (update_result.is_error()) {
+                    // E2-F5 follow-on: FATAL, like every other store_positions site in this
+                    // runner. This one logged and carried on, so a failed T-1 position write
+                    // left the run exiting 0 with the previous day's rows still holding their
+                    // Day-T placeholders -- the row-versus-aggregate split that L5 exists to
+                    // catch, produced by a run that looked clean.
+                    //
+                    // It matters more since E2-F5: store_positions now REFUSES to fall back to
+                    // an unscoped delete and returns an error instead, so this path is
+                    // genuinely reachable on a transient SQL fault rather than only on a
+                    // broken schema. The transaction rolls back cleanly (pqxx::work destructs
+                    // uncommitted), so nothing is half-written -- but the day is unfinalized
+                    // and the next run would build on it.
                     ERROR("Failed to update Day T-1 positions: " + std::string(update_result.error()->what()));
+                    ERROR("Day T-1 positions could not be finalized. Refusing to exit 0 with "
+                          "an unfinalized book.");
+                    return 1;
                 } else {
                     INFO("Successfully updated " + std::to_string(finalized_to_store.size()) + " Day T-1 positions with finalized PnL");
                 }

--- a/apps/strategies/live_equity_mean_reversion.cpp
+++ b/apps/strategies/live_equity_mean_reversion.cpp
@@ -690,6 +690,90 @@ int main(int argc, char* argv[]) {
             INFO("No previous day positions found (first run or no data): " + std::string(previous_positions_result.error()->what()));
         }
 
+        // An empty prior book is legitimate on a genuine first run, and catastrophic
+        // otherwise. The two are indistinguishable from here -- both are an empty map --
+        // and the consequences of guessing wrong are total: the strategy seeds flat, the
+        // corporate-action block is skipped by its own !previous_positions.empty() guard,
+        // every position silently disappears from trading.positions, and the next day's
+        // executions are sized as deltas from zero against stock the broker still holds.
+        //
+        // Runs MUST be sequential and complete -- that is inherent to the T-1 lag model,
+        // where day T's P&L is finalized by day T+1's run -- so a hole here means a run was
+        // missed, not that the strategy is flat. The remedy is to replay the missing dates
+        // in order, which works and needs no code. What was missing is being TOLD: this
+        // previously exited 0 with no ERROR and no WARN, so a monitor watching exit codes
+        // saw a clean run while the book was being abandoned (E2-F8).
+        //
+        // Deliberately NOT resolved by falling back to MAX(date): that would paper over a
+        // broken invariant and could silently revive a stale book.
+        if (previous_positions.empty()) {
+            // An empty prior book has two very different causes and they must not be
+            // conflated:
+            //   (a) the strategy legitimately holds nothing -- it exited everything, or it
+            //       is a genuine first run;
+            //   (b) a run was MISSED, so the prior day was never written at all.
+            //
+            // (b) is silent and destructive: the strategy seeds flat, the corporate-action
+            // block is skipped by its own !previous_positions.empty() guard, every position
+            // vanishes from trading.positions, and the next day's executions are sized as
+            // deltas from zero against stock the broker still holds (E2-F8).
+            //
+            // The discriminator is NOT "are there positions" -- a flat book has none and is
+            // perfectly valid. It is "did a run HAPPEN for that date". Every run writes a
+            // live_results row whether or not it holds anything, so that row is the evidence
+            // a run occurred. Testing positions instead would refuse to start every time the
+            // strategy went flat, which is a normal state.
+            //
+            // Deliberately NOT resolved by falling back to MAX(date): that would paper over
+            // a broken invariant and could silently revive a stale book. Runs must be
+            // sequential -- inherent to the T-1 lag model -- so the remedy is to replay the
+            // missing dates in order, which works and needs no code change. What was missing
+            // was being TOLD.
+            const std::string prev_date_str = trade_ngin::core::format_utc_date(previous_date);
+            auto prev_run = db->execute_query(
+                "SELECT count(*)::text FROM trading.live_results "
+                "WHERE strategy_id = '" + std::string(kEquityStrategyId) + "'"
+                " AND portfolio_id = '" + portfolio_id + "'"
+                " AND date = '" + prev_date_str + "'");
+
+            long prev_run_rows = 0;
+            if (prev_run.is_ok() && prev_run.value()->num_rows() > 0) {
+                auto col = std::static_pointer_cast<arrow::StringArray>(
+                    prev_run.value()->column(0)->chunk(0));
+                if (!col->IsNull(0)) prev_run_rows = std::stol(std::string(col->GetView(0)));
+            }
+
+            if (prev_run_rows > 0) {
+                INFO("Previous trading day (" + prev_date_str +
+                     ") ran and held no positions -- the strategy is flat, which is a valid "
+                     "state. Continuing.");
+            } else {
+                auto last_run = db->execute_query(
+                    "SELECT MAX(date)::text FROM trading.live_results "
+                    "WHERE strategy_id = '" + std::string(kEquityStrategyId) + "'"
+                    " AND portfolio_id = '" + portfolio_id + "'"
+                    " AND date < '" + today_date_str + "'");
+
+                std::string last_run_date;
+                if (last_run.is_ok() && last_run.value()->num_rows() > 0) {
+                    auto col = std::static_pointer_cast<arrow::StringArray>(
+                        last_run.value()->column(0)->chunk(0));
+                    if (!col->IsNull(0)) last_run_date = std::string(col->GetView(0));
+                }
+
+                if (!last_run_date.empty()) {
+                    ERROR("No run was recorded for the previous trading day (" + prev_date_str +
+                          "), but this strategy last ran on " + last_run_date +
+                          ". A run was missed. Replay every date from " + last_run_date +
+                          " forward, in order, before running " + today_date_str +
+                          " -- continuing would seed the strategy flat and silently abandon "
+                          "the book. Refusing to run.");
+                    return 1;
+                }
+                INFO("No prior run anywhere for this strategy -- genuine first run.");
+            }
+        }
+
         DEBUG("Previous date used for lookup: " + std::to_string(std::chrono::system_clock::to_time_t(previous_date)));
         DEBUG("Current date: " + std::to_string(std::chrono::system_clock::to_time_t(now)));
         DEBUG("Previous positions loaded: " + std::to_string(previous_positions.size()));

--- a/apps/strategies/live_equity_mean_reversion.cpp
+++ b/apps/strategies/live_equity_mean_reversion.cpp
@@ -2198,7 +2198,10 @@ int main(int argc, char* argv[]) {
         }
 
         double daily_realized_pnl = 0.0;
-        double daily_unrealized_pnl = 0.0;
+        // daily_unrealized_pnl used to be declared and pinned to 0.0 here as a Day-T placeholder.
+        // Nothing ever repaired it -- the Day T-1 UPDATE below never mentions the column -- so
+        // every equity row carried 0 even though the book had open marks (E2-F12). It is now
+        // computed for real in STEP 5, once the previous day's mark is known.
         double daily_pnl_for_today = -total_daily_commissions;  // Only commissions on Day T
 
         INFO("Day T PnL (placeholder): $0.00");
@@ -2291,13 +2294,78 @@ int main(int argc, char* argv[]) {
                 INFO("Could not load day-before-yesterday aggregates: " + std::string(e.what()));
             }
 
+            // Strip the mark out of the day-before-yesterday total_pnl, for the same reason as
+            // in STEP 5: get_previous_live_aggregates() returns the STORED total_pnl, which is
+            // now mark-to-market for equities. yesterday_total_pnl_cumulative is a REALIZED
+            // running total -- it feeds total_realized_pnl below -- so an unstripped value
+            // would push the day-before-yesterday's open-position mark into the realized
+            // column, inflating it by exactly the prior day's total_unrealized_pnl.
+            double day_before_yesterday_total_unrealized_pnl = 0.0;
+            try {
+                std::string dby_unrl_query =
+                    "SELECT COALESCE(total_unrealized_pnl, 0.0) FROM trading.live_results "
+                    "WHERE strategy_id = 'LIVE_EQUITY_MEAN_REVERSION' AND portfolio_id = '" + portfolio_id + "' "
+                    "AND DATE(date) < '" + yesterday_date_str + "' "
+                    "ORDER BY date DESC LIMIT 1";
+                auto du = db->execute_query(dby_unrl_query);
+                if (du.is_ok() && du.value()->num_rows() > 0) {
+                    auto r = DataConversionUtils::safe_get_double(du.value()->column(0), 0,
+                                                                  "total_unrealized_pnl");
+                    if (r.is_ok()) {
+                        day_before_yesterday_total_unrealized_pnl = r.value();
+                    } else {
+                        WARN("Could not read day-before-yesterday total_unrealized_pnl (" +
+                             std::string(r.error()->what()) + "); treating it as 0, which will "
+                             "overstate total_realized_pnl by the prior mark.");
+                    }
+                }
+            } catch (const std::exception& e) {
+                WARN("Could not load day-before-yesterday total_unrealized_pnl: " + std::string(e.what()));
+            }
+            const double day_before_yesterday_realized_only =
+                day_before_yesterday_total_pnl - day_before_yesterday_total_unrealized_pnl;
+
             // Calculate yesterday's cumulative values
             // NOTE: Since we may not have correct commissions, the cumulative values will be recalculated by SQL
             // using the daily_pnl formula (daily_realized_pnl - daily_commissions)
-            double yesterday_total_pnl_cumulative = day_before_yesterday_total_pnl + yesterday_daily_pnl_finalized;
+            double yesterday_total_pnl_cumulative = day_before_yesterday_realized_only + yesterday_daily_pnl_finalized;
             double yesterday_total_commissions_cumulative = day_before_yesterday_total_commissions + yesterday_commissions;
             double yesterday_total_realized_pnl_cumulative = yesterday_total_pnl_cumulative + yesterday_total_commissions_cumulative;
-            double yesterday_portfolio_value_finalized = day_before_yesterday_portfolio_value + yesterday_daily_pnl_finalized;
+            // Yesterday's own mark, i.e. the total_unrealized_pnl the INSERT wrote on the T-1
+            // row. The UPDATE's current_portfolio_value expression below reads the same stored
+            // value (bare `total_unrealized_pnl` on the RHS of a SET is the pre-UPDATE value),
+            // so computing it the same way here keeps the return columns consistent with the
+            // equity they are supposed to describe.
+            double yesterday_total_unrealized_pnl = 0.0;
+            try {
+                std::string y_unrl_query =
+                    "SELECT COALESCE(total_unrealized_pnl, 0.0) FROM trading.live_results "
+                    "WHERE strategy_id = 'LIVE_EQUITY_MEAN_REVERSION' AND portfolio_id = '" + portfolio_id + "' "
+                    "AND DATE(date) = '" + yesterday_date_str + "'";
+                auto yu = db->execute_query(y_unrl_query);
+                if (yu.is_ok() && yu.value()->num_rows() > 0) {
+                    auto r = DataConversionUtils::safe_get_double(yu.value()->column(0), 0,
+                                                                  "total_unrealized_pnl");
+                    if (r.is_ok()) {
+                        yesterday_total_unrealized_pnl = r.value();
+                    } else {
+                        WARN("Could not read yesterday's total_unrealized_pnl (" +
+                             std::string(r.error()->what()) + "); the T-1 return columns will be "
+                             "computed off a realized-only equity and will disagree with "
+                             "current_portfolio_value.");
+                    }
+                }
+            } catch (const std::exception& e) {
+                WARN("Could not load yesterday's total_unrealized_pnl: " + std::string(e.what()));
+            }
+
+            // Mark-to-market equity for T-1. Anchored on initial_capital rather than chained off
+            // the previous stored value, so it cannot drift from the SQL expression that writes
+            // current_portfolio_value -- the two are the same formula.
+            double yesterday_portfolio_value_finalized = initial_capital
+                + day_before_yesterday_realized_only
+                + yesterday_daily_pnl_finalized
+                + yesterday_total_unrealized_pnl;
 
             // Calculate yesterday's returns using LiveMetricsCalculator
             double yesterday_daily_return = metrics_calculator->calculate_daily_return(
@@ -2387,9 +2455,21 @@ int main(int argc, char* argv[]) {
             //  UPDATE must read the same column or the whole statement fails)
             // IMPORTANT: Only update portfolio_leverage and equity_to_margin_ratio if they are NULL or 0
             std::string update_query =
+                // Mark-to-market, EQUITIES ONLY -- mirrors the Day-T block in STEP 5; read the
+                // long comment there first. Two things matter here:
+                //   (1) The running total must stay REALIZED-ONLY, so the prior row's mark is
+                //       stripped back off (`total_pnl - total_unrealized_pnl` in day_before)
+                //       before today's realized flow is added. Without the strip, each day
+                //       re-adds the previous day's open-position mark and the curve diverges.
+                //   (2) This row's OWN mark is then layered on once. Bare `total_unrealized_pnl`
+                //       on the right-hand side of a SET reads the row's pre-UPDATE value, which
+                //       is the snapshot the INSERT wrote for that day -- exactly what we want.
+                // This UPDATE previously never mentioned daily_unrealized_pnl at all, which is
+                // why the Day-T placeholder 0 survived on every finalized equity row.
                 "WITH day_before AS ("
                 "  SELECT COALESCE(current_portfolio_value, " + std::to_string(initial_capital) + ") as portfolio, "
-                "         COALESCE(total_pnl, 0.0) as total_pnl, "
+                "         COALESCE(total_pnl, 0.0) - COALESCE(total_unrealized_pnl, 0.0) as realized_only, "
+                "         COALESCE(total_unrealized_pnl, 0.0) as prev_unrealized, "
                 "         COALESCE(total_realized_pnl, 0.0) as total_realized_pnl_prev "
                 "  FROM trading.live_results "
                 "  WHERE strategy_id = 'LIVE_EQUITY_MEAN_REVERSION' AND portfolio_id = '" + portfolio_id + "' AND DATE(date) < '" + yesterday_date_str + "' "
@@ -2397,18 +2477,22 @@ int main(int argc, char* argv[]) {
                 ") "
                 "UPDATE trading.live_results SET "
                 "daily_realized_pnl = " + std::to_string(yesterday_total_pnl) + ", "
-                "daily_pnl = " + std::to_string(yesterday_total_pnl) + " - COALESCE(daily_transaction_costs, 0.0), "
-                "total_pnl = COALESCE((SELECT total_pnl FROM day_before), 0.0) + (" + std::to_string(yesterday_total_pnl) + " - COALESCE(daily_transaction_costs, 0.0)), "
+                "daily_unrealized_pnl = COALESCE(total_unrealized_pnl, 0.0) - COALESCE((SELECT prev_unrealized FROM day_before), 0.0), "
+                "daily_pnl = (" + std::to_string(yesterday_total_pnl) + " - COALESCE(daily_transaction_costs, 0.0)) "
+                "            + (COALESCE(total_unrealized_pnl, 0.0) - COALESCE((SELECT prev_unrealized FROM day_before), 0.0)), "
+                "total_pnl = COALESCE((SELECT realized_only FROM day_before), 0.0) + (" + std::to_string(yesterday_total_pnl) + " - COALESCE(daily_transaction_costs, 0.0)) + COALESCE(total_unrealized_pnl, 0.0), "
                 "total_realized_pnl = " + std::to_string(yesterday_total_realized_pnl_cumulative) + ", "
-                "current_portfolio_value = COALESCE((SELECT portfolio FROM day_before), " + std::to_string(initial_capital) + ") + (" + std::to_string(yesterday_total_pnl) + " - COALESCE(daily_transaction_costs, 0.0)), "
+                "current_portfolio_value = " + std::to_string(initial_capital) + " + COALESCE((SELECT realized_only FROM day_before), 0.0) + (" + std::to_string(yesterday_total_pnl) + " - COALESCE(daily_transaction_costs, 0.0)) + COALESCE(total_unrealized_pnl, 0.0), "
                 "daily_return = CASE WHEN COALESCE((SELECT portfolio FROM day_before), " + std::to_string(initial_capital) + ") > 0 "
-                "               THEN ((" + std::to_string(yesterday_total_pnl) + " - COALESCE(daily_transaction_costs, 0.0)) / COALESCE((SELECT portfolio FROM day_before), " + std::to_string(initial_capital) + ")) * 100.0 "
+                "               THEN (((" + std::to_string(yesterday_total_pnl) + " - COALESCE(daily_transaction_costs, 0.0)) "
+                "                      + (COALESCE(total_unrealized_pnl, 0.0) - COALESCE((SELECT prev_unrealized FROM day_before), 0.0))) "
+                "                     / COALESCE((SELECT portfolio FROM day_before), " + std::to_string(initial_capital) + ")) * 100.0 "
                 "               ELSE 0.0 END, "
                 "total_cumulative_return = " + std::to_string(yesterday_total_cumulative_return_pct) + ", "
                 "total_annualized_return = " + std::to_string(yesterday_total_return_annualized) + ", "
                 "portfolio_leverage = CASE WHEN portfolio_leverage IS NULL OR portfolio_leverage = 0 THEN " + std::to_string(yesterday_portfolio_leverage) + " ELSE portfolio_leverage END, "
                 "equity_to_margin_ratio = CASE WHEN equity_to_margin_ratio IS NULL OR equity_to_margin_ratio = 0 THEN " + std::to_string(yesterday_equity_to_margin_ratio) + " ELSE equity_to_margin_ratio END, "
-                "cash_available = COALESCE((SELECT portfolio FROM day_before), " + std::to_string(initial_capital) + ") + (" + std::to_string(yesterday_total_pnl) + " - COALESCE(daily_transaction_costs, 0.0)) - COALESCE(margin_posted, 0.0) "
+                "cash_available = " + std::to_string(initial_capital) + " + COALESCE((SELECT realized_only FROM day_before), 0.0) + (" + std::to_string(yesterday_total_pnl) + " - COALESCE(daily_transaction_costs, 0.0)) + COALESCE(total_unrealized_pnl, 0.0) - COALESCE(margin_posted, 0.0) "
                 "WHERE strategy_id = 'LIVE_EQUITY_MEAN_REVERSION' AND portfolio_id = '" + portfolio_id + "' AND DATE(date) = '" + yesterday_date_str + "'";
 
             INFO("Executing UPDATE query for Day T-1 live_results...");
@@ -2580,6 +2664,12 @@ int main(int argc, char* argv[]) {
         double previous_portfolio_value = initial_capital; // Default to initial capital
         double previous_total_pnl = 0.0;
         double previous_total_commissions = 0.0;
+        // The previous row's mark-to-market snapshot. Needed for two things: to strip the mark
+        // back out of the previous stored total_pnl so the running total stays realized-only,
+        // and to difference into daily_unrealized_pnl. get_previous_live_aggregates() is shared
+        // with the futures runners so it is not widened to return this; the equity runner reads
+        // the column itself, scoped by portfolio_id like every other query in this file.
+        double previous_total_unrealized_pnl = 0.0;
 
         try {
             auto db_ptr = std::dynamic_pointer_cast<PostgresDatabase>(db);
@@ -2598,19 +2688,95 @@ int main(int argc, char* argv[]) {
             INFO("Could not load previous day aggregates: " + std::string(e.what()));
         }
 
-        // Calculate cumulative values for Day T
-        double total_pnl = previous_total_pnl + daily_pnl_for_today;
-        double current_portfolio_value = previous_portfolio_value + daily_pnl_for_today;
-        double daily_pnl = daily_pnl_for_today;  // Only commissions on Day T
+        // Load the previous row's mark-to-market snapshot (see declaration above). A missing
+        // row -- the first trading day -- correctly leaves this at 0.0, which makes the
+        // realized-only strip a no-op and makes daily_unrealized_pnl equal the full opening
+        // mark, both of which are right on day one.
+        try {
+            std::string prev_unrealized_query =
+                "SELECT COALESCE(total_unrealized_pnl, 0.0) FROM trading.live_results "
+                "WHERE strategy_id = 'LIVE_EQUITY_MEAN_REVERSION' AND portfolio_id = '" + portfolio_id + "' "
+                "AND DATE(date) < '" + today_date_str + "' "
+                "ORDER BY date DESC LIMIT 1";
+            auto pu = db->execute_query(prev_unrealized_query);
+            if (pu.is_ok() && pu.value()->num_rows() > 0) {
+                auto r = DataConversionUtils::safe_get_double(pu.value()->column(0), 0,
+                                                              "total_unrealized_pnl");
+                if (r.is_ok()) {
+                    previous_total_unrealized_pnl = r.value();
+                    INFO("Loaded previous total_unrealized_pnl: $" +
+                         std::to_string(previous_total_unrealized_pnl));
+                } else {
+                    WARN("Could not read previous total_unrealized_pnl (" +
+                         std::string(r.error()->what()) + "); treating the previous mark as 0. "
+                         "total_pnl will be overstated by the prior mark until the next clean read.");
+                }
+            } else {
+                INFO("No previous total_unrealized_pnl row; treating the previous mark as 0");
+            }
+        } catch (const std::exception& e) {
+            WARN("Could not load previous total_unrealized_pnl: " + std::string(e.what()));
+        }
+
+        // Mark-to-market accounting -- EQUITIES ONLY. Read this before changing anything here.
+        //
+        // WHY EQUITIES DIFFER FROM FUTURES (E2-F12). `average_price` does not mean the same
+        // thing in the two books:
+        //   * Futures: average_price IS the prior settlement close, i.e. a mark. A position is
+        //     entered at close(T-1) and settled at close(T), so the entire move is realized on
+        //     the day it happens and unrealized is 0 BY IDENTITY. The futures runners therefore
+        //     write 0 to both unrealized columns and a realized-only total_pnl, which for them
+        //     already IS mark-to-market. Nothing about the futures path may change.
+        //   * Equities: average_price is a true weighted cost basis that survives across days.
+        //     An open position carries a real mark-to-market gain or loss that is NOT in
+        //     realized PnL. Reporting realized-only here understates a book holding winners and
+        //     leaves the equity curve flat while the book actually moves.
+        // So this runner reports total_pnl and current_portfolio_value INCLUDING unrealized.
+        //
+        // WHY THE RECURSION IS REALIZED-ONLY. total_pnl was previously accumulated as
+        // `previous_total_pnl + daily_pnl_for_today`, reading the previous row's total_pnl back
+        // out of the DB. If unrealized were folded into the stored total_pnl and that same
+        // recursion were kept, every day would re-add the PRIOR day's open-position mark on top
+        // of today's -- unrealized would compound into a cumulative sum of daily snapshots and
+        // the equity curve would diverge without bound. Unrealized is a SNAPSHOT, not a flow:
+        // it replaces the prior snapshot, it does not add to it. The running total therefore
+        // stays realized-only and unrealized is layered on top once, at the end.
         double total_commissions_cumulative = previous_total_commissions + total_daily_commissions;
 
-        // For equities, track realized PnL separately from unrealized
-        double total_realized_pnl = total_pnl + total_commissions_cumulative;
-        // Calculate total unrealized PnL from current open positions
+        // Calculate total unrealized PnL from current open positions. Computed BEFORE total_pnl
+        // now (it used to be derived after) because total_pnl depends on it.
         double total_unrealized_pnl = 0.0;
         for (const auto& [sym, pos] : positions) {
             total_unrealized_pnl += pos.unrealized_pnl.as_double();
         }
+
+        // Strip the mark out of the previous row's stored total_pnl to recover the realized-only
+        // running total. previous_total_pnl comes from get_previous_live_aggregates(), which is
+        // shared with the futures runners and reads the stored total_pnl column -- for futures
+        // previous_total_unrealized_pnl is 0 so this subtraction is a no-op there.
+        double previous_total_pnl_realized_only = previous_total_pnl - previous_total_unrealized_pnl;
+
+        // Realized-only running total: the accumulator, unchanged in meaning from before.
+        double total_pnl_realized_only = previous_total_pnl_realized_only + daily_pnl_for_today;
+
+        // total_realized_pnl keeps its original derivation off the realized-only accumulator,
+        // so the invariant total_pnl_realized_only == total_realized_pnl - total_commissions
+        // still holds exactly and the reconciliation in the protocol is unaffected.
+        double total_realized_pnl = total_pnl_realized_only + total_commissions_cumulative;
+
+        // Day-over-day change in the mark. This is what daily_unrealized_pnl should have held
+        // all along; it was previously hard-wired to 0.0 as a Day-T placeholder and never
+        // repaired by the Day T-1 UPDATE, so it read 0 on every equity row.
+        double daily_unrealized_pnl = total_unrealized_pnl - previous_total_unrealized_pnl;
+
+        // Mark-to-market reported figures.
+        double total_pnl = total_pnl_realized_only + total_unrealized_pnl;
+        double current_portfolio_value = initial_capital + total_pnl;
+
+        // daily_pnl must be the day-over-day change in total_pnl or the equity-curve continuity
+        // invariant (protocol L6: value(T) - value(T-1) == daily_pnl(T)) breaks the moment the
+        // curve became mark-to-market.
+        double daily_pnl = daily_pnl_for_today + daily_unrealized_pnl;
 
         // Calculate returns using LiveMetricsCalculator
         double daily_return = metrics_calculator->calculate_daily_return(daily_pnl, previous_portfolio_value);

--- a/apps/strategies/live_equity_mean_reversion.cpp
+++ b/apps/strategies/live_equity_mean_reversion.cpp
@@ -405,6 +405,16 @@ int main(int argc, char* argv[]) {
 
         // Create portfolio manager and add strategy
         INFO("Creating portfolio manager...");
+        // A fractional target is a legitimate end state when the strategy allows
+        // fractional shares, so the optimizer/risk loop must not keep iterating
+        // toward whole units -- each extra lap re-applies the risk scale to an
+        // already-scaled book (E2-F1). Set from the strategy's own config so live
+        // and backtest agree. Futures leave this false and are unaffected.
+        portfolio_config.allow_fractional_positions = mean_rev_config.allow_fractional_shares;
+        INFO(std::string("Fractional positions permitted: ") +
+             (portfolio_config.allow_fractional_positions
+                  ? "yes (from strategy allow_fractional_shares)"
+                  : "no"));
         auto portfolio = std::make_shared<trade_ngin::PortfolioManager>(portfolio_config);
         auto add_result =
             portfolio->add_strategy(mr_strategy, 1.0, portfolio_config.use_optimization,

--- a/apps/strategies/live_equity_mean_reversion.cpp
+++ b/apps/strategies/live_equity_mean_reversion.cpp
@@ -836,9 +836,39 @@ int main(int argc, char* argv[]) {
             previous_positions;
 
         // Executions synthesised from corporate actions (terminations), merged into the
-        // day's executions after execute_day_t so their realized P&L reaches live_results
-        // and the equity curve, and so a broker statement has a counterpart (E2-F11).
+        // day's executions after execute_day_t so a broker statement has a counterpart.
+        //
+        // E2-F12 (comment correction): this used to claim the executions are what carry the
+        // realized P&L into live_results and the equity curve. That was FALSE.
+        // live_results.daily_realized_pnl has never been derived from executions -- it comes
+        // from the day-T aggregate and the T-1 finalization -- so appending an execution gave
+        // the corp-action delta no route into any aggregate at all. The row said 122.00 and
+        // live_results said 0.00.
+        //
+        // The execution row is still worth emitting: it is the broker-reconcilable
+        // counterpart, and without it a liquidation appears on a statement with nothing in
+        // trading.executions to match. But it is NOT the P&L path. That is
+        // corp_action_realized_total below (E2-F7).
         std::vector<ExecutionReport> corp_action_executions;
+
+        // E2-F7: the realized P&L a termination locks in, summed so it can be folded into
+        // the day's aggregate.
+        //
+        // CorporateActionsLifecycle computes `realized_delta = (exit_price - avg_price) *
+        // qty_before` and writes it onto the position and the adjustment record -- and until
+        // now its ONLY other consumer in the entire tree was a log string. No aggregate read
+        // it, so a terminated holding's gain or loss never reached daily_realized_pnl,
+        // total_pnl, current_portfolio_value or the equity curve.
+        //
+        // It is booked on day T, the ex-date, NOT threaded through finalize_previous_day.
+        // That function writes the T-1 row, so passing the delta to it would book a day-T
+        // cash flow onto the previous day -- exactly the restatement 8a1a96ef removed. It
+        // would also put the T-1 aggregate out of agreement with the T-1 executions and
+        // position rows.
+        //
+        // Booking it here touches NO shared file, so the futures binaries are unchanged by
+        // construction rather than by argument.
+        double corp_action_realized_total = 0.0;
 
         DEBUG("Previous date used for lookup: " + std::to_string(std::chrono::system_clock::to_time_t(previous_date)));
         DEBUG("Current date: " + std::to_string(std::chrono::system_clock::to_time_t(now)));
@@ -1566,6 +1596,10 @@ int main(int argc, char* argv[]) {
                 if (adj.outcome != LifecycleOutcome::EXITED_AT_FINAL_CLOSE) continue;
                 if (std::abs(adj.quantity_before) < 1e-9 || !(adj.exit_price > 0.0)) continue;
 
+                // E2-F7: the P&L route. Gated on the same conditions as the execution row so
+                // the two can never disagree about which events were recognised.
+                corp_action_realized_total += adj.realized_delta;
+
                 ExecutionReport ca_exec;
                 ca_exec.order_id = "CORPACTION_" + adj.symbol + "_" + adj.event_date;
                 ca_exec.exec_id  = "CA_" + adj.symbol + "_" + adj.event_date + "_EXIT";
@@ -1599,17 +1633,100 @@ int main(int argc, char* argv[]) {
                     p.last_update = now;
                     lifecycle_positions.push_back(std::move(p));
                 }
+
+                // E2-F13: record class-3 events in the audit/dedup log.
+                //
+                // audit_log.record() was called ONLY from the class-1 applier block, so a
+                // termination left no row in trading.corp_action_applied at all -- no audit
+                // trail, and nothing to stop a replay re-applying it. Class-1 events have
+                // been deduped since the dedup table landed; class 3 never was.
+                //
+                // LifecycleAdjustment and PositionAdjustment are different records, so the
+                // fields are mapped explicitly. event_value carries the exit price (the
+                // event's defining parameter for a termination, as the split factor or
+                // $/share is for class 1) and ratio_change stays 1.0 because a termination
+                // restates no price.
+                //
+                // The dedup key is (symbol, event_date, type), and TERMINATION is a new type
+                // value, so these rows cannot collide with existing SPLIT/DIVIDEND keys.
+                // Its own instance, following the div_log precedent below. Safe because the
+                // class-1 audit_log is long out of scope by now -- the header's "concurrent
+                // instances not supported" warning is about a save() race between two LIVE
+                // objects, and these are strictly sequential.
+                CorporateActionsAuditLog lifecycle_audit(ca_state_dir, db,
+                                                         portfolio_id,
+                                                         "LIVE_EQUITY_MEAN_REVERSION",
+                                                         "EQUITY_MEAN_REVERSION");
+                auto lc_loaded = lifecycle_audit.load();
+                if (lc_loaded.is_error()) {
+                    // Fail closed, matching the class-1 block: a dedup record that cannot be
+                    // read cannot be extended safely, and writing on top of an unknown state
+                    // risks re-applying a termination on the next run.
+                    ERROR("Cannot read the corp-action dedup record for lifecycle events: " +
+                          std::string(lc_loaded.error()->what()));
+                    return 1;
+                }
+
+                std::size_t recorded = 0;
+                for (const auto& adj : lifecycle_log) {
+                    if (adj.outcome != LifecycleOutcome::EXITED_AT_FINAL_CLOSE &&
+                        adj.outcome != LifecycleOutcome::CONVERTED_TO_CONTRA) {
+                        continue;  // nothing was applied; nothing to dedup against
+                    }
+                    PositionAdjustment rec;
+                    rec.symbol = adj.symbol;
+                    rec.event_date = adj.event_date;
+                    rec.type = CorpActionType::TERMINATION;
+                    rec.quantity_before = adj.quantity_before;
+                    rec.quantity_after = adj.quantity_after;
+                    rec.avg_price_before = 0.0;
+                    rec.avg_price_after = 0.0;
+                    rec.event_value = adj.exit_price;
+                    rec.ratio_change = 1.0;
+                    lifecycle_audit.record(rec);
+                    ++recorded;
+                }
+
+                // Positions and their dedup rows commit as ONE unit, for the same reason the
+                // class-1 block does it: positions committed with the dedup write lost would
+                // leave the next run free to re-apply the event.
+                auto lc_unit = db->begin_unit_of_work();
+                if (lc_unit.is_error()) {
+                    ERROR("Cannot open a unit of work for lifecycle persistence: " +
+                          std::string(lc_unit.error()->what()));
+                    return 1;
+                }
+                DbTransaction& lc_txn = *lc_unit.value();
+
                 auto store_lc = db->store_positions(
-                    lifecycle_positions,
+                    lc_txn, lifecycle_positions,
                     kEquityStrategyId, kEquityStrategyName,
                     portfolio_id, "trading.positions");
                 if (store_lc.is_error()) {
                     ERROR("Failed to persist lifecycle-adjusted positions: " +
                           std::string(store_lc.error()->what()));
+                    return 1;  // lc_txn rolls back on scope exit
+                }
+
+                if (recorded > 0) {
+                    auto save_lc = lifecycle_audit.save_in(lc_txn);
+                    if (save_lc.is_error()) {
+                        ERROR("Failed to persist lifecycle dedup records: " +
+                              std::string(save_lc.error()->what()));
+                        return 1;  // lc_txn rolls back on scope exit
+                    }
+                }
+
+                auto lc_commit = lc_txn.commit();
+                if (lc_commit.is_error()) {
+                    ERROR("Failed to commit lifecycle adjustments: " +
+                          std::string(lc_commit.error()->what()));
                     return 1;
                 }
+
                 INFO("Persisted " + std::to_string(lifecycle_log.size()) +
-                     " lifecycle adjustment(s) to trading.positions");
+                     " lifecycle adjustment(s) to trading.positions, " +
+                     std::to_string(recorded) + " dedup record(s)");
             }
         }
 
@@ -1945,7 +2062,30 @@ int main(int argc, char* argv[]) {
 
         // Feed executions back to strategy for cost basis tracking.
         // BaseStrategy::on_execution() maintains weighted average_price and realized_pnl.
+        //
+        // E2-F11: corporate-action exits are EXCLUDED. They are synthetic accounting entries,
+        // not fills the strategy should learn a basis from, and feeding them in corrupts its
+        // book.
+        //
+        // The mechanism: apply_terminations sets pos.quantity = 0 BEFORE the strategy is
+        // seeded from that same map, so by the time on_execution sees the exit the strategy
+        // holds ZERO of the symbol. Its realized branch (base_strategy.cpp:197-199) requires a
+        // position on the opposite side of the fill, so it books nothing -- and then the
+        // `else` at :237-251 treats the SELL as OPENING A SHORT, leaving the strategy holding
+        // a phantom -qty_before position in a delisted symbol at the exit price.
+        //
+        // It is invisible today: this runs after signal generation, and the zero-quantity
+        // filter drops the row before it is persisted. But the strategy carries a fabricated
+        // short for the rest of the process, and anything later that reads positions_ -- a
+        // stop-loss check, a risk aggregate, a second strategy sharing the book -- would see
+        // it. The realized P&L these exits lock in reaches the aggregate through
+        // corp_action_realized_total instead, which is the correct route.
         for (const auto& exec : daily_executions) {
+            if (exec.order_id.rfind("CORPACTION_", 0) == 0) {
+                DEBUG("Skipping on_execution for corp-action exit " + exec.symbol +
+                      " (synthetic entry; realized P&L booked via the day-T aggregate)");
+                continue;
+            }
             auto exec_result = mr_strategy->on_execution(exec);
             if (exec_result.is_error()) {
                 WARN("Failed to process execution for " + exec.symbol + ": " +
@@ -2358,6 +2498,25 @@ int main(int argc, char* argv[]) {
         double daily_realized_pnl = 0.0;
         if (mr_strategy) {
             daily_realized_pnl = mr_strategy->get_metrics().realized_pnl + total_daily_commissions;
+        }
+
+        // E2-F7: add the realized P&L locked in by corporate actions on this ex-date.
+        //
+        // A termination's gain or loss is genuine trade-realized P&L -- the position is gone
+        // and the proceeds are final -- but it never passes through BaseStrategy::on_execution
+        // in a way that books it. apply_terminations sets quantity = 0 BEFORE the strategy is
+        // seeded, so on_execution's realized branch (base_strategy.cpp:197-199, which requires
+        // a position on the opposite side of the fill) is false and computes nothing.
+        // metrics_.realized_pnl above therefore misses it entirely.
+        //
+        // Adding it here puts it in daily_realized_pnl, and from there it flows through the
+        // existing arithmetic into daily_pnl, total_realized_pnl, total_pnl,
+        // current_portfolio_value and the equity curve -- no new column, no second channel,
+        // no cross-day persistence.
+        if (corp_action_realized_total != 0.0) {
+            INFO("Corp-action realized P&L booked into Day T aggregate: $" +
+                 std::to_string(corp_action_realized_total));
+            daily_realized_pnl += corp_action_realized_total;
         }
 
         // daily_unrealized_pnl used to be declared and pinned to 0.0 here as a Day-T placeholder.

--- a/apps/strategies/live_equity_mean_reversion.cpp
+++ b/apps/strategies/live_equity_mean_reversion.cpp
@@ -313,8 +313,25 @@ int main(int argc, char* argv[]) {
 
         std::cout << "Retrieved " << symbols.size() << " symbols" << std::endl;
         std::cout << "Initial capital: $" << initial_capital << std::endl;
-        std::cout << "Commission rate: " << (commission_rate * 100) << " bps" << std::endl;
-        std::cout << "Slippage model: " << slippage_model << " bps" << std::endl;
+        // E2-C6: describe the model that actually charges, not two inert config values.
+        //
+        // These printed `execution.commission_rate` and `execution.slippage_bps` from
+        // config/defaults.json as though they were the live cost model. Neither is used:
+        // commission_rate is written into StrategyConfig::costs, which has NO reader anywhere
+        // in the tree, and slippage_bps is read into a local and never consulted. The banner
+        // told an operator the book paid "0.05 bps" while TransactionCostManager was charging
+        // a $1.00-per-order floor -- on the observed window that floor was 96% of all
+        // commission paid.
+        //
+        // Print the real schedule instead. If the config values are ever wired up, print them
+        // here again -- but they must drive the model first.
+        std::cout << "Commission model: IBKR Pro Fixed -- $0.005/share, $1.00 min/order, "
+                     "1% of trade value max, fees included" << std::endl;
+        std::cout << "Implicit costs: spread + market impact, charged via "
+                     "total_transaction_costs" << std::endl;
+        std::cout << "  (config execution.commission_rate=" << commission_rate
+                  << ", execution.slippage_bps=" << slippage_model
+                  << " are NOT used by the cost model)" << std::endl;
 
         INFO("Configuration loaded successfully. Processing " +
              std::to_string(symbols.size()) + " symbols from " +
@@ -2190,6 +2207,36 @@ int main(int argc, char* argv[]) {
                  " daily_unrealized_pnl=" + std::to_string(static_cast<double>(validated_position.unrealized_pnl)));
         }
         
+        // E2-C7: live has NO overnight borrow-cost accrual, so it must not carry a short.
+        //
+        // TransactionCostManager::calculate_overnight_borrow_fees() has exactly one caller,
+        // backtest_coordinator.cpp -- the live path never accrues it. A short position held
+        // live would therefore cost nothing overnight while the same position in the backtest
+        // is charged, making the two silently disagree on any short book.
+        //
+        // Unreachable today: Equity::is_short_allowed() requires account_mode == REG_T AND
+        // short_selling_allowed, and equity.hpp defaults them to CASH/false with REG_T
+        // configured nowhere. That is exactly why this is a guard rather than an
+        // implementation -- writing untested borrow accrual for a case that cannot occur is
+        // worse than refusing the case. When shorting IS enabled (tracked as T2.10), this
+        // fires on day one and the accrual gets written then, against a real book.
+        {
+            std::vector<std::string> shorts;
+            for (const auto& p : positions_to_save) {
+                if (p.quantity.as_double() < 0.0) shorts.push_back(p.symbol);
+            }
+            if (!shorts.empty()) {
+                std::string joined;
+                for (const auto& sym : shorts) joined += (joined.empty() ? "" : ", ") + sym;
+                ERROR("Refusing to persist a short equity position: live accrues no overnight "
+                      "borrow cost, so this book would be under-charged against its own "
+                      "backtest. Symbols: " + joined);
+                ERROR("Enable borrow-fee accrual in the live EOD path before allowing shorts "
+                      "(see TransactionCostManager::calculate_overnight_borrow_fees).");
+                return 1;
+            }
+        }
+
         if (!positions_to_save.empty()) {
             INFO("Attempting to save " + std::to_string(positions_to_save.size()) + " positions to database");
             DEBUG("Database connection status: " + std::string(db->is_connected() ? "connected" : "disconnected"));

--- a/apps/strategies/live_equity_mean_reversion.cpp
+++ b/apps/strategies/live_equity_mean_reversion.cpp
@@ -1119,6 +1119,24 @@ int main(int argc, char* argv[]) {
                     INFO("Corp-action dedup record read successfully and is "
                          "empty -- genuine first run for this strategy");
                 }
+                // E2-F23: a dedup row dated on or after today was written by a LATER pass
+                // -- an un-reset replay, or a re-run of a day that applied an event with
+                // today's ex-date. Honouring it would skip the event and finalize T-1 in
+                // the wrong frame (the E2-F16 phantom, measured at -4,824 on BKNG).
+                // A re-run is only valid when the dedup rows and the book come from the
+                // same pass: reset both together, then run.
+                {
+                    const std::string latest_ex = audit_log.latest_applied_ex_date();
+                    if (!latest_ex.empty() && latest_ex >= today_date_str) {
+                        ERROR("Corp-action dedup record holds an entry with ex_date " + latest_ex +
+                              " >= today (" + today_date_str + "). It was written by a later "
+                              "pass over this book. Refusing to run: reset trading.corp_action_applied "
+                              "for this portfolio TOGETHER with the book (positions, live_results, "
+                              "equity_curve, executions) from the replay start date, then replay in "
+                              "order. Never re-run a day after a later day has run.");
+                        return 1;
+                    }
+                }
 
                 // Dividend-denominator closes, keyed (symbol, YYYY-MM-DD).
                 //
@@ -1671,6 +1689,11 @@ int main(int argc, char* argv[]) {
                         }
                     }
 
+                    // E2-F19 cleanup: nothing to persist when no event applied. The
+                    // placeholder rows this block writes are dated today and carry the
+                    // loaded book; writing them with zero adjustments was what let a
+                    // stale book survive an empty day-T write (E2-F24).
+                    if (!adjustments.empty()) {
                     // Persist corrected positions back so future runs (and
                     // tomorrow's load_positions_by_date) pick up the adjusted state.
                     // Stamp last_update = now (ultrareview bug_007): the date-keyed
@@ -1731,6 +1754,9 @@ int main(int argc, char* argv[]) {
                     }
                     INFO("Persisted " + std::to_string(adjustments.size()) +
                          " corp-action adjustments to trading.positions");
+                    } else {
+                        INFO("No class-1 corp-action adjustments applied this run; nothing persisted");
+                    }
                 }
             }
         }
@@ -1747,7 +1773,13 @@ int main(int argc, char* argv[]) {
         // Both change WHAT is held rather than its price, so they run after
         // the class-1 rescale and before target generation. Failures here are
         // non-fatal: the position map is left as-is and the run continues.
-        if (!previous_positions.empty()) {
+        //
+        // E2-F21: gated on a trading day like signals and executions are. A termination
+        // with a weekend ex-date would otherwise emit an execution and book realized P&L
+        // on a day the market was shut. Nothing is recorded on the skip, and the
+        // admission rule (delist_date <= as_of) still admits the event on the next open
+        // session, so Monday books it.
+        if (!today_is_non_trading && !previous_positions.empty()) {
             auto today_t2 = std::chrono::system_clock::to_time_t(now);
             std::tm today_tm2{};
             gmtime_r(&today_t2, &today_tm2);
@@ -4330,7 +4362,12 @@ int main(int argc, char* argv[]) {
                     yesterday_positions_finalized,  // Now populated with yesterday's finalized positions
                     yesterday_exit_prices,  // Day T-1 close prices for yesterday's positions
                     yesterday_entry_prices,  // Day T-2 close prices for yesterday's positions
-                    yesterday_daily_metrics_final  // Yesterday's metrics
+                    yesterday_daily_metrics_final,  // Yesterday's metrics
+                    // E2-F11: the charts query THIS book. The overload used to hardcode the
+                    // trend-following strategy id and an empty portfolio, so every equity
+                    // email rendered empty charts.
+                    std::string(kEquityStrategyId),
+                    portfolio_id
                 );
                 
                 // Send email without CSV attachments (CSV export disabled for mean reversion)

--- a/apps/strategies/live_equity_mean_reversion.cpp
+++ b/apps/strategies/live_equity_mean_reversion.cpp
@@ -559,6 +559,21 @@ int main(int argc, char* argv[]) {
         }
         
         auto all_bars = conversion_result.value();
+
+        // E2-F15: the newest loaded bar PER SYMBOL. Hoisted here (it used to be built
+        // inside the delisting-staleness block) because the corporate-action code needs it
+        // too, and both must agree on one definition of "how far does this symbol's price
+        // series actually reach".
+        //
+        // This is the horizon that decides whether a corporate action may be applied. See
+        // the gate below and docs/E2_FINDING_15_SPLIT_PRICE_UNIT_DESYNC.md.
+        std::unordered_map<std::string, std::string> last_bar_date;
+        for (const auto& bar : all_bars) {
+            const std::string d =
+                format_ymd_utc(std::chrono::system_clock::to_time_t(bar.timestamp));
+            auto it = last_bar_date.find(bar.symbol);
+            if (it == last_bar_date.end() || d > it->second) last_bar_date[bar.symbol] = d;
+        }
         INFO("Loaded " + std::to_string(all_bars.size()) + " total bars");
 
         // Data-freshness guard (review T2.9): the newest bar actually loaded for our
@@ -869,6 +884,11 @@ int main(int argc, char* argv[]) {
         // Booking it here touches NO shared file, so the futures binaries are unchanged by
         // construction rather than by argument.
         double corp_action_realized_total = 0.0;
+
+        // E2-F15: ex-date of any class-1 event APPLIED on this run, per symbol. Used to pick
+        // the right T-1 snapshot for finalization -- see the selection below.
+        std::unordered_map<std::string, std::string> applied_class1_ex_date;
+
 
         DEBUG("Previous date used for lookup: " + std::to_string(std::chrono::system_clock::to_time_t(previous_date)));
         DEBUG("Current date: " + std::to_string(std::chrono::system_clock::to_time_t(now)));
@@ -1218,6 +1238,41 @@ int main(int argc, char* argv[]) {
                     return p->second.quantity.as_double();
                 };
 
+                // E2-F17: is the book's state at ex_date-1 actually KNOWN? Every run writes a
+                // live_results row whether or not it holds anything (the same evidence E2-F8
+                // uses to tell "flat" from "never ran"), so that row is what turns an empty
+                // position lookup from "unknown" into "verifiably flat". Without it, absent
+                // history would be read as flat and real adjustments would be dropped.
+                std::unordered_map<std::string, bool> run_on_record_cache;
+                auto book_state_known_at_ex_date = [&](const std::string& ex_date) -> bool {
+                    auto cached = run_on_record_cache.find(ex_date);
+                    if (cached != run_on_record_cache.end()) return cached->second;
+
+                    bool known = false;
+                    std::tm tm{};
+                    std::istringstream ss(ex_date);
+                    ss >> std::get_time(&tm, "%Y-%m-%d");
+                    if (!ss.fail()) {
+                        auto tt = std::mktime(&tm) - 24 * 60 * 60;  // ex_date - 1 day
+                        const std::string prev_str = trade_ngin::core::format_utc_date(
+                            std::chrono::system_clock::from_time_t(tt));
+                        auto r = db->execute_query(
+                            "SELECT count(*)::text FROM trading.live_results "
+                            "WHERE strategy_id = '" + std::string(kEquityStrategyId) + "'"
+                            " AND portfolio_id = '" + portfolio_id + "'"
+                            " AND date = '" + prev_str + "'");
+                        if (r.is_ok() && r.value()->num_rows() > 0) {
+                            auto col = std::static_pointer_cast<arrow::StringArray>(
+                                r.value()->column(0)->chunk(0));
+                            if (!col->IsNull(0)) {
+                                known = std::stol(std::string(col->GetView(0))) > 0;
+                            }
+                        }
+                    }
+                    run_on_record_cache[ex_date] = known;
+                    return known;
+                };
+
                 std::vector<CorpActionEvent> events;
                 events.reserve(rows.size());
                 // Intra-batch dedup (ultrareview bug_037): if the same
@@ -1232,6 +1287,60 @@ int main(int argc, char* argv[]) {
                     if (audit_log.is_applied(row.ticker, row.date_str, type)) continue;
                     if (previous_positions.find(row.ticker) == previous_positions.end()) continue;
                     if (!seen_in_batch.emplace(row.ticker, row.date_str, type).second) continue;
+
+                    // E2-F15 HORIZON GATE: only apply an event the PRICE SERIES already knows
+                    // about.
+                    //
+                    // The applier's real contract is "restate the basis into the frame the
+                    // price series is already in". Two windows made that false: the event
+                    // fetch reads split_factor / div_cash from the ex-date bar ROW and so
+                    // spans day D, while the bar load ends at the last completed session on a
+                    // replay (`end_date = now - 24h`, :226). build_equity_adjusted_query
+                    // back-adjusts a bar by the steps of every LATER bar, so with the ex-date
+                    // bar outside the window there is no step to apply and the closes stay
+                    // raw -- correctly, given what it was given.
+                    //
+                    // The position then moved into post-event units while every price stayed
+                    // pre-event. Reproduced live: BKNG 25:1 on 2026-04-06 restated qty 10 ->
+                    // 250 and basis 4194.31 -> 167.7724, then sold 248.799399 shares at the
+                    // PRE-split 4194.31 -- $1,001,800 of realized P&L on a $100,000 book. It
+                    // also mis-sized the target (1.200601 pre-split shares read as post-split)
+                    // and, on a REVERSE split, inverts the stop-loss into a spurious
+                    // liquidation.
+                    //
+                    // Deferring costs one run and is self-healing by design:
+                    // derive_corp_action_window reaches back to position inception and the
+                    // dedup record is durable, precisely so a deferred event is picked up
+                    // later. No PositionAdjustment is produced, so no dedup row is written and
+                    // the event is reconsidered next run -- the same recovery shape the
+                    // dividend-denominator skip above already relies on.
+                    //
+                    // In TRUE LIVE this gate is a no-op: `end_date = now`, so once the ex-date
+                    // bar is published it is loaded and the horizon passes. The defect lives
+                    // on the replay branch.
+                    //
+                    // DO NOT "fix" this by rescaling the price maps instead. previous_day_ and
+                    // two_days_ago_close_prices are also the inputs to finalize_previous_day,
+                    // which marks previous_positions_pre_action -- the deliberately
+                    // un-restated T-1 snapshot from 8a1a96ef. Rescaling them restates Day T-1
+                    // by the ratio and trades a $1M error for a $40k one.
+                    {
+                        auto lb = last_bar_date.find(row.ticker);
+                        if (lb == last_bar_date.end() || row.date_str > lb->second) {
+                            WARN("Deferring " +
+                                 std::string(CorporateActionsApplier::type_to_string(type)) +
+                                 " for " + row.ticker + " (ex_date " + row.date_str +
+                                 "): its loaded price series ends " +
+                                 (lb == last_bar_date.end() ? std::string("nowhere -- the symbol "
+                                  "is held but has no bars in the load window")
+                                                            : lb->second) +
+                                 ", so the bars are still in PRE-event units and restating the "
+                                 "basis now would leave price and position in different frames "
+                                 "(E2-F15). No dedup row is written; it applies on the next run "
+                                 "once the ex-date bar is in the window.");
+                            continue;
+                        }
+                    }
 
                     CorpActionEvent ev;
                     ev.symbol = row.ticker;
@@ -1296,6 +1405,8 @@ int main(int argc, char* argv[]) {
                         // current qty if the historical positions row is
                         // missing (e.g. first-week catch-up runs).
                         ev.qty_at_ex_date = qty_at_ex_date(row.ticker, row.date_str);
+                        ev.book_state_known_at_ex_date =
+                            book_state_known_at_ex_date(row.date_str);
                     }
                     events.push_back(std::move(ev));
                 }
@@ -1311,6 +1422,61 @@ int main(int argc, char* argv[]) {
                              std::to_string(adj.avg_price_after) +
                              ", ratio " + std::to_string(adj.ratio_change));
                         audit_log.record(adj);
+                    }
+
+                    for (const auto& adj : adjustments) {
+                        auto& slot = applied_class1_ex_date[adj.symbol];
+                        if (slot.empty() || adj.event_date > slot) slot = adj.event_date;
+                    }
+
+                    // E2-F15 / G1 -- THE INVARIANT THAT WOULD HAVE CAUGHT THIS.
+                    //
+                    // A price-restating event rescales the basis. If the price series is in
+                    // the same frame, it has been rescaled by the SAME factor, so the ratio
+                    // of basis to mark is unchanged:
+                    //
+                    //     avg_after / mark_after  ==  avg_before / mark_before
+                    //
+                    // On the BKNG failure this read 167.7724/4194.31 against 4194.31/4194.31
+                    // -- off by exactly the split ratio, 25. Nothing else caught it: L5,
+                    // total_pnl = (realized - costs) + unrealized, equity continuity and the
+                    // daily-flow identity are all INTERNAL-consistency checks, and the wrong
+                    // number was consistently wrong everywhere. This is the one statement
+                    // that compares the restatement against something outside itself.
+                    //
+                    // It generalises unchanged to dividends and to reverse splits, and it
+                    // fires on any future path that rescales one side and not the other.
+                    for (const auto& adj : adjustments) {
+                        auto mk = previous_day_close_prices.find(adj.symbol);
+                        if (mk == previous_day_close_prices.end() || !(mk->second > 0.0)) continue;
+                        if (!(adj.avg_price_before > 0.0) || !(adj.avg_price_after > 0.0)) continue;
+
+                        // The mark is NOT restated by the applier, so post-event it should
+                        // already be in the same frame as the new basis. Compare the implied
+                        // ratios rather than the raw numbers.
+                        const double implied = (adj.avg_price_before / adj.avg_price_after);
+                        if (std::abs(implied - adj.ratio_change) > 1e-6 * std::max(1.0, adj.ratio_change)) {
+                            ERROR("E2-F15 invariant violated for " + adj.symbol + " (" +
+                                  adj.event_date + "): basis moved by " +
+                                  std::to_string(implied) + " but the event ratio is " +
+                                  std::to_string(adj.ratio_change) +
+                                  " -- the basis and the price series are in different frames.");
+                            return 1;
+                        }
+
+                        const double basis_to_mark = adj.avg_price_after / mk->second;
+                        if (basis_to_mark > 5.0 || basis_to_mark < 0.2) {
+                            ERROR("E2-F15 guard: after applying " +
+                                  std::string(CorporateActionsApplier::type_to_string(adj.type)) +
+                                  " to " + adj.symbol + " the cost basis (" +
+                                  std::to_string(adj.avg_price_after) +
+                                  ") is implausible against the mark (" +
+                                  std::to_string(mk->second) + "), ratio " +
+                                  std::to_string(basis_to_mark) +
+                                  ". The position and the price series are almost certainly in "
+                                  "different unit frames. Refusing to trade on it.");
+                            return 1;
+                        }
                     }
 
                     // Persist corrected positions back so future runs (and
@@ -1442,13 +1608,7 @@ int main(int argc, char* argv[]) {
                 // price. Bars settle it -- a symbol still printing after the
                 // claimed delisting is plainly not delisted -- and we already hold
                 // every bar of the load window, so this costs no query.
-                std::unordered_map<std::string, std::string> last_bar_date;
-                for (const auto& bar : all_bars) {
-                    const std::string d =
-                        format_ymd_utc(std::chrono::system_clock::to_time_t(bar.timestamp));
-                    auto it = last_bar_date.find(bar.symbol);
-                    if (it == last_bar_date.end() || d > it->second) last_bar_date[bar.symbol] = d;
-                }
+                // last_bar_date is built once, above -- see E2-F15.
 
                 for (const auto& [symbol, delist_date] : delist_result.value()) {
                     if (previous_positions.find(symbol) == previous_positions.end()) continue;
@@ -1462,6 +1622,11 @@ int main(int argc, char* argv[]) {
                              ") -- the ticker is trading, so the row belongs to a prior issuer");
                         continue;
                     }
+                    // E2-F15 (DEFERRED, logged): if this symbol also had a class-1 event applied
+                    // on THIS run, its basis is post-event while final_closes is seeded from
+                    // the pre-event price map, so realized_delta would be computed across two
+                    // frames. Rare -- it needs a class-1 event and a termination on the same
+                    // run date -- and deferred by HD. See E2_FINDING_15 section 10.
                     TerminationEvent ev;
                     ev.symbol = symbol;
                     ev.event_date = delist_date;
@@ -1853,9 +2018,49 @@ int main(int argc, char* argv[]) {
             // actually stood on T-1. Using the mutated `previous_positions` here wrote the
             // post-action quantities and basis onto the T-1 row, restating a day before the
             // ex-date (see the snapshot's comment above).
+            //
+            // E2-F15: that is right ONLY while the event's ex-date is AFTER T-1. When a
+            // DEFERRED event is catching up -- ex_date <= T-1 -- the T-1 close is already
+            // post-event, so finalizing the pre-action book marks a pre-event basis against a
+            // post-event price. Measured: BKNG's 2026-04-06 row took
+            // `1.200601 * (176.19 - 4194.31) = -4824.16` of phantom unrealized, dropping the
+            // equity curve to 95,080.29 for that day. It does NOT self-correct -- running
+            // 04-08 and 04-09 left the 04-06 row unchanged.
+            //
+            // So pick per symbol: the RESTATED book where a deferred event has now been
+            // applied for a date on or before T-1, the pre-action snapshot everywhere else.
+            //
+            // NOTE ON REACHABILITY, so nobody reads more discrimination into this than it has.
+            // The E2-F15 gate only admits an event when `ex_date <= last_bar_date`, and the
+            // loaded series never reaches past T-1 under the lag model, so every APPLIED
+            // class-1 event necessarily satisfies `ex_date <= T-1`. The predicate below is
+            // therefore true for every symbol carrying an applied event today, and the
+            // pre-action snapshot survives only for symbols with NO event -- which is the
+            // overwhelming majority and the case 8a1a96ef was actually about.
+            //
+            // 8a1a96ef's protection is NOT weakened by that. Its regression was an event with
+            // `ex_date == today` applying and restating T-1, a day before its own ex-date.
+            // The gate now defers exactly that event, so the situation cannot arise upstream
+            // of here. The predicate is kept explicit rather than assumed: it states the rule
+            // that makes this correct, and keeps it correct if the gate's horizon ever moves.
             std::vector<Position> prev_positions_vec;
             prev_positions_vec.reserve(previous_positions_pre_action.size());
             for (const auto& [symbol, pos] : previous_positions_pre_action) {
+                auto ex = applied_class1_ex_date.find(symbol);
+                const bool event_covers_t1 =
+                    ex != applied_class1_ex_date.end() &&
+                    ex->second <= core::format_utc_date(previous_date);
+                if (event_covers_t1) {
+                    auto restated = previous_positions.find(symbol);
+                    if (restated != previous_positions.end()) {
+                        INFO("Finalizing " + symbol + " from the RESTATED T-1 book: a " +
+                             "deferred corp action for " + ex->second +
+                             " was applied this run, so the T-1 close is already post-event "
+                             "and the pre-action basis would be a frame behind it (E2-F15).");
+                        prev_positions_vec.push_back(restated->second);
+                        continue;
+                    }
+                }
                 prev_positions_vec.push_back(pos);
             }
 

--- a/apps/strategies/live_equity_mean_reversion.cpp
+++ b/apps/strategies/live_equity_mean_reversion.cpp
@@ -1238,24 +1238,64 @@ int main(int argc, char* argv[]) {
                     return p->second.quantity.as_double();
                 };
 
-                // E2-F17: is the book's state at ex_date-1 actually KNOWN? Every run writes a
-                // live_results row whether or not it holds anything (the same evidence E2-F8
-                // uses to tell "flat" from "never ran"), so that row is what turns an empty
-                // position lookup from "unknown" into "verifiably flat". Without it, absent
-                // history would be read as flat and real adjustments would be dropped.
+                // E2-F17 signal S2. The SAME lookup keyed on the ex-date ITSELF, not ex_date-1.
+                // The two dates answer different questions and must not be conflated:
+                //   ex_date - 1  -> who was on the register for the dividend CASH (above)
+                //   end of ex_date -> whether the basis being restated is pre-event
+                // A fill on run E is priced at close(E-1), i.e. pre-event, so a position opened
+                // ON the ex-date run has a clean basis and MUST still be restated. Measuring at
+                // E-1 would call it "flat at the ex-date" and skip a real adjustment.
+                //
+                // Parsed with timegm, NOT mktime. The ex_date-1 lambda above uses
+                // `std::mktime`, which reads the tm as LOCAL time and then formats UTC -- on a
+                // host at a positive UTC offset that lands a day early. That is pre-existing
+                // and out of scope here, but new code must not propagate it.
+                auto parse_ex_date = [](const std::string& d)
+                    -> std::optional<std::chrono::system_clock::time_point> {
+                    std::tm tm{};
+                    std::istringstream ss(d);
+                    ss >> std::get_time(&tm, "%Y-%m-%d");
+                    if (ss.fail()) return std::nullopt;
+                    return std::chrono::system_clock::from_time_t(timegm(&tm));
+                };
+
+                std::unordered_map<std::string, std::unordered_map<std::string, Position>>
+                    positions_at_exdate_cache;
+                auto qty_at_end_of_ex_date = [&](const std::string& symbol,
+                                                 const std::string& ex_date) -> double {
+                    auto cached = positions_at_exdate_cache.find(ex_date);
+                    if (cached == positions_at_exdate_cache.end()) {
+                        auto parsed = parse_ex_date(ex_date);
+                        if (!parsed) return 0.0;
+                        auto r = db->load_positions_by_date(
+                            kEquityStrategyId, kEquityStrategyName,
+                            portfolio_id, *parsed, "trading.positions");
+                        auto& slot = positions_at_exdate_cache[ex_date];
+                        if (r.is_ok()) slot = r.value();
+                        cached = positions_at_exdate_cache.find(ex_date);
+                    }
+                    auto p = cached->second.find(symbol);
+                    if (p == cached->second.end()) return 0.0;
+                    return p->second.quantity.as_double();
+                };
+
+                // E2-F17: is the book's state at the END OF THE EX-DATE actually KNOWN? Every
+                // run writes a live_results row whether or not it holds anything (the same
+                // evidence E2-F8 uses to tell "flat" from "never ran"), so that row is what
+                // turns an empty position lookup from "unknown" into "verifiably flat".
+                // Without it, absent history would be read as flat and real adjustments would
+                // be dropped.
+                //
+                // Keyed on the EX-DATE, not ex_date-1 -- see qty_at_end_of_ex_date above for
+                // why the two dates are not interchangeable.
                 std::unordered_map<std::string, bool> run_on_record_cache;
-                auto book_state_known_at_ex_date = [&](const std::string& ex_date) -> bool {
+                auto run_on_record_at_ex_date = [&](const std::string& ex_date) -> bool {
                     auto cached = run_on_record_cache.find(ex_date);
                     if (cached != run_on_record_cache.end()) return cached->second;
 
                     bool known = false;
-                    std::tm tm{};
-                    std::istringstream ss(ex_date);
-                    ss >> std::get_time(&tm, "%Y-%m-%d");
-                    if (!ss.fail()) {
-                        auto tt = std::mktime(&tm) - 24 * 60 * 60;  // ex_date - 1 day
-                        const std::string prev_str = trade_ngin::core::format_utc_date(
-                            std::chrono::system_clock::from_time_t(tt));
+                    if (auto parsed = parse_ex_date(ex_date)) {
+                        const std::string prev_str = trade_ngin::core::format_utc_date(*parsed);
                         auto r = db->execute_query(
                             "SELECT count(*)::text FROM trading.live_results "
                             "WHERE strategy_id = '" + std::string(kEquityStrategyId) + "'"
@@ -1272,6 +1312,57 @@ int main(int argc, char* argv[]) {
                     run_on_record_cache[ex_date] = known;
                     return known;
                 };
+
+                // E2-F17 signal S1 (primary): the last date this strategy BOUGHT each symbol.
+                // A fill on run D is priced at close(D-1), so a BUY dated strictly AFTER the
+                // ex-date was struck at a price the market had already adjusted -- positive
+                // evidence that the basis now held is post-event and must NOT be restated.
+                // A SELL cannot re-form a long book's basis, so BUY alone is sufficient.
+                //
+                // One batched query for every symbol with an event, floored at the earliest
+                // candidate ex-date so the scan stays small.
+                std::unordered_map<std::string, std::string> last_buy_by_symbol;
+                bool exec_history_readable = false;
+                if (!event_symbols.empty()) {
+                    std::string min_ex_date;
+                    for (const auto& row : rows) {
+                        if (previous_positions.find(row.ticker) == previous_positions.end()) continue;
+                        if (min_ex_date.empty() || row.date_str < min_ex_date) min_ex_date = row.date_str;
+                    }
+                    if (!min_ex_date.empty()) {
+                        // Bounded ABOVE by T-1, the date of the book being restated. Two
+                        // reasons, and the first is not optional:
+                        //
+                        // 1. NO LOOKAHEAD. On a replay, trading.executions also holds rows for
+                        //    dates after the run being processed. Unbounded, this reported
+                        //    "BUY 2026-07-30" as evidence against a 2026-06-08 ex-date while
+                        //    replaying June, and skipped a dividend that had to apply.
+                        //
+                        // 2. IT IS THE RIGHT QUESTION. The applier restates `previous_positions`
+                        //    -- the end-of-T-1 book -- BEFORE today's trading. Fills dated after
+                        //    T-1 have not happened yet at apply time and cannot have touched the
+                        //    basis being restated. Only a fill in (ex_date, T-1] can, which is
+                        //    exactly a LATE apply: the event was deferred or the symbol was
+                        //    unheld when it was first offered, and the book moved in between.
+                        //
+                        // Without the upper bound the rule degenerates for a strategy that
+                        // re-sizes daily: nearly every held name has some later BUY, so nearly
+                        // every real adjustment gets skipped.
+                        const std::string t1_str = trade_ngin::core::format_utc_date(previous_date);
+                        auto lb = db->get_last_buy_dates(kEquityStrategyId, kEquityStrategyName,
+                                                         portfolio_id, event_symbols,
+                                                         min_ex_date, t1_str);
+                        if (lb.is_ok()) {
+                            last_buy_by_symbol = lb.value();
+                            exec_history_readable = true;
+                        } else {
+                            WARN("E2-F17: could not read execution history for basis provenance ("
+                                 + std::string(lb.error()->what()) +
+                                 "). Every event this run resolves to UNKNOWN and will be APPLIED "
+                                 "with a warning rather than skipped.");
+                        }
+                    }
+                }
 
                 std::vector<CorpActionEvent> events;
                 events.reserve(rows.size());
@@ -1405,9 +1496,45 @@ int main(int argc, char* argv[]) {
                         // current qty if the historical positions row is
                         // missing (e.g. first-week catch-up runs).
                         ev.qty_at_ex_date = qty_at_ex_date(row.ticker, row.date_str);
-                        ev.book_state_known_at_ex_date =
-                            book_state_known_at_ex_date(row.date_str);
                     }
+
+                    // E2-F17: basis provenance, resolved for EVERY class-1 type.
+                    //
+                    // THE PLACEMENT IS THE FIX. This previously sat inside the DIVIDEND branch
+                    // above, so splits and ADR splits always reached the applier with the
+                    // default and the guard could never fire on them -- leaving the
+                    // catastrophic case (a 25:1 split restating a post-ex-date basis by 2400%)
+                    // completely unguarded, while the dividend case looked covered.
+                    //
+                    // Only POSITIVE evidence may skip; everything else applies.
+                    {
+                        auto lb = last_buy_by_symbol.find(row.ticker);
+                        const bool bought_after =
+                            lb != last_buy_by_symbol.end() && lb->second > row.date_str;
+
+                        if (bought_after) {
+                            // S1: an actual BUY priced after the event.
+                            ev.basis_provenance =
+                                CorpActionEvent::BasisProvenance::FORMED_AFTER_EX_DATE;
+                            ev.basis_provenance_evidence = "BUY " + lb->second;
+                        } else if (run_on_record_at_ex_date(row.date_str) &&
+                                   !(std::abs(qty_at_end_of_ex_date(row.ticker, row.date_str)) >
+                                     1e-9)) {
+                            // S2: a run is on record for the ex-date and the book held nothing
+                            // in this symbol at the end of it, so whatever is held now was
+                            // acquired later. Covers a book with no execution history.
+                            ev.basis_provenance =
+                                CorpActionEvent::BasisProvenance::FORMED_AFTER_EX_DATE;
+                            ev.basis_provenance_evidence =
+                                "book verifiably flat at end of ex-date " + row.date_str;
+                        } else if (exec_history_readable) {
+                            ev.basis_provenance =
+                                CorpActionEvent::BasisProvenance::FORMED_ON_OR_BEFORE_EX_DATE;
+                        } else {
+                            ev.basis_provenance = CorpActionEvent::BasisProvenance::UNKNOWN;
+                        }
+                    }
+
                     events.push_back(std::move(ev));
                 }
 
@@ -1476,6 +1603,46 @@ int main(int argc, char* argv[]) {
                                   ". The position and the price series are almost certainly in "
                                   "different unit frames. Refusing to trade on it.");
                             return 1;
+                        }
+                    }
+
+                    // E2-F17 / G3 -- THE SAME BOUND, ON THE EVENTS WE REFUSED.
+                    //
+                    // G1 above iterates `adjustments`, i.e. events that WERE applied, so a
+                    // SKIP is invariant-free. That asymmetry is dangerous now that a skip is
+                    // possible for splits: wrongly refusing a real 25:1 leaves basis and mark
+                    // 25x apart, which is strictly worse than the double-adjustment the skip
+                    // exists to prevent, and nothing downstream would notice.
+                    //
+                    // A refusal is a decision, and it is checkable: if declining to restate
+                    // leaves the basis visibly out of frame with the T-1 mark, the refusal was
+                    // wrong. Same bounds and same fail-closed shape as the applied side.
+                    {
+                        std::set<std::string> applied_syms;
+                        for (const auto& adj : adjustments) applied_syms.insert(adj.symbol);
+
+                        for (const auto& ev : events) {
+                            if (applied_syms.count(ev.symbol)) continue;   // it applied
+                            auto pos = previous_positions.find(ev.symbol);
+                            if (pos == previous_positions.end()) continue; // nothing held
+                            auto mk = previous_day_close_prices.find(ev.symbol);
+                            if (mk == previous_day_close_prices.end() || !(mk->second > 0.0)) continue;
+                            const double basis = pos->second.average_price.as_double();
+                            if (!(basis > 0.0)) continue;
+                            if (!(std::abs(pos->second.quantity.as_double()) > 1e-9)) continue;
+
+                            const double basis_to_mark = basis / mk->second;
+                            if (basis_to_mark > 5.0 || basis_to_mark < 0.2) {
+                                ERROR("E2-F17 guard: " + ev.symbol + " carried an unapplied " +
+                                      std::string(CorporateActionsApplier::type_to_string(ev.type)) +
+                                      " (ex_date " + ev.ex_date + ") and its cost basis (" +
+                                      std::to_string(basis) + ") is implausible against the mark (" +
+                                      std::to_string(mk->second) + "), ratio " +
+                                      std::to_string(basis_to_mark) +
+                                      ". Refusing to restate was almost certainly wrong -- the "
+                                      "book is a corporate action out of frame. Refusing to trade.");
+                                return 1;
+                            }
                         }
                     }
 

--- a/apps/strategies/live_equity_mean_reversion.cpp
+++ b/apps/strategies/live_equity_mean_reversion.cpp
@@ -340,7 +340,16 @@ int main(int argc, char* argv[]) {
         portfolio_config.reserve_capital = initial_capital * app_config.reserve_capital_pct;
         portfolio_config.max_strategy_allocation = app_config.strategy_defaults.max_strategy_allocation;
         portfolio_config.min_strategy_allocation = app_config.strategy_defaults.min_strategy_allocation;
-        portfolio_config.use_optimization = app_config.strategy_defaults.use_optimization;
+        // Mean reversion does NOT use dynamic optimization (HD, 2026-09-01). The optimizer
+        // is a trend-following construct -- position-buffered contract optimization over a
+        // futures universe -- and it cannot even see this strategy: PortfolioManager
+        // populates its symbol data only for TrendFollowingStrategy
+        // (portfolio_manager.cpp:993), so every equity symbol fell through to a flat 0.01
+        // weight (the true weight is price/capital, wrong by 1.4x-7.7x) and zero cost
+        // against a cost penalty of 50 -- 30,692 "not found in trading data" warnings in a
+        // single run. bt_equity_mean_reversion.cpp already disables it; this makes live
+        // agree rather than optimising on values it made up.
+        portfolio_config.use_optimization = false;
         portfolio_config.use_risk_management = app_config.strategy_defaults.use_risk_management;
         portfolio_config.opt_config = opt_config;
         portfolio_config.risk_config = risk_config;
@@ -425,6 +434,51 @@ int main(int argc, char* argv[]) {
             return 1;
         }
         INFO("Strategy added to portfolio successfully");
+
+        // Per-run provenance: what this run was configured with. The futures runners have
+        // always written it (live_portfolio_conservative.cpp:620); the equity runner never
+        // did, so trading.live_run_metadata held 245 futures rows and nothing for
+        // equities. Nothing reads this table -- it exists so a past run's allocations and
+        // config can be reconstructed after the fact, which is exactly what you want when
+        // a number from months ago has to be explained.
+        {
+            nlohmann::json portfolio_config_json;
+            portfolio_config_json["total_capital"] =
+                static_cast<double>(portfolio_config.total_capital);
+            portfolio_config_json["reserve_capital"] =
+                static_cast<double>(portfolio_config.reserve_capital);
+            portfolio_config_json["use_optimization"] = portfolio_config.use_optimization;
+            portfolio_config_json["use_risk_management"] = portfolio_config.use_risk_management;
+            portfolio_config_json["allow_fractional_positions"] =
+                portfolio_config.allow_fractional_positions;
+
+            // Single-strategy runner: the live equity path rejects more than one strategy.
+            nlohmann::json strategy_alloc_json;
+            strategy_alloc_json[kEquityStrategyName] = 1.0;
+
+            nlohmann::json strategy_configs_json;
+            strategy_configs_json[kEquityStrategyName] = {
+                {"lookback_period", mean_rev_config.lookback_period},
+                {"entry_threshold", mean_rev_config.entry_threshold},
+                {"exit_threshold", mean_rev_config.exit_threshold},
+                {"risk_target", mean_rev_config.risk_target},
+                {"position_size", mean_rev_config.position_size},
+                {"vol_lookback", mean_rev_config.vol_lookback},
+                {"use_stop_loss", mean_rev_config.use_stop_loss},
+                {"stop_loss_pct", mean_rev_config.stop_loss_pct},
+                {"allow_fractional_shares", mean_rev_config.allow_fractional_shares}};
+
+            auto metadata_result = db->store_live_run_metadata(
+                now, kEquityStrategyId, portfolio_id, strategy_alloc_json,
+                portfolio_config_json, strategy_configs_json);
+
+            if (metadata_result.is_error()) {
+                WARN("Failed to store live run metadata: " +
+                     std::string(metadata_result.error()->what()));
+            } else {
+                INFO("Successfully stored live run metadata for date");
+            }
+        }
 
         // Create LiveTradingCoordinator to manage all live trading components
         INFO("Creating LiveTradingCoordinator for centralized component management");
@@ -602,9 +656,26 @@ int main(int argc, char* argv[]) {
         bool today_is_non_trading = (today_dow == 0 || today_dow == 6 ||
                                      holiday_checker.is_holiday(today_date_str));
 
-        if (today_is_non_trading && !use_override_date) {
-            INFO("Today (" + today_date_str + ") is a non-trading day - skipping equity processing");
-            return 0;
+        // A closed market does NOT mean "do nothing". You still hold the book over a
+        // weekend or holiday even though no new bar exists to signal from, so the day is
+        // processed as a CARRY-FORWARD: positions, live_results and equity_curve are all
+        // written with the previous day's book, and signal generation and execution are
+        // skipped. Futures already behaves this way -- CONSERVATIVE_PORTFOLIO has rows on
+        // all seven weekdays across positions (244 Sat / 244 Sun), live_results and
+        // equity_curve alike.
+        //
+        // Previously this returned early, and only in real-time mode: an explicit replay
+        // date bypassed the guard entirely and processed the weekend as a normal trading
+        // day, which would book a fill dated Saturday at Friday's close. Equities cannot
+        // trade Saturday, so that execution is factually false and would break broker
+        // reconciliation, even though the net position lands the same. The T-1 lag already
+        // handles the real case: Monday's run reaches back to Friday's close via the
+        // widened lookup and trades there.
+        if (today_is_non_trading) {
+            INFO("Today (" + today_date_str +
+                 ") is a non-trading day - carrying the book forward: no signals, no "
+                 "executions, positions/live_results/equity_curve written from the "
+                 "previous session.");
         }
 
         // Load previous day positions for PnL calculation
@@ -1293,28 +1364,39 @@ int main(int argc, char* argv[]) {
         // has to be handed the book back first, and it has to be the book as restated
         // by the corporate-action blocks above, since a split changes quantity and a
         // dividend changes cost basis. See LiveDailyCycle::prepare_strategy_for_signals.
-        INFO("Seeding strategy with previous-day book and generating signals...");
-        auto strat_prewarm = LiveDailyCycle::prepare_strategy_for_signals(
-            *mr_strategy, previous_positions, all_bars);
-        if (strat_prewarm.is_error()) {
-            std::cerr << "Failed to preprocess data in strategy: "
-                      << strat_prewarm.error()->what() << std::endl;
-            return 1;
-        }
+        std::unordered_map<std::string, Position> positions;
 
-        // Process data through portfolio pipeline (optimization + risk), mirroring backtest
-        INFO("Processing data through portfolio manager (optimization + risk)...");
-        auto port_process_result = portfolio->process_market_data(all_bars);
-        if (port_process_result.is_error()) {
-            std::cerr << "Failed to process data in portfolio manager: "
-                      << port_process_result.error()->what() << std::endl;
-            return 1;
-        }
-        INFO("Portfolio processing completed");
+        if (today_is_non_trading) {
+            // Carry the book forward untouched. No bar closed today, so there is nothing
+            // to signal from and nothing legitimate to trade against; re-deriving targets
+            // from a stale bar would manufacture a weekend trade.
+            positions = previous_positions;
+            INFO("Non-trading day: carried " + std::to_string(positions.size()) +
+                 " position(s) forward without generating signals.");
+        } else {
+            INFO("Seeding strategy with previous-day book and generating signals...");
+            auto strat_prewarm = LiveDailyCycle::prepare_strategy_for_signals(
+                *mr_strategy, previous_positions, all_bars);
+            if (strat_prewarm.is_error()) {
+                std::cerr << "Failed to preprocess data in strategy: "
+                          << strat_prewarm.error()->what() << std::endl;
+                return 1;
+            }
 
-        // Get optimized portfolio positions (integer-rounded after optimization/risk)
-        INFO("Retrieving optimized portfolio positions...");
-        auto positions = portfolio->get_portfolio_positions();
+            // Process data through portfolio pipeline (risk; optimization is off for MR)
+            INFO("Processing data through portfolio manager (risk)...");
+            auto port_process_result = portfolio->process_market_data(all_bars);
+            if (port_process_result.is_error()) {
+                std::cerr << "Failed to process data in portfolio manager: "
+                          << port_process_result.error()->what() << std::endl;
+                return 1;
+            }
+            INFO("Portfolio processing completed");
+
+            // Get portfolio positions (post risk-management)
+            INFO("Retrieving portfolio positions...");
+            positions = portfolio->get_portfolio_positions();
+        }
 
         // Verify we have prices for all required symbols
         std::set<std::string> all_symbols;
@@ -1425,15 +1507,33 @@ int main(int argc, char* argv[]) {
                 throw std::runtime_error("PnLManager finalization failed");
             }
 
-            // Store updated positions for yesterday (Day T-1) in database
-            if (!yesterday_finalized_positions.empty()) {
+            // Store updated positions for yesterday (Day T-1) in database.
+            // finalize_previous_day returns a row for EVERY carried position, flat ones
+            // included, so it must apply the same zero-quantity rule as the Day-T write
+            // above or it re-introduces exactly the rows that rule exists to prevent.
+            // This is the path that actually produced the observed dead rows: 4 of the 6
+            // had zero quantity AND zero P&L, so the Day-T filter was never the one
+            // letting them through. The futures finalization path has no filter either,
+            // but never needs one -- its Day-T rule keeps zeros out of the table, so a
+            // zero never comes back through previous_positions.
+            std::vector<Position> finalized_to_store;
+            finalized_to_store.reserve(yesterday_finalized_positions.size());
+            for (const auto& fp : yesterday_finalized_positions) {
+                if (std::abs(fp.quantity.as_double()) > 1e-10) {
+                    finalized_to_store.push_back(fp);
+                } else {
+                    DEBUG("Skipping zero-quantity Day T-1 position: " + fp.symbol);
+                }
+            }
+
+            if (!finalized_to_store.empty()) {
                 // Always save yesterday's finalized positions immediately (not queued)
                 // These are updates to existing positions from the previous day
-                auto update_result = db->store_positions(yesterday_finalized_positions, kEquityStrategyId, kEquityStrategyName, portfolio_id, "trading.positions");
+                auto update_result = db->store_positions(finalized_to_store, kEquityStrategyId, kEquityStrategyName, portfolio_id, "trading.positions");
                 if (update_result.is_error()) {
                     ERROR("Failed to update Day T-1 positions: " + std::string(update_result.error()->what()));
                 } else {
-                    INFO("Successfully updated " + std::to_string(yesterday_finalized_positions.size()) + " Day T-1 positions with finalized PnL");
+                    INFO("Successfully updated " + std::to_string(finalized_to_store.size()) + " Day T-1 positions with finalized PnL");
                 }
             }
 
@@ -1488,17 +1588,28 @@ int main(int argc, char* argv[]) {
         // Price, execute, and roll back anything that could not be priced. The rules
         // and their rationale live in LiveDailyCycle::execute_day_t so that the runner
         // and its tests exercise one implementation rather than two that can drift.
-        auto day_t_exec = LiveDailyCycle::execute_day_t(
-            *execution_manager, positions, previous_positions, previous_day_close_prices,
-            all_bars, now, app_config.live.execution_price_max_staleness_days);
+        //
+        // Skipped entirely on a non-trading day. `positions` was carried forward from
+        // `previous_positions` above, so every delta is zero and no execution could be
+        // generated anyway -- but the guard is explicit rather than incidental, because
+        // "the deltas happen to be zero" is not the reason we must not trade on a day the
+        // exchange is shut.
+        LiveDailyCycle::ExecutionOutcome exec_outcome;
+        if (today_is_non_trading) {
+            INFO("Non-trading day: skipping execution generation entirely.");
+        } else {
+            auto day_t_exec = LiveDailyCycle::execute_day_t(
+                *execution_manager, positions, previous_positions, previous_day_close_prices,
+                all_bars, now, app_config.live.execution_price_max_staleness_days);
 
-        if (day_t_exec.is_error()) {
-            ERROR("ExecutionManager failed: " + std::string(day_t_exec.error()->what()));
-            // No fallback - component is required to work
-            throw std::runtime_error("ExecutionManager failed");
+            if (day_t_exec.is_error()) {
+                ERROR("ExecutionManager failed: " + std::string(day_t_exec.error()->what()));
+                // No fallback - component is required to work
+                throw std::runtime_error("ExecutionManager failed");
+            }
+            exec_outcome = day_t_exec.value();
         }
 
-        auto exec_outcome = day_t_exec.value();
         std::vector<ExecutionReport> daily_executions = exec_outcome.executions;
         INFO("ExecutionManager generated " + std::to_string(daily_executions.size()) +
              " executions");
@@ -1704,12 +1815,23 @@ int main(int argc, char* argv[]) {
         positions_to_save.reserve(positions.size());
 
         for (const auto& [symbol, position] : positions) {
-            // Save positions if they have non-zero quantity OR if they have PnL (closed positions today)
-            bool has_quantity = position.quantity.as_double() != 0.0;
-            bool has_pnl = (position.realized_pnl.as_double() != 0.0 || position.unrealized_pnl.as_double() != 0.0);
+            // Only save positions with non-zero quantity.
+            // Zero-quantity positions (closed positions) should NOT be stored -- the same
+            // rule and tolerance the futures runner uses
+            // (live_portfolio_conservative.cpp:1657). A flat symbol is ABSENT from
+            // trading.positions, not present with a zero: futures conservative holds 0
+            // zero-qty rows in 1702, and only 1702 of a possible 4830 symbol-days exist.
+            // The close is recorded in trading.executions, which is the audit trail; a
+            // zero position row adds nothing and accumulates (at 852 symbols it would
+            // dominate the table). Realized P&L from the exit lands in
+            // live_results.daily_realized_pnl, exactly as it does for futures.
+            //
+            // The previous rule also kept a row when it carried PnL, which is why flat
+            // rows survived here and never do on the futures path.
+            bool has_quantity = std::abs(position.quantity.as_double()) > 1e-10;
 
-            // Don't save positions with zero quantity and zero PnL
-            if (!has_quantity && !has_pnl) {
+            if (!has_quantity) {
+                DEBUG("Skipping zero-quantity position: " + symbol);
                 continue;
             }
 
@@ -2041,7 +2163,7 @@ int main(int argc, char* argv[]) {
                 "         COALESCE(total_pnl, 0.0) as total_pnl, "
                 "         COALESCE(total_realized_pnl, 0.0) as total_realized_pnl_prev "
                 "  FROM trading.live_results "
-                "  WHERE strategy_id = 'LIVE_EQUITY_MEAN_REVERSION' AND DATE(date) < '" + yesterday_date_str + "' "
+                "  WHERE strategy_id = 'LIVE_EQUITY_MEAN_REVERSION' AND portfolio_id = '" + portfolio_id + "' AND DATE(date) < '" + yesterday_date_str + "' "
                 "  ORDER BY date DESC LIMIT 1"
                 ") "
                 "UPDATE trading.live_results SET "
@@ -2058,7 +2180,7 @@ int main(int argc, char* argv[]) {
                 "portfolio_leverage = CASE WHEN portfolio_leverage IS NULL OR portfolio_leverage = 0 THEN " + std::to_string(yesterday_portfolio_leverage) + " ELSE portfolio_leverage END, "
                 "equity_to_margin_ratio = CASE WHEN equity_to_margin_ratio IS NULL OR equity_to_margin_ratio = 0 THEN " + std::to_string(yesterday_equity_to_margin_ratio) + " ELSE equity_to_margin_ratio END, "
                 "cash_available = COALESCE((SELECT portfolio FROM day_before), " + std::to_string(initial_capital) + ") + (" + std::to_string(yesterday_total_pnl) + " - COALESCE(daily_transaction_costs, 0.0)) - COALESCE(margin_posted, 0.0) "
-                "WHERE strategy_id = 'LIVE_EQUITY_MEAN_REVERSION' AND DATE(date) = '" + yesterday_date_str + "'";
+                "WHERE strategy_id = 'LIVE_EQUITY_MEAN_REVERSION' AND portfolio_id = '" + portfolio_id + "' AND DATE(date) = '" + yesterday_date_str + "'";
 
             INFO("Executing UPDATE query for Day T-1 live_results...");
             INFO("UPDATE will set current_portfolio_value for date: " + yesterday_date_str);
@@ -2081,7 +2203,7 @@ int main(int argc, char* argv[]) {
             // Query the current portfolio value from updated live_results
             std::string get_equity_query =
                 "SELECT current_portfolio_value FROM trading.live_results "
-                "WHERE strategy_id = 'LIVE_EQUITY_MEAN_REVERSION' AND DATE(date) = '" + yesterday_date_str + "'";
+                "WHERE strategy_id = 'LIVE_EQUITY_MEAN_REVERSION' AND portfolio_id = '" + portfolio_id + "' AND DATE(date) = '" + yesterday_date_str + "'";
 
             INFO("Querying for portfolio value with date: " + yesterday_date_str);
 
@@ -2159,7 +2281,7 @@ int main(int argc, char* argv[]) {
                     "SELECT daily_return, daily_pnl, daily_realized_pnl, daily_unrealized_pnl, "
                     "portfolio_leverage, equity_to_margin_ratio "
                     "FROM trading.live_results "
-                    "WHERE strategy_id = 'LIVE_EQUITY_MEAN_REVERSION' AND DATE(date) = '" + yesterday_date_str + "'";
+                    "WHERE strategy_id = 'LIVE_EQUITY_MEAN_REVERSION' AND portfolio_id = '" + portfolio_id + "' AND DATE(date) = '" + yesterday_date_str + "'";
 
                 INFO("Loading yesterday's metrics from database with query: " + metrics_query);
                 auto metrics_result = db->execute_query(metrics_query);
@@ -2629,7 +2751,7 @@ int main(int argc, char* argv[]) {
 
                 std::string positions_query_email = "SELECT symbol, quantity, average_price, daily_realized_pnl, daily_unrealized_pnl, last_update "
                                                    "FROM trading.positions "
-                                                   "WHERE strategy_id = 'LIVE_EQUITY_MEAN_REVERSION' AND DATE(last_update) = '" + yesterday_date_for_email + "'";
+                                                   "WHERE strategy_id = 'LIVE_EQUITY_MEAN_REVERSION' AND portfolio_id = '" + portfolio_id + "' AND DATE(last_update) = '" + yesterday_date_for_email + "'";
 
                 auto positions_result_email = db->execute_query(positions_query_email);
 
@@ -2679,7 +2801,7 @@ int main(int argc, char* argv[]) {
                         "SELECT daily_return, daily_unrealized_pnl, daily_realized_pnl, daily_pnl, "
                         "daily_transaction_costs, total_dividend_income "
                         "FROM trading.live_results "
-                        "WHERE strategy_id = 'LIVE_EQUITY_MEAN_REVERSION' AND date = '" + yesterday_date_for_email + "' "
+                        "WHERE strategy_id = 'LIVE_EQUITY_MEAN_REVERSION' AND portfolio_id = '" + portfolio_id + "' AND date = '" + yesterday_date_for_email + "' "
                         "ORDER BY date DESC LIMIT 1";
 
                     INFO("Loading yesterday's daily metrics from live_results: " + yesterday_metrics_query);

--- a/apps/strategies/live_equity_mean_reversion.cpp
+++ b/apps/strategies/live_equity_mean_reversion.cpp
@@ -2030,7 +2030,10 @@ int main(int argc, char* argv[]) {
 
             // UPDATE yesterday's live_results with ALL recalculated metrics
             // Note: We calculate daily_pnl, total_pnl, and current_portfolio_value in SQL
-            // to properly incorporate the EXISTING daily_commissions value
+            // to properly incorporate the EXISTING daily_transaction_costs value
+            // (trading.live_results has no commissions column -- see E2-F5; the INSERT
+            //  above writes the equity commission into daily_transaction_costs, and this
+            //  UPDATE must read the same column or the whole statement fails)
             // IMPORTANT: Only update portfolio_leverage and equity_to_margin_ratio if they are NULL or 0
             std::string update_query =
                 "WITH day_before AS ("
@@ -2043,18 +2046,18 @@ int main(int argc, char* argv[]) {
                 ") "
                 "UPDATE trading.live_results SET "
                 "daily_realized_pnl = " + std::to_string(yesterday_total_pnl) + ", "
-                "daily_pnl = " + std::to_string(yesterday_total_pnl) + " - COALESCE(daily_commissions, 0.0), "
-                "total_pnl = COALESCE((SELECT total_pnl FROM day_before), 0.0) + (" + std::to_string(yesterday_total_pnl) + " - COALESCE(daily_commissions, 0.0)), "
+                "daily_pnl = " + std::to_string(yesterday_total_pnl) + " - COALESCE(daily_transaction_costs, 0.0), "
+                "total_pnl = COALESCE((SELECT total_pnl FROM day_before), 0.0) + (" + std::to_string(yesterday_total_pnl) + " - COALESCE(daily_transaction_costs, 0.0)), "
                 "total_realized_pnl = " + std::to_string(yesterday_total_realized_pnl_cumulative) + ", "
-                "current_portfolio_value = COALESCE((SELECT portfolio FROM day_before), " + std::to_string(initial_capital) + ") + (" + std::to_string(yesterday_total_pnl) + " - COALESCE(daily_commissions, 0.0)), "
+                "current_portfolio_value = COALESCE((SELECT portfolio FROM day_before), " + std::to_string(initial_capital) + ") + (" + std::to_string(yesterday_total_pnl) + " - COALESCE(daily_transaction_costs, 0.0)), "
                 "daily_return = CASE WHEN COALESCE((SELECT portfolio FROM day_before), " + std::to_string(initial_capital) + ") > 0 "
-                "               THEN ((" + std::to_string(yesterday_total_pnl) + " - COALESCE(daily_commissions, 0.0)) / COALESCE((SELECT portfolio FROM day_before), " + std::to_string(initial_capital) + ")) * 100.0 "
+                "               THEN ((" + std::to_string(yesterday_total_pnl) + " - COALESCE(daily_transaction_costs, 0.0)) / COALESCE((SELECT portfolio FROM day_before), " + std::to_string(initial_capital) + ")) * 100.0 "
                 "               ELSE 0.0 END, "
                 "total_cumulative_return = " + std::to_string(yesterday_total_cumulative_return_pct) + ", "
                 "total_annualized_return = " + std::to_string(yesterday_total_return_annualized) + ", "
                 "portfolio_leverage = CASE WHEN portfolio_leverage IS NULL OR portfolio_leverage = 0 THEN " + std::to_string(yesterday_portfolio_leverage) + " ELSE portfolio_leverage END, "
                 "equity_to_margin_ratio = CASE WHEN equity_to_margin_ratio IS NULL OR equity_to_margin_ratio = 0 THEN " + std::to_string(yesterday_equity_to_margin_ratio) + " ELSE equity_to_margin_ratio END, "
-                "cash_available = COALESCE((SELECT portfolio FROM day_before), " + std::to_string(initial_capital) + ") + (" + std::to_string(yesterday_total_pnl) + " - COALESCE(daily_commissions, 0.0)) - COALESCE(margin_posted, 0.0) "
+                "cash_available = COALESCE((SELECT portfolio FROM day_before), " + std::to_string(initial_capital) + ") + (" + std::to_string(yesterday_total_pnl) + " - COALESCE(daily_transaction_costs, 0.0)) - COALESCE(margin_posted, 0.0) "
                 "WHERE strategy_id = 'LIVE_EQUITY_MEAN_REVERSION' AND DATE(date) = '" + yesterday_date_str + "'";
 
             INFO("Executing UPDATE query for Day T-1 live_results...");
@@ -2090,13 +2093,28 @@ int main(int argc, char* argv[]) {
                 INFO("Query returned " + std::to_string(table->num_rows()) + " rows");
 
                 if (table->num_rows() > 0) {
-                    auto array = std::static_pointer_cast<arrow::DoubleArray>(table->column(0)->chunk(0));
+                    // current_portfolio_value is NUMERIC, which this driver surfaces as a
+                    // StringArray -- every other numeric read in this file does the same
+                    // (see the yesterday-metrics block below). Casting the chunk to
+                    // DoubleArray does not convert it; static_pointer_cast just
+                    // reinterprets the pointer, so Value(0) read a garbage double that
+                    // printed as 0.000000, failed the "< 1000" guard, and skipped the
+                    // Day T-1 equity_curve update on 6 of 10 days -- leaving equity_curve
+                    // disagreeing with live_results.current_portfolio_value (E2-F7).
+                    auto array = std::static_pointer_cast<arrow::StringArray>(table->column(0)->chunk(0));
 
                     // Check for NULL value before reading
                     if (array->IsNull(0)) {
                         ERROR("Cannot update Day T-1 equity_curve: current_portfolio_value is NULL for date " + yesterday_date_str);
                     } else {
-                        double portfolio_value = array->Value(0);
+                        double portfolio_value = 0.0;
+                        try {
+                            portfolio_value = std::stod(std::string(array->GetView(0)));
+                        } catch (const std::exception& e) {
+                            ERROR("Could not parse current_portfolio_value '" +
+                                  std::string(array->GetView(0)) + "' for " + yesterday_date_str +
+                                  ": " + e.what());
+                        }
                         INFO("Raw value read from database: " + std::to_string(portfolio_value));
 
                         // Validate the value before using it
@@ -2659,7 +2677,7 @@ int main(int argc, char* argv[]) {
                     // email body alongside Daily Total PnL.
                     std::string yesterday_metrics_query =
                         "SELECT daily_return, daily_unrealized_pnl, daily_realized_pnl, daily_pnl, "
-                        "daily_commissions, total_dividend_income "
+                        "daily_transaction_costs, total_dividend_income "
                         "FROM trading.live_results "
                         "WHERE strategy_id = 'LIVE_EQUITY_MEAN_REVERSION' AND date = '" + yesterday_date_for_email + "' "
                         "ORDER BY date DESC LIMIT 1";

--- a/apps/strategies/live_equity_mean_reversion.cpp
+++ b/apps/strategies/live_equity_mean_reversion.cpp
@@ -2093,7 +2093,8 @@ int main(int argc, char* argv[]) {
             try {
                 // Call PostgreSQL function to calculate trading days
                 auto trading_days_result = db->execute_query(
-                    "SELECT trading.get_trading_days('LIVE_EQUITY_MEAN_REVERSION', DATE '" + yesterday_date_str + "')");
+                    "SELECT trading.get_trading_days('LIVE_EQUITY_MEAN_REVERSION', DATE '" + yesterday_date_str +
+                    "', '" + portfolio_id + "')");
                 
                 if (trading_days_result.is_ok()) {
                     auto table = trading_days_result.value();
@@ -2403,7 +2404,8 @@ int main(int argc, char* argv[]) {
 
             // Call PostgreSQL function to calculate trading days
             auto trading_days_result = db->execute_query(
-                "SELECT trading.get_trading_days('LIVE_EQUITY_MEAN_REVERSION', DATE '" + now_date_str + "')");
+                "SELECT trading.get_trading_days('LIVE_EQUITY_MEAN_REVERSION', DATE '" + now_date_str +
+                    "', '" + portfolio_id + "')");
             
             if (trading_days_result.is_ok()) {
                 auto table = trading_days_result.value();

--- a/apps/strategies/live_equity_mean_reversion.cpp
+++ b/apps/strategies/live_equity_mean_reversion.cpp
@@ -2482,10 +2482,15 @@ int main(int argc, char* argv[]) {
                 {"net_notional", net_notional},
                 {"daily_return", daily_return},
                 {"daily_pnl", daily_pnl},
-                {"total_commissions", total_commissions_cumulative},
+                // trading.live_results has no commissions columns -- it carries the
+                // transaction-cost pair the futures runner writes. For equities the
+                // commission IS the realised transaction cost, so it lands there.
+                // Naming a non-existent column makes the whole INSERT fail, which is
+                // how live_results silently went unwritten (E2-F5).
+                {"total_transaction_costs", total_commissions_cumulative},
                 {"daily_realized_pnl", daily_realized_pnl},
                 {"daily_unrealized_pnl", daily_unrealized_pnl},
-                {"daily_commissions", total_daily_commissions},
+                {"daily_transaction_costs", total_daily_commissions},
                 {"margin_posted", total_posted_margin},
                 {"cash_available", current_portfolio_value - total_posted_margin},
                 {"total_dividend_income", total_dividend_income}
@@ -2534,8 +2539,13 @@ int main(int argc, char* argv[]) {
         // Use the new LiveResultsManager - save all results at once
         INFO("Saving all live trading results using LiveResultsManager...");
 
+        bool persist_failed = false;
         auto save_result = results_manager->save_all_results("LIVE_EQUITY_MEAN_REVERSION", now);
         if (save_result.is_error()) {
+            // save_all_results attempts every table and names the ones that failed
+            // (FIX-0b). Logging that and returning 0 anyway defeats the point: a caller
+            // reading the exit status would treat a partially-written run as a success.
+            persist_failed = true;
             ERROR("Failed to save all live results: " + std::string(save_result.error()->what()));
         } else {
             INFO("Successfully saved all live trading results to database");
@@ -2807,6 +2817,11 @@ int main(int argc, char* argv[]) {
         std::cerr << "At end of main: initialized=" << Logger::instance().is_initialized()
                   << std::endl;
 
+        if (persist_failed) {
+            ERROR("Run completed but one or more result tables were not persisted -- "
+                  "exiting non-zero so this is not mistaken for a successful run.");
+            return 1;
+        }
         return 0;
 
     } catch (const std::exception& e) {

--- a/apps/strategies/live_equity_mean_reversion.cpp
+++ b/apps/strategies/live_equity_mean_reversion.cpp
@@ -1401,8 +1401,11 @@ int main(int argc, char* argv[]) {
                 previous_day_close_prices,  // T-1 prices
                 two_days_ago_close_prices,  // T-2 prices
                 initial_capital,  // Previous portfolio value (TODO: get actual previous value)
-                0.0  // Commissions (will be handled later)
-            );
+                0.0,  // Commissions (will be handled later)
+                // Equities carry a true weighted cost basis in average_price, so the
+                // T-1 row records mark-to-market unrealized P&L. Futures pass no policy
+                // and stay on SETTLED, where the move is entirely realized (E2-F3).
+                trade_ngin::LivePnLManager::UnrealizedPolicy::MARK_TO_MARKET);
 
             if (finalization_result.is_ok()) {
                 auto& result = finalization_result.value();

--- a/apps/strategies/live_equity_mean_reversion.cpp
+++ b/apps/strategies/live_equity_mean_reversion.cpp
@@ -904,6 +904,11 @@ int main(int argc, char* argv[]) {
         // Booking it here touches NO shared file, so the futures binaries are unchanged by
         // construction rather than by argument.
         double corp_action_realized_total = 0.0;
+        // E2-F19 (R4): the same deltas, per symbol, so the terminated symbol's day-T
+        // ROW carries what the aggregate carries. Filled under the identical gate as
+        // corp_action_realized_total so the two can never disagree about which events
+        // were recognised.
+        std::unordered_map<std::string, double> corp_action_realized_by_symbol;
 
         // E2-F15: ex-date of any class-1 event APPLIED on this run, per symbol. Used to pick
         // the right T-1 snapshot for finalization -- see the selection below.
@@ -1966,6 +1971,7 @@ int main(int argc, char* argv[]) {
                 // E2-F7: the P&L route. Gated on the same conditions as the execution row so
                 // the two can never disagree about which events were recognised.
                 corp_action_realized_total += adj.realized_delta;
+                corp_action_realized_by_symbol[adj.symbol] += adj.realized_delta;
 
                 ExecutionReport ca_exec;
                 ca_exec.order_id = "CORPACTION_" + adj.symbol + "_" + adj.event_date;
@@ -2562,6 +2568,44 @@ int main(int argc, char* argv[]) {
                   "failure - investigate.");
         }
 
+        // E2-F19 gap G1: a held symbol that left the configured universe was closed out
+        // by execute_day_t and booked by on_execution, but has no entry in the target
+        // map and so no row. Give the exit a row, or the rows cannot sum to the
+        // aggregate.
+        auto rowless_exits = LiveDailyCycle::add_rowless_exits(positions, strategy_positions, now);
+        for (const auto& symbol : rowless_exits) {
+            WARN("Closed-out symbol " + symbol + " has no day-T target entry (left the "
+                 "universe?); recorded a closed row carrying its realized P&L of $" +
+                 std::to_string(positions.at(symbol).realized_pnl.as_double()));
+        }
+
+        // E2-F19 (R4): a termination's realized P&L reaches the aggregate through
+        // corp_action_realized_total; the synthetic exit is deliberately kept out of
+        // on_execution (E2-F11), so nothing put it on the symbol's row. Add it here,
+        // once, after resolve_and_apply_basis has assigned the strategy's figure with
+        // `=`. On a non-trading day the terminated entry arrives through the carried
+        // book (qty 0); on a trading day through the target map. Either way the row
+        // exists, or is created, and the dead-row rule below keeps it because it
+        // carries realized.
+        for (const auto& [symbol, delta] : corp_action_realized_by_symbol) {
+            if (delta == 0.0) continue;
+            auto it = positions.find(symbol);
+            if (it == positions.end()) {
+                Position closed;
+                closed.symbol = symbol;
+                closed.quantity = Quantity(0.0);
+                closed.average_price = Decimal(0.0);
+                closed.unrealized_pnl = Decimal(0.0);
+                closed.realized_pnl = Decimal(0.0);
+                closed.last_update = now;
+                it = positions.emplace(symbol, closed).first;
+            }
+            it->second.realized_pnl = Decimal(it->second.realized_pnl.as_double() + delta);
+            INFO("Corp-action realized $" + std::to_string(delta) + " booked onto the " +
+                 symbol + " day-T row (row now " +
+                 std::to_string(it->second.realized_pnl.as_double()) + ")");
+        }
+
         // Log final Day T position state
         for (const auto& [symbol, pos] : positions) {
             if (pos.quantity.as_double() != 0.0) {
@@ -2962,6 +3006,48 @@ int main(int argc, char* argv[]) {
             INFO("Corp-action realized P&L booked into Day T aggregate: $" +
                  std::to_string(corp_action_realized_total));
             daily_realized_pnl += corp_action_realized_total;
+        }
+
+        // E2-F19 (R5): protocol L5's realized clause, asserted inside the run.
+        //
+        // The rows and the aggregate come from the SAME accumulator -- pos.realized_pnl
+        // and metrics_.realized_pnl are incremented in the same branch of on_execution
+        // from the same expression; the rows are the decomposition by symbol, the
+        // aggregate the sum (plus the day's costs added back, plus corp-action realized,
+        // which R4 put on the rows too). So the residual is identically zero unless
+        // something broke the identity: a fill whose on_execution failed (now fatal
+        // above), a held symbol absent from the target map (add_rowless_exits above),
+        // or a future filter that drops a row carrying realized. Both previous attempts
+        // at this column shipped without this check and were reverted after a replay
+        // found 20 and 32 violating days. This is the difference between "L5 passed on
+        // the days we checked" and "L5 cannot fail without the run failing".
+        //
+        // Tolerance 1e-4 absolute: Decimal is fixed-point at 1e-8 with per-fill
+        // rounding on the row side while metrics_ is a double, so the sides differ by
+        // up to ~5e-9 per fill.
+        {
+            double row_realized_sum = 0.0;
+            std::string breakdown;
+            for (const auto& p : positions_to_save) {
+                const double r = static_cast<double>(p.realized_pnl);
+                row_realized_sum += r;
+                if (std::abs(r) > LiveDailyCycle::kRowTolerance) {
+                    breakdown += " " + p.symbol + "=" + std::to_string(r);
+                }
+            }
+            const double residual = row_realized_sum - daily_realized_pnl;
+            if (std::abs(residual) > 1e-4) {
+                ERROR("L5 realized identity VIOLATED: sum of positions.daily_realized_pnl (" +
+                      std::to_string(row_realized_sum) + ") != live_results.daily_realized_pnl (" +
+                      std::to_string(daily_realized_pnl) + "), residual " +
+                      std::to_string(residual) + ". Per-symbol rows:" +
+                      (breakdown.empty() ? std::string(" <none>") : breakdown) +
+                      ". Refusing to persist a day whose rows do not sum to its aggregate.");
+                return 1;
+            }
+            INFO("L5 realized identity holds: rows " + std::to_string(row_realized_sum) +
+                 " == aggregate " + std::to_string(daily_realized_pnl) +
+                 " (residual " + std::to_string(residual) + ")");
         }
 
         // daily_unrealized_pnl used to be declared and pinned to 0.0 here as a Day-T placeholder.

--- a/apps/strategies/live_equity_mean_reversion.cpp
+++ b/apps/strategies/live_equity_mean_reversion.cpp
@@ -1704,6 +1704,11 @@ int main(int argc, char* argv[]) {
         INFO("PnLManager initialized with InstrumentRegistry access");
 
         double yesterday_total_pnl = 0.0;
+        // E2-F1: the Day T-1 book marked at close(T-1), summed from the same finalized rows
+        // that get persisted. This is what total_unrealized_pnl[T-1] must hold, so the
+        // aggregate and the position rows agree by construction (protocol L5). 0.0 under
+        // SETTLED, so futures could never pick up a value here even if it reached this code.
+        double yesterday_finalized_unrealized = 0.0;
         std::vector<trade_ngin::Position> yesterday_finalized_positions;
 
         if (!two_days_ago_close_prices.empty() && !previous_positions.empty() && pnl_manager) {
@@ -1735,6 +1740,7 @@ int main(int argc, char* argv[]) {
             if (finalization_result.is_ok()) {
                 auto& result = finalization_result.value();
                 yesterday_total_pnl = result.finalized_daily_pnl;
+                yesterday_finalized_unrealized = result.finalized_unrealized_pnl;
                 yesterday_finalized_positions = result.finalized_positions;
 
                 INFO("PnLManager finalized Day T-1: Total PnL=$" + std::to_string(yesterday_total_pnl));
@@ -2230,9 +2236,26 @@ int main(int argc, char* argv[]) {
         // ========================================
         INFO("STEP 3: Calculating commissions and Day T PnL...");
 
-        // Calculate commissions from executions
+        // E2-C4: charge the FULL modelled transaction cost, not commission alone.
+        //
+        // This summed exec.commissions_fees while both futures runners sum
+        // exec.total_transaction_costs (live_portfolio_conservative.cpp:1445,
+        // live_portfolio.cpp:1431), so spread and market impact were computed, stored on
+        // the execution row, and then silently dropped from P&L and the equity curve.
+        // Measured 2026-07-24..08-03: executions totalled $16.0801, live_results recorded
+        // $15.00 -- $1.0801 of real slippage never charged. It is also why live disagreed
+        // with its own backtest, which does charge the full figure
+        // (backtest_coordinator.cpp:777).
+        //
+        // Slippage IS a true cost here and subtracting it is NOT a double-count: fill_price
+        // is deliberately kept as the clean reference price with no embedded slippage
+        // (execution_manager.cpp:159, backtest_execution_manager.cpp:82), so the modelled
+        // figure is the ONLY representation of execution cost in the system. Note
+        // total_transaction_costs = commissions_fees + slippage_market_impact;
+        // implicit_price_impact is the per-share intermediate, already inside slippage, and
+        // must not be added again.
         for (const auto& exec : daily_executions) {
-            total_daily_commissions += exec.commissions_fees.as_double();
+            total_daily_commissions += exec.total_transaction_costs.as_double();
         }
         INFO("Total daily commissions: $" + std::to_string(total_daily_commissions));
 
@@ -2242,16 +2265,47 @@ int main(int argc, char* argv[]) {
             pnl_manager->update_position_pnl(symbol, 0.0, 0.0);  // Zero PnL for Day T
         }
 
+        // E2-F1: today's TRADE-realized P&L, gross of costs.
+        //
+        // Realized P&L does NOT need the T-1 lag. A closing fill on day D is priced at
+        // close(D-1) and the P&L it locks in is known the moment it fills, so it belongs on
+        // day D's row and is written here at insert. Only the MARK needs the next day's
+        // close, and that is what the Day T-1 UPDATE now supplies.
+        //
+        // Before this, daily_realized_pnl was a literal 0.0 here and the T-1 UPDATE
+        // overwrote it with finalize_previous_day()'s output -- the whole book's daily mark
+        // move, `sum qty*(close(T-1) - close(T-2))`, booked as "realized" even for positions
+        // that never traded. That is the futures settlement model, correct there because a
+        // futures position genuinely settles daily, and wrong for a cash equity book. It is
+        // also what made total_pnl double-count once E2-F12 layered the open mark on top:
+        // cumulative "realized" ALREADY contained the full move from entry, so adding
+        // unrealized measured from the same cost basis counted it twice. Verified against
+        // hand-computed P&L from raw executions and closes: cumulative daily_realized_pnl
+        // tracked true mark-to-market P&L exactly, which is only possible if it was already
+        // the whole thing.
+        //
+        // metrics_.realized_pnl accumulates `sum(trade realized) - sum(costs)` over THIS
+        // process's executions only (it starts at zero each run and seeding does not touch
+        // it), so adding the day's costs back recovers the gross figure. Gross is what gets
+        // reported, with costs in their own column, exactly as futures does it -- the
+        // consumer subtracts once, in daily_pnl below.
         double daily_realized_pnl = 0.0;
+        if (mr_strategy) {
+            daily_realized_pnl = mr_strategy->get_metrics().realized_pnl + total_daily_commissions;
+        }
+
         // daily_unrealized_pnl used to be declared and pinned to 0.0 here as a Day-T placeholder.
         // Nothing ever repaired it -- the Day T-1 UPDATE below never mentions the column -- so
         // every equity row carried 0 even though the book had open marks (E2-F12). It is now
         // computed for real in STEP 5, once the previous day's mark is known.
-        double daily_pnl_for_today = -total_daily_commissions;  // Only commissions on Day T
+        //
+        // The reported flow is `(realized - costs) + change in mark`, mirroring futures'
+        // `gross - costs`. Costs are subtracted exactly once, here.
+        double daily_pnl_for_today = daily_realized_pnl - total_daily_commissions;
 
-        INFO("Day T PnL (placeholder): $0.00");
-        INFO("Day T commissions: $" + std::to_string(total_daily_commissions));
-        INFO("Day T total impact: $" + std::to_string(daily_pnl_for_today));
+        INFO("Day T trade-realized (gross): $" + std::to_string(daily_realized_pnl));
+        INFO("Day T transaction costs: $" + std::to_string(total_daily_commissions));
+        INFO("Day T realized net of costs: $" + std::to_string(daily_pnl_for_today));
 
         // ========================================
         // STEP 4: UPDATE Day T-1 live_results AND equity_curve WITH FINALIZED PnL
@@ -2268,8 +2322,16 @@ int main(int argc, char* argv[]) {
         double yesterday_realized_pnl_for_email = 0.0;
         double yesterday_unrealized_pnl_for_email = 0.0;
 
-        if (!two_days_ago_close_prices.empty() && yesterday_total_pnl != 0.0 && !is_first_trading_day) {
-            INFO("STEP 4: Updating Day T-1 live_results with finalized PnL: $" + std::to_string(yesterday_total_pnl));
+        // E2-F1: the Day T-1 UPDATE's job is now to write the MARK, not to overwrite realized.
+        // It must therefore run whenever T-1 closes were resolved, even on a day whose mark
+        // move happened to be zero. The old `yesterday_total_pnl != 0.0` condition skipped the
+        // whole statement on such a day, leaving the row un-finalized -- and combined with the
+        // date mismatch (E2-F14) it fired on every weekend, which is how the Sunday/Monday
+        // reruns were able to leave live_results stale while still rewriting position rows.
+        if (!previous_day_close_prices.empty() && !is_first_trading_day) {
+            INFO("STEP 4: Finalizing Day T-1 live_results -- mark $" +
+                 std::to_string(yesterday_finalized_unrealized) + ", day move $" +
+                 std::to_string(yesterday_total_pnl));
 
             // Get yesterday's commissions and other existing metrics from database
             double yesterday_commissions = 0.0;
@@ -2339,78 +2401,78 @@ int main(int argc, char* argv[]) {
                 INFO("Could not load day-before-yesterday aggregates: " + std::string(e.what()));
             }
 
-            // Strip the mark out of the day-before-yesterday total_pnl, for the same reason as
-            // in STEP 5: get_previous_live_aggregates() returns the STORED total_pnl, which is
-            // now mark-to-market for equities. yesterday_total_pnl_cumulative is a REALIZED
-            // running total -- it feeds total_realized_pnl below -- so an unstripped value
-            // would push the day-before-yesterday's open-position mark into the realized
-            // column, inflating it by exactly the prior day's total_unrealized_pnl.
-            double day_before_yesterday_total_unrealized_pnl = 0.0;
+            // E2-F1: the "realized-only strip" that used to live here is GONE, along with the
+            // day-before-yesterday total_unrealized_pnl read that fed it and the
+            // yesterday_total_*_cumulative chain derived from it.
+            //
+            // That machinery existed only because total_pnl was an ACCUMULATOR carrying a
+            // mark-to-market value: each day had to subtract the prior row's mark before
+            // adding its own flow, or the mark compounded. total_pnl is now DERIVED --
+            // `(cumulative realized - cumulative costs) + current mark` -- and
+            // total_realized_pnl accumulates a genuine trade-realized flow, so there is
+            // nothing to strip. The UPDATE below reads total_realized_pnl straight off the
+            // previous row.
+            //
+            // If you find yourself reintroducing a strip here, stop: it means total_pnl has
+            // been turned back into a running total, which is the defect this replaced.
+
+            // E2-F1: the read of the T-1 row's STORED total_unrealized_pnl that used to sit
+            // here is gone. That value was the Day-T snapshot -- the book priced at close(T-2)
+            // -- which is precisely the stale figure E2-F13 identified. The T-1 mark is now
+            // yesterday_finalized_unrealized, summed from the finalized rows at close(T-1),
+            // and both the SQL below and the equity figure above use it.
+
+
+            // E2-F1: mark-to-market equity for T-1, computed from the SAME components the
+            // UPDATE below writes into current_portfolio_value:
+            //     initial + (prev_cumulative_realized + this row's realized - cumulative costs)
+            //             + this row's finalized mark
+            // It feeds total_cumulative_return and total_annualized_return, which are set in
+            // that same statement, so it has to be derived here rather than read back. Keeping
+            // the two expressions identical is the point -- when they drifted apart, the return
+            // columns described an equity the row did not carry.
+            double t1_daily_realized = 0.0;
+            double t1_total_costs = 0.0;
+            double dby_total_realized = 0.0;
             try {
-                std::string dby_unrl_query =
-                    "SELECT COALESCE(total_unrealized_pnl, 0.0) FROM trading.live_results "
-                    "WHERE strategy_id = 'LIVE_EQUITY_MEAN_REVERSION' AND portfolio_id = '" + portfolio_id + "' "
-                    "AND DATE(date) < '" + yesterday_date_str + "' "
-                    "ORDER BY date DESC LIMIT 1";
-                auto du = db->execute_query(dby_unrl_query);
-                if (du.is_ok() && du.value()->num_rows() > 0) {
-                    auto r = DataConversionUtils::safe_get_double(du.value()->column(0), 0,
-                                                                  "total_unrealized_pnl");
-                    if (r.is_ok()) {
-                        day_before_yesterday_total_unrealized_pnl = r.value();
-                    } else {
-                        WARN("Could not read day-before-yesterday total_unrealized_pnl (" +
-                             std::string(r.error()->what()) + "); treating it as 0, which will "
-                             "overstate total_realized_pnl by the prior mark.");
+                std::string comp_query =
+                    "SELECT COALESCE(y.daily_realized_pnl, 0.0), "
+                    "       COALESCE(y.total_transaction_costs, 0.0), "
+                    "       COALESCE((SELECT total_realized_pnl FROM trading.live_results "
+                    "                 WHERE strategy_id = 'LIVE_EQUITY_MEAN_REVERSION' "
+                    "                   AND portfolio_id = '" + portfolio_id + "' "
+                    "                   AND DATE(date) < '" + yesterday_date_str + "' "
+                    "                 ORDER BY date DESC LIMIT 1), 0.0) "
+                    "FROM trading.live_results y "
+                    "WHERE y.strategy_id = 'LIVE_EQUITY_MEAN_REVERSION' "
+                    "  AND y.portfolio_id = '" + portfolio_id + "' "
+                    "  AND DATE(y.date) = '" + yesterday_date_str + "'";
+                auto cq = db->execute_query(comp_query);
+                if (cq.is_ok() && cq.value()->num_rows() > 0) {
+                    auto a = DataConversionUtils::safe_get_double(cq.value()->column(0), 0,
+                                                                  "daily_realized_pnl");
+                    auto b = DataConversionUtils::safe_get_double(cq.value()->column(1), 0,
+                                                                  "total_transaction_costs");
+                    auto c = DataConversionUtils::safe_get_double(cq.value()->column(2), 0,
+                                                                  "total_realized_pnl");
+                    if (a.is_ok()) t1_daily_realized = a.value();
+                    if (b.is_ok()) t1_total_costs = b.value();
+                    if (c.is_ok()) dby_total_realized = c.value();
+                    if (!a.is_ok() || !b.is_ok() || !c.is_ok()) {
+                        WARN("Could not read all T-1 equity components; the return columns "
+                             "will disagree with current_portfolio_value for this row.");
                     }
+                } else {
+                    WARN("No T-1 live_results row found for the equity components read; "
+                         "return columns will be computed off initial capital alone.");
                 }
             } catch (const std::exception& e) {
-                WARN("Could not load day-before-yesterday total_unrealized_pnl: " + std::string(e.what()));
-            }
-            const double day_before_yesterday_realized_only =
-                day_before_yesterday_total_pnl - day_before_yesterday_total_unrealized_pnl;
-
-            // Calculate yesterday's cumulative values
-            // NOTE: Since we may not have correct commissions, the cumulative values will be recalculated by SQL
-            // using the daily_pnl formula (daily_realized_pnl - daily_commissions)
-            double yesterday_total_pnl_cumulative = day_before_yesterday_realized_only + yesterday_daily_pnl_finalized;
-            double yesterday_total_commissions_cumulative = day_before_yesterday_total_commissions + yesterday_commissions;
-            double yesterday_total_realized_pnl_cumulative = yesterday_total_pnl_cumulative + yesterday_total_commissions_cumulative;
-            // Yesterday's own mark, i.e. the total_unrealized_pnl the INSERT wrote on the T-1
-            // row. The UPDATE's current_portfolio_value expression below reads the same stored
-            // value (bare `total_unrealized_pnl` on the RHS of a SET is the pre-UPDATE value),
-            // so computing it the same way here keeps the return columns consistent with the
-            // equity they are supposed to describe.
-            double yesterday_total_unrealized_pnl = 0.0;
-            try {
-                std::string y_unrl_query =
-                    "SELECT COALESCE(total_unrealized_pnl, 0.0) FROM trading.live_results "
-                    "WHERE strategy_id = 'LIVE_EQUITY_MEAN_REVERSION' AND portfolio_id = '" + portfolio_id + "' "
-                    "AND DATE(date) = '" + yesterday_date_str + "'";
-                auto yu = db->execute_query(y_unrl_query);
-                if (yu.is_ok() && yu.value()->num_rows() > 0) {
-                    auto r = DataConversionUtils::safe_get_double(yu.value()->column(0), 0,
-                                                                  "total_unrealized_pnl");
-                    if (r.is_ok()) {
-                        yesterday_total_unrealized_pnl = r.value();
-                    } else {
-                        WARN("Could not read yesterday's total_unrealized_pnl (" +
-                             std::string(r.error()->what()) + "); the T-1 return columns will be "
-                             "computed off a realized-only equity and will disagree with "
-                             "current_portfolio_value.");
-                    }
-                }
-            } catch (const std::exception& e) {
-                WARN("Could not load yesterday's total_unrealized_pnl: " + std::string(e.what()));
+                WARN("Could not load T-1 equity components: " + std::string(e.what()));
             }
 
-            // Mark-to-market equity for T-1. Anchored on initial_capital rather than chained off
-            // the previous stored value, so it cannot drift from the SQL expression that writes
-            // current_portfolio_value -- the two are the same formula.
             double yesterday_portfolio_value_finalized = initial_capital
-                + day_before_yesterday_realized_only
-                + yesterday_daily_pnl_finalized
-                + yesterday_total_unrealized_pnl;
+                + ((dby_total_realized + t1_daily_realized) - t1_total_costs)
+                + yesterday_finalized_unrealized;
 
             // Calculate yesterday's returns using LiveMetricsCalculator
             double yesterday_daily_return = metrics_calculator->calculate_daily_return(
@@ -2499,45 +2561,82 @@ int main(int argc, char* argv[]) {
             //  above writes the equity commission into daily_transaction_costs, and this
             //  UPDATE must read the same column or the whole statement fails)
             // IMPORTANT: Only update portfolio_leverage and equity_to_margin_ratio if they are NULL or 0
+            // E2-F1 -- the Day T-1 finalization, restated.
+            //
+            // WHAT CHANGED AND WHY. This statement used to overwrite daily_realized_pnl with
+            // finalize_previous_day()'s output: the whole book's daily mark move,
+            // `sum qty*(close(T-1) - close(T-2))`, booked as "realized" even for positions
+            // that never traded. That is the std::to_string(yesterday_finalized_unrealized)TURES settlement model. It is correct there --
+            // a futures position is entered at close(T-1) and settled at close(T), so the
+            // move genuinely IS realized daily and unrealized is 0 by identity -- and it is
+            // wrong for a cash equity book, where a held position's move is unrealized until
+            // it is sold.
+            //
+            // It also made total_pnl double-count. Cumulative "realized" already contained
+            // the entire move from entry, so once E2-F12 layered total_unrealized_pnl on top,
+            // the same price move was counted twice. Verified against P&L hand-computed from
+            // raw executions and closes: cumulative daily_realized_pnl tracked true
+            // mark-to-market P&L EXACTLY, which is only possible if it was already the whole
+            // thing rather than a realized component.
+            //
+            // THE MODEL NOW, mirroring futures' `gross - costs`:
+            //   daily_realized_pnl   trade-realized, gross, written on the day itself at
+            //                        INSERT and NOT touched here -- a closing fill's P&L is
+            //                        known when it fills and needs no T-1 lag.
+            //   total_unrealized_pnl the T-1 book marked at close(T-1), i.e. the sum of the
+            //                        same finalized rows persisted to trading.positions, so
+            //                        the aggregate equals the row sum by construction (L5).
+            //                        This is what E2-F13 was: the column used to be a DAY-T
+            //                        snapshot priced at close(T-2) that finalization never
+            //                        revisited, so it differed from the rows by exactly that
+            //                        day's P&L.
+            //   daily_pnl            (realized - costs) + change in mark. Costs subtracted
+            //                        ONCE, here; pos.realized_pnl is gross for this reason.
+            //   total_pnl            (cumulative realized - cumulative costs) + current mark.
+            //                        DERIVED, not accumulated.
+            //
+            // The old "realized-only strip" is gone with the defect that needed it. total_pnl
+            // is no longer a running sum that the mark has to be added to and stripped back
+            // out of each day; it is recomputed from cumulative realized, cumulative costs and
+            // the current mark. Do not reintroduce an accumulator here -- a snapshot added to
+            // a running total is exactly how the mark started compounding.
+            //
+            // Bare column names on the right-hand side of a SET read the row's PRE-UPDATE
+            // values, which is what we want for daily_realized_pnl, daily_transaction_costs
+            // and total_transaction_costs: all three were written by that day's own INSERT.
             std::string update_query =
-                // Mark-to-market, EQUITIES ONLY -- mirrors the Day-T block in STEP 5; read the
-                // long comment there first. Two things matter here:
-                //   (1) The running total must stay REALIZED-ONLY, so the prior row's mark is
-                //       stripped back off (`total_pnl - total_unrealized_pnl` in day_before)
-                //       before today's realized flow is added. Without the strip, each day
-                //       re-adds the previous day's open-position mark and the curve diverges.
-                //   (2) This row's OWN mark is then layered on once. Bare `total_unrealized_pnl`
-                //       on the right-hand side of a SET reads the row's pre-UPDATE value, which
-                //       is the snapshot the INSERT wrote for that day -- exactly what we want.
-                // This UPDATE previously never mentioned daily_unrealized_pnl at all, which is
-                // why the Day-T placeholder 0 survived on every finalized equity row.
                 "WITH day_before AS ("
                 "  SELECT COALESCE(current_portfolio_value, " + std::to_string(initial_capital) + ") as portfolio, "
-                "         COALESCE(total_pnl, 0.0) - COALESCE(total_unrealized_pnl, 0.0) as realized_only, "
                 "         COALESCE(total_unrealized_pnl, 0.0) as prev_unrealized, "
-                "         COALESCE(total_realized_pnl, 0.0) as total_realized_pnl_prev "
+                "         COALESCE(total_realized_pnl, 0.0) as prev_total_realized "
                 "  FROM trading.live_results "
                 "  WHERE strategy_id = 'LIVE_EQUITY_MEAN_REVERSION' AND portfolio_id = '" + portfolio_id + "' AND DATE(date) < '" + yesterday_date_str + "' "
                 "  ORDER BY date DESC LIMIT 1"
                 ") "
                 "UPDATE trading.live_results SET "
-                "daily_realized_pnl = " + std::to_string(yesterday_total_pnl) + ", "
-                "daily_unrealized_pnl = COALESCE(total_unrealized_pnl, 0.0) - COALESCE((SELECT prev_unrealized FROM day_before), 0.0), "
-                "daily_pnl = (" + std::to_string(yesterday_total_pnl) + " - COALESCE(daily_transaction_costs, 0.0)) "
-                "            + (COALESCE(total_unrealized_pnl, 0.0) - COALESCE((SELECT prev_unrealized FROM day_before), 0.0)), "
-                "total_pnl = COALESCE((SELECT realized_only FROM day_before), 0.0) + (" + std::to_string(yesterday_total_pnl) + " - COALESCE(daily_transaction_costs, 0.0)) + COALESCE(total_unrealized_pnl, 0.0), "
-                "total_realized_pnl = " + std::to_string(yesterday_total_realized_pnl_cumulative) + ", "
-                "current_portfolio_value = " + std::to_string(initial_capital) + " + COALESCE((SELECT realized_only FROM day_before), 0.0) + (" + std::to_string(yesterday_total_pnl) + " - COALESCE(daily_transaction_costs, 0.0)) + COALESCE(total_unrealized_pnl, 0.0), "
+                // The mark, from the finalized rows. daily_realized_pnl is deliberately absent.
+                "total_unrealized_pnl = " + std::to_string(yesterday_finalized_unrealized) + ", "
+                "daily_unrealized_pnl = " + std::to_string(yesterday_finalized_unrealized) + " - COALESCE((SELECT prev_unrealized FROM day_before), 0.0), "
+                "total_realized_pnl = COALESCE((SELECT prev_total_realized FROM day_before), 0.0) + COALESCE(daily_realized_pnl, 0.0), "
+                "daily_pnl = (COALESCE(daily_realized_pnl, 0.0) - COALESCE(daily_transaction_costs, 0.0)) "
+                "            + (" + std::to_string(yesterday_finalized_unrealized) + " - COALESCE((SELECT prev_unrealized FROM day_before), 0.0)), "
+                "total_pnl = (COALESCE((SELECT prev_total_realized FROM day_before), 0.0) + COALESCE(daily_realized_pnl, 0.0) "
+                "             - COALESCE(total_transaction_costs, 0.0)) + " + std::to_string(yesterday_finalized_unrealized) + ", "
+                "current_portfolio_value = " + std::to_string(initial_capital) + " "
+                "             + (COALESCE((SELECT prev_total_realized FROM day_before), 0.0) + COALESCE(daily_realized_pnl, 0.0) "
+                "                - COALESCE(total_transaction_costs, 0.0)) + " + std::to_string(yesterday_finalized_unrealized) + ", "
                 "daily_return = CASE WHEN COALESCE((SELECT portfolio FROM day_before), " + std::to_string(initial_capital) + ") > 0 "
-                "               THEN (((" + std::to_string(yesterday_total_pnl) + " - COALESCE(daily_transaction_costs, 0.0)) "
-                "                      + (COALESCE(total_unrealized_pnl, 0.0) - COALESCE((SELECT prev_unrealized FROM day_before), 0.0))) "
+                "               THEN (((COALESCE(daily_realized_pnl, 0.0) - COALESCE(daily_transaction_costs, 0.0)) "
+                "                      + (" + std::to_string(yesterday_finalized_unrealized) + " - COALESCE((SELECT prev_unrealized FROM day_before), 0.0))) "
                 "                     / COALESCE((SELECT portfolio FROM day_before), " + std::to_string(initial_capital) + ")) * 100.0 "
                 "               ELSE 0.0 END, "
                 "total_cumulative_return = " + std::to_string(yesterday_total_cumulative_return_pct) + ", "
                 "total_annualized_return = " + std::to_string(yesterday_total_return_annualized) + ", "
                 "portfolio_leverage = CASE WHEN portfolio_leverage IS NULL OR portfolio_leverage = 0 THEN " + std::to_string(yesterday_portfolio_leverage) + " ELSE portfolio_leverage END, "
                 "equity_to_margin_ratio = CASE WHEN equity_to_margin_ratio IS NULL OR equity_to_margin_ratio = 0 THEN " + std::to_string(yesterday_equity_to_margin_ratio) + " ELSE equity_to_margin_ratio END, "
-                "cash_available = " + std::to_string(initial_capital) + " + COALESCE((SELECT realized_only FROM day_before), 0.0) + (" + std::to_string(yesterday_total_pnl) + " - COALESCE(daily_transaction_costs, 0.0)) + COALESCE(total_unrealized_pnl, 0.0) - COALESCE(margin_posted, 0.0) "
+                "cash_available = " + std::to_string(initial_capital) + " "
+                "             + (COALESCE((SELECT prev_total_realized FROM day_before), 0.0) + COALESCE(daily_realized_pnl, 0.0) "
+                "                - COALESCE(total_transaction_costs, 0.0)) + " + std::to_string(yesterday_finalized_unrealized) + " - COALESCE(margin_posted, 0.0) "
                 "WHERE strategy_id = 'LIVE_EQUITY_MEAN_REVERSION' AND portfolio_id = '" + portfolio_id + "' AND DATE(date) = '" + yesterday_date_str + "'";
 
             INFO("Executing UPDATE query for Day T-1 live_results...");
@@ -2545,7 +2644,22 @@ int main(int argc, char* argv[]) {
 
             auto update_result = db->execute_direct_query(update_query);
             if (update_result.is_error()) {
+                // E2-F1: a failed T-1 UPDATE is FATAL. It used to log and carry on, and the
+                // run still exited 0 -- the same defect class as E2-F5/E2-F6, where a
+                // swallowed write failure made a zero exit code meaningless.
+                //
+                // This is not hypothetical: during E2-F1 development a malformed statement
+                // failed on every single day of a 12-day replay, every run exited 0, and the
+                // only symptom was that total_unrealized_pnl silently kept its stale Day-T
+                // value. Every internal identity still reconciled, because the INSERT path
+                // computes them consistently -- so the run looked clean and was not.
+                //
+                // If this statement does not apply, the T-1 row keeps a mark priced at
+                // close(T-2) and the book is wrong from that day forward. Fail the run.
                 ERROR("Failed to update Day T-1 live_results: " + std::string(update_result.error()->what()));
+                ERROR("Day T-1 aggregates could not be finalized. Refusing to exit 0 with a "
+                      "stale mark on " + yesterday_date_str + ".");
+                return 1;
             } else {
                 INFO("Successfully updated Day T-1 live_results with finalized PnL and all metrics");
 
@@ -2795,27 +2909,79 @@ int main(int argc, char* argv[]) {
             total_unrealized_pnl += pos.unrealized_pnl.as_double();
         }
 
-        // Strip the mark out of the previous row's stored total_pnl to recover the realized-only
-        // running total. previous_total_pnl comes from get_previous_live_aggregates(), which is
-        // shared with the futures runners and reads the stored total_pnl column -- for futures
-        // previous_total_unrealized_pnl is 0 so this subtraction is a no-op there.
-        double previous_total_pnl_realized_only = previous_total_pnl - previous_total_unrealized_pnl;
+        // E2-F1: on a CLOSED day the mark is CARRIED, not recomputed to zero.
+        //
+        // A carry-forward day (weekend or holiday, per B1) generates no executions, so
+        // LiveDailyCycle has no execution_prices to mark against and every position's
+        // unrealized_pnl comes back 0 -- making the sum above 0 even though the book is
+        // unchanged and fully marked. The stored position rows are NOT zero: they carry the
+        // held mark. So the aggregate and the rows disagreed on exactly the closed days.
+        //
+        // The reported effect was a fabricated round trip. Measured on the 2026-07-24..08-04
+        // replay before this guard: Saturday 08-01 reported daily_pnl = -1052.6450 and
+        // Monday reversed it, on days the market never opened. That corrupts daily_return,
+        // and every volatility- and drawdown-derived metric with it.
+        //
+        // No new close exists, so there is no new mark and no P&L: carry the previous value
+        // and let daily_unrealized_pnl fall out as exactly 0. This also restores L5 on closed
+        // days, because the carried figure is precisely what the position rows hold.
+        if (today_is_non_trading) {
+            INFO("Non-trading day: carrying the previous mark ($" +
+                 std::to_string(previous_total_unrealized_pnl) +
+                 ") rather than recomputing it from an unmarked book");
+            total_unrealized_pnl = previous_total_unrealized_pnl;
+        }
 
-        // Realized-only running total: the accumulator, unchanged in meaning from before.
-        double total_pnl_realized_only = previous_total_pnl_realized_only + daily_pnl_for_today;
+        // E2-F1: cumulative TRADE-realized, gross. Read from the previous row and extended by
+        // today's realized rather than derived from a total_pnl accumulator.
+        //
+        // The old code did the reverse -- it accumulated total_pnl and back-solved
+        // total_realized_pnl from it -- which only worked while "realized" meant the daily
+        // mark move. It also needed a "realized-only strip" (subtracting the prior row's mark
+        // from the prior total_pnl) to stop the mark compounding day over day. Both are gone:
+        // realized is now a genuine flow that accumulates, and total_pnl is DERIVED from it.
+        // Do not turn total_pnl back into an accumulator -- adding a snapshot to a running
+        // total is precisely how the mark started compounding.
+        double previous_total_realized_pnl = 0.0;
+        try {
+            std::string prev_realized_query =
+                "SELECT COALESCE(total_realized_pnl, 0.0) FROM trading.live_results "
+                "WHERE strategy_id = 'LIVE_EQUITY_MEAN_REVERSION' AND portfolio_id = '" + portfolio_id + "' "
+                "AND DATE(date) < '" + today_date_str + "' "
+                "ORDER BY date DESC LIMIT 1";
+            auto pr = db->execute_query(prev_realized_query);
+            if (pr.is_ok() && pr.value()->num_rows() > 0) {
+                auto r = DataConversionUtils::safe_get_double(pr.value()->column(0), 0,
+                                                              "total_realized_pnl");
+                if (r.is_ok()) {
+                    previous_total_realized_pnl = r.value();
+                    INFO("Loaded previous total_realized_pnl: $" +
+                         std::to_string(previous_total_realized_pnl));
+                } else {
+                    WARN("Could not read previous total_realized_pnl (" +
+                         std::string(r.error()->what()) + "); treating it as 0. Cumulative "
+                         "realized and every figure derived from it will be understated until "
+                         "the next clean read.");
+                }
+            } else {
+                INFO("No previous total_realized_pnl row; starting the cumulative at 0");
+            }
+        } catch (const std::exception& e) {
+            WARN("Could not load previous total_realized_pnl: " + std::string(e.what()));
+        }
 
-        // total_realized_pnl keeps its original derivation off the realized-only accumulator,
-        // so the invariant total_pnl_realized_only == total_realized_pnl - total_commissions
-        // still holds exactly and the reconciliation in the protocol is unaffected.
-        double total_realized_pnl = total_pnl_realized_only + total_commissions_cumulative;
+        double total_realized_pnl = previous_total_realized_pnl + daily_realized_pnl;
 
         // Day-over-day change in the mark. This is what daily_unrealized_pnl should have held
         // all along; it was previously hard-wired to 0.0 as a Day-T placeholder and never
         // repaired by the Day T-1 UPDATE, so it read 0 on every equity row.
         double daily_unrealized_pnl = total_unrealized_pnl - previous_total_unrealized_pnl;
 
-        // Mark-to-market reported figures.
-        double total_pnl = total_pnl_realized_only + total_unrealized_pnl;
+        // The reported identity, and the one to hand-check:
+        //     total_pnl = (cumulative realized - cumulative costs) + current mark
+        // Costs are subtracted exactly once. Realized is gross precisely so that this is the
+        // only place they come off, matching how the futures runners report `gross - costs`.
+        double total_pnl = (total_realized_pnl - total_commissions_cumulative) + total_unrealized_pnl;
         double current_portfolio_value = initial_capital + total_pnl;
 
         // daily_pnl must be the day-over-day change in total_pnl or the equity-curve continuity

--- a/apps/strategies/live_equity_mean_reversion.cpp
+++ b/apps/strategies/live_equity_mean_reversion.cpp
@@ -774,6 +774,25 @@ int main(int argc, char* argv[]) {
             }
         }
 
+        // The book AS IT STOOD on T-1, captured before any corporate action touches it.
+        //
+        // The corp-action blocks below mutate `previous_positions` IN PLACE (non-const ref
+        // by design -- see AVERAGE_PRICE_LIFECYCLE.md step 2). The Day T-1 finalization then
+        // builds its input from that same map and writes the result back at the T-1 DATE, so
+        // the post-action quantities and basis landed on a row for a day the action had not
+        // yet happened. Measured: a position seeded at 10 @ 4194.31 on 2026-04-02 came back
+        // as 250 @ 167.7724 on 2026-04-02 after the 2026-04-06 split was applied -- history
+        // restated four days before the ex-date.
+        //
+        // For a split that is "only" falsified quantity history, since notional is
+        // preserved. For a DIVIDEND it is worse: the basis changes without notional being
+        // preserved, so the T-1 row would carry a cost basis that was not true that day and
+        // any P&L computed over it would be wrong.
+        //
+        // T-1 is finalized from this snapshot; the adjustment belongs to the ex-date forward.
+        const std::unordered_map<std::string, Position> previous_positions_pre_action =
+            previous_positions;
+
         DEBUG("Previous date used for lookup: " + std::to_string(std::chrono::system_clock::to_time_t(previous_date)));
         DEBUG("Current date: " + std::to_string(std::chrono::system_clock::to_time_t(now)));
         DEBUG("Previous positions loaded: " + std::to_string(previous_positions.size()));
@@ -1386,8 +1405,22 @@ int main(int argc, char* argv[]) {
                     ev.event_date = row.date_str;
                     ev.vendor_label = row.action;
                     ev.contra_ticker = row.contra_ticker;
-                    ev.ratio = row.value;
-                    ev.has_terms = !row.contra_ticker.empty() && row.value > 0.0;
+                    // corporate_action.value is NOT a share exchange ratio. Measured over
+                    // the table: acquisitionby/of average 2,051 and reach 133,846.7, and
+                    // `split` reaches 10,872,442 -- these are deal values in millions. A
+                    // real stock-for-stock ratio is ~0.1-3.0. Feeding it in as `ratio` would
+                    // have turned 40 DFS shares into 40 x 50343.3 = 2,013,732 COF shares at
+                    // a basis of $0.0039, against a real currently-trading symbol, with
+                    // nothing downstream able to catch it (E2-F9).
+                    //
+                    // So this runner does not claim to have terms. The handler's rollover
+                    // path is left fully intact and still activates the day a trustworthy
+                    // deal-terms source exists -- the judgement is about PROVENANCE, not
+                    // magnitude, and a plausibility band cannot separate a genuine 0.5 ratio
+                    // from a $0.6m deal value. Until then every termination exits at the
+                    // final real close, which is conservative and broker-reconcilable.
+                    ev.ratio = 0.0;
+                    ev.has_terms = false;
                     // A terms row supersedes a bare delisting for the same
                     // symbol: it says what the holding BECAME.
                     bool replaced = false;
@@ -1554,10 +1587,14 @@ int main(int argc, char* argv[]) {
         if (!two_days_ago_close_prices.empty() && !previous_positions.empty() && pnl_manager) {
             INFO("Using PnLManager to finalize Day T-1 positions...");
 
-            // Convert map to vector for PnLManager
+            // Convert map to vector for PnLManager.
+            // Sourced from the PRE-corp-action snapshot: Day T-1 is finalized as the book
+            // actually stood on T-1. Using the mutated `previous_positions` here wrote the
+            // post-action quantities and basis onto the T-1 row, restating a day before the
+            // ex-date (see the snapshot's comment above).
             std::vector<Position> prev_positions_vec;
-            prev_positions_vec.reserve(previous_positions.size());
-            for (const auto& [symbol, pos] : previous_positions) {
+            prev_positions_vec.reserve(previous_positions_pre_action.size());
+            for (const auto& [symbol, pos] : previous_positions_pre_action) {
                 prev_positions_vec.push_back(pos);
             }
 

--- a/apps/strategies/live_equity_mean_reversion.cpp
+++ b/apps/strategies/live_equity_mean_reversion.cpp
@@ -747,6 +747,26 @@ int main(int argc, char* argv[]) {
             INFO("No previous day positions found (first run or no data): " + std::string(previous_positions_result.error()->what()));
         }
 
+        // E2-F19: a position closed to zero keeps its row for the day it closed, so the
+        // exit's realized P&L has somewhere to live (see LiveDailyCycle::is_dead_row).
+        // Everything below this line -- corporate actions, the run-gap guard, seeding,
+        // execution, basis resolution -- is written against a book of HELD positions,
+        // so closed rows are split out here and reach exactly one place: the T-1 write
+        // set, where they are re-appended verbatim so the DELETE-then-INSERT that
+        // rewrites the T-1 date does not destroy them.
+        std::unordered_map<std::string, Position> previous_closed_rows;
+        {
+            std::unordered_map<std::string, Position> open_rows;
+            LiveDailyCycle::split_open_and_closed(previous_positions, open_rows,
+                                                  previous_closed_rows);
+            previous_positions = std::move(open_rows);
+            if (!previous_closed_rows.empty()) {
+                INFO("Loaded " + std::to_string(previous_closed_rows.size()) +
+                     " closed row(s) for Day T-1 (realized carried on the close date); " +
+                     std::to_string(previous_positions.size()) + " held position(s) remain");
+            }
+        }
+
         // An empty prior book is legitimate on a genuine first run, and catastrophic
         // otherwise. The two are indistinguishable from here -- both are an empty map --
         // and the consequences of guessing wrong are total: the strategy seeds flat, the
@@ -1657,6 +1677,13 @@ int main(int argc, char* argv[]) {
                     for (const auto& [sym, pos] : previous_positions) {
                         Position p = pos;
                         p.last_update = now;
+                        // E2-F19: this is a day-T placeholder for the restated book, not
+                        // a P&L record. The loaded realized is T-1's flow; stamping it on
+                        // a day-T row would let a placeholder that survives an empty
+                        // day-T write (book fully terminated) reload tomorrow as a closed
+                        // row carrying yesterday's realized, and be re-persisted at T-1
+                        // forever. The day-T write below records the day's real figure.
+                        p.realized_pnl = Decimal(0.0);
                         positions_to_store.push_back(std::move(p));
                     }
                     // Adjusted positions and the dedup rows that stop those
@@ -1702,6 +1729,14 @@ int main(int argc, char* argv[]) {
                 }
             }
         }
+
+        // The book after the class-1 rescale and BEFORE the lifecycle handlers. The
+        // E2-F16 restated-frame rule for the T-1 finalization needs exactly this
+        // snapshot: a termination sets quantity to 0 and adds a day-T cash flow to
+        // realized_pnl, and a rename or contra-merge re-keys entries -- none of which
+        // happened on T-1 (E2-F19 gap G4; LiveDailyCycle::select_finalization_book).
+        const std::unordered_map<std::string, Position> previous_positions_post_class1 =
+            previous_positions;
 
         // ---- Class 2 SERIES_CONTINUITY + Class 3 TERMINATION ----
         // Both change WHAT is held rather than its price, so they run after
@@ -1963,6 +1998,10 @@ int main(int argc, char* argv[]) {
                     Position p = pos;
                     p.symbol = sym;
                     p.last_update = now;
+                    // E2-F19: day-T placeholder, same rule as the class-1 store above.
+                    // A termination's realized_delta reaches the day-T row and the
+                    // aggregate through corp_action_realized_total, not through here.
+                    p.realized_pnl = Decimal(0.0);
                     lifecycle_positions.push_back(std::move(p));
                 }
 
@@ -2210,25 +2249,22 @@ int main(int argc, char* argv[]) {
             // The gate now defers exactly that event, so the situation cannot arise upstream
             // of here. The predicate is kept explicit rather than assumed: it states the rule
             // that makes this correct, and keeps it correct if the gate's horizon ever moves.
-            std::vector<Position> prev_positions_vec;
-            prev_positions_vec.reserve(previous_positions_pre_action.size());
-            for (const auto& [symbol, pos] : previous_positions_pre_action) {
-                auto ex = applied_class1_ex_date.find(symbol);
-                const bool event_covers_t1 =
-                    ex != applied_class1_ex_date.end() &&
-                    ex->second <= core::format_utc_date(previous_date);
-                if (event_covers_t1) {
-                    auto restated = previous_positions.find(symbol);
-                    if (restated != previous_positions.end()) {
-                        INFO("Finalizing " + symbol + " from the RESTATED T-1 book: a " +
-                             "deferred corp action for " + ex->second +
-                             " was applied this run, so the T-1 close is already post-event "
-                             "and the pre-action basis would be a frame behind it (E2-F15).");
-                        prev_positions_vec.push_back(restated->second);
-                        continue;
-                    }
-                }
-                prev_positions_vec.push_back(pos);
+            //
+            // E2-F19 gap G4: the restated book is the POST-CLASS-1, PRE-LIFECYCLE
+            // snapshot, not the fully mutated map -- a symbol that also terminated or
+            // was renamed this run would otherwise be finalized onto T-1 as a qty-0 row
+            // carrying a day-T cash flow. The rule lives in
+            // LiveDailyCycle::select_finalization_book so it is unit-testable.
+            std::vector<std::string> restated_symbols;
+            std::vector<Position> prev_positions_vec = LiveDailyCycle::select_finalization_book(
+                previous_positions_pre_action, previous_positions_post_class1,
+                applied_class1_ex_date, core::format_utc_date(previous_date),
+                &restated_symbols);
+            for (const auto& symbol : restated_symbols) {
+                INFO("Finalizing " + symbol + " from the RESTATED T-1 book: a " +
+                     "deferred corp action for " + applied_class1_ex_date.at(symbol) +
+                     " was applied this run, so the T-1 close is already post-event "
+                     "and the pre-action basis would be a frame behind it (E2-F15).");
             }
 
             // Use PnLManager to finalize previous day
@@ -2263,22 +2299,39 @@ int main(int argc, char* argv[]) {
             }
 
             // Store updated positions for yesterday (Day T-1) in database.
+            //
+            // E2-F19 / E2-F20: the finalizer writes the settlement move into every row's
+            // realized_pnl. That is the futures definition; on this cash book it is a
+            // MARK, and it overwrote the trade realized T-1's own run had recorded -- on
+            // a weekend three times over, so Monday's load read Friday's mark move and
+            // seeded it. The T-1 row keeps the LOADED realized (the day's own flow); the
+            // finalizer's aggregate fields are untouched. The shared finalizer is not
+            // edited: the futures runners persist its rows as-is.
+            LiveDailyCycle::restore_loaded_realized(yesterday_finalized_positions,
+                                                    previous_positions_pre_action);
+
             // finalize_previous_day returns a row for EVERY carried position, flat ones
-            // included, so it must apply the same zero-quantity rule as the Day-T write
-            // above or it re-introduces exactly the rows that rule exists to prevent.
-            // This is the path that actually produced the observed dead rows: 4 of the 6
-            // had zero quantity AND zero P&L, so the Day-T filter was never the one
-            // letting them through. The futures finalization path has no filter either,
-            // but never needs one -- its Day-T rule keeps zeros out of the table, so a
-            // zero never comes back through previous_positions.
+            // included, so it applies the same dead-row rule as the Day-T write below:
+            // a row is dropped only when it carries neither quantity nor realized. This
+            // is the path that actually produced the observed dead rows (4 of the 6 had
+            // zero quantity AND zero P&L), and those are still dropped. A row with zero
+            // quantity and a realized figure is a close-day row and is kept.
             std::vector<Position> finalized_to_store;
-            finalized_to_store.reserve(yesterday_finalized_positions.size());
+            finalized_to_store.reserve(yesterday_finalized_positions.size() +
+                                       previous_closed_rows.size());
             for (const auto& fp : yesterday_finalized_positions) {
-                if (std::abs(fp.quantity.as_double()) > 1e-10) {
+                if (!LiveDailyCycle::is_dead_row(fp)) {
                     finalized_to_store.push_back(fp);
                 } else {
-                    DEBUG("Skipping zero-quantity Day T-1 position: " + fp.symbol);
+                    DEBUG("Skipping dead Day T-1 position (no quantity, no realized): " +
+                          fp.symbol);
                 }
+            }
+            // Closed rows loaded for T-1 are re-appended verbatim -- there is nothing to
+            // mark and their realized is already the day's figure. Appended AFTER the
+            // finalized rows: store_positions keys its DELETE on positions[0].last_update.
+            for (const auto& [symbol, closed] : previous_closed_rows) {
+                finalized_to_store.push_back(closed);
             }
 
             // E2-F14 guard: never let a day with NO T-1 prices overwrite a day that was
@@ -2460,8 +2513,16 @@ int main(int argc, char* argv[]) {
             }
             auto exec_result = mr_strategy->on_execution(exec);
             if (exec_result.is_error()) {
-                WARN("Failed to process execution for " + exec.symbol + ": " +
-                     std::string(exec_result.error()->what()));
+                // E2-F19: FATAL. A dropped fill leaves its cost in total_daily_commissions
+                // while its realized reaches neither the row nor metrics_, and the
+                // strategy's book no longer matches the executions the run has already
+                // persisted. Continuing would produce a day whose rows cannot sum to its
+                // aggregate for a reason no later check could name.
+                ERROR("Failed to process execution for " + exec.symbol + ": " +
+                      std::string(exec_result.error()->what()) +
+                      ". Refusing to continue with a book that does not reflect a "
+                      "persisted execution.");
+                return 1;
             } else {
                 DEBUG("Strategy processed execution for " + exec.symbol +
                       ": avg_price updated via on_execution()");
@@ -2642,25 +2703,28 @@ int main(int argc, char* argv[]) {
         positions_to_save.reserve(positions.size());
 
         for (const auto& [symbol, position] : positions) {
-            // Only save positions with non-zero quantity.
-            // Zero-quantity positions (closed positions) should NOT be stored -- the same
-            // rule and tolerance the futures runner uses
-            // (live_portfolio_conservative.cpp:1657). A flat symbol is ABSENT from
-            // trading.positions, not present with a zero: futures conservative holds 0
-            // zero-qty rows in 1702, and only 1702 of a possible 4830 symbol-days exist.
-            // The close is recorded in trading.executions, which is the audit trail; a
-            // zero position row adds nothing and accumulates (at 852 symbols it would
-            // dominate the table). Realized P&L from the exit lands in
-            // live_results.daily_realized_pnl, exactly as it does for futures.
+            // E2-F19: a row is dropped only when it carries neither quantity nor
+            // realized P&L (LiveDailyCycle::is_dead_row). The previous rule dropped on
+            // quantity alone, copied from the futures runner on the premise that "the
+            // exit's realized lands in live_results exactly as it does for futures".
+            // The rule was identical; the consequence was not. A futures exit realizes
+            // exactly zero (average_price is reset to close(T-1) daily and the fill
+            // strikes at close(T-1)), so its dropped row is genuinely empty. An equity
+            // exit realizes the whole accumulated gain against a true cost basis, and
+            // dropping the row lost the largest figure of the position's life at row
+            // level: 11 close events in the 2026-04..08 series, e.g. TMUS 2026-04-15
+            // -402.65 in live_results with no row to carry it.
             //
-            // The previous rule also kept a row when it carried PnL, which is why flat
-            // rows survived here and never do on the futures path.
-            bool has_quantity = std::abs(position.quantity.as_double()) > 1e-10;
-
-            if (!has_quantity) {
-                DEBUG("Skipping zero-quantity position: " + symbol);
+            // A flat symbol with no trade still writes no row -- the 852-symbol
+            // accumulation the old comment feared cannot occur, because a symbol that
+            // closed on an earlier day carries realized 0 today (the seed is zeroed).
+            // A closed row exists on the close date only.
+            if (LiveDailyCycle::is_dead_row(position)) {
+                DEBUG("Skipping dead position (no quantity, no realized): " + symbol);
                 continue;
             }
+            const bool closed_row =
+                std::abs(position.quantity.as_double()) <= LiveDailyCycle::kRowTolerance;
 
             // Create a new position with validated values
             trade_ngin::Position validated_position;
@@ -2728,6 +2792,15 @@ int main(int argc, char* argv[]) {
                         validated_position.average_price = trade_ngin::Decimal(1.0);
                     }
                 }
+            }
+
+            if (closed_row) {
+                // No basis for a position that no longer exists: on_execution leaves the
+                // exit price in average_price after a full close, and storing a price on
+                // a closed row is the category error AVERAGE_PRICE_LIFECYCLE.md exists to
+                // prevent. Zero reads unambiguously as "closed".
+                validated_position.average_price = Decimal(0.0);
+                validated_position.unrealized_pnl = Decimal(0.0);
             }
 
             positions_to_save.push_back(validated_position);

--- a/apps/strategies/live_equity_mean_reversion.cpp
+++ b/apps/strategies/live_equity_mean_reversion.cpp
@@ -1436,8 +1436,51 @@ int main(int argc, char* argv[]) {
             }
 
             if (!terminations.empty()) {
+                // A terminating symbol is, by definition, one that has STOPPED trading, so
+                // it cannot be in previous_day_close_prices -- that map is built from the
+                // run date's T-1 bar, and a delisted name has no bar there. Handing it in
+                // alone meant every termination took the SKIPPED_NO_PRICE branch and the
+                // position was left dangling with "operator review required", even though
+                // the final close sits in the database (DFS: 200.05 on its last bar,
+                // 2025-05-16). The data was never missing; the lookup was asking the wrong
+                // question (E2-F10).
+                //
+                // So: start from the T-1 map, then for any terminating symbol still absent,
+                // fall back to its LAST REAL CLOSE. Same principle as the execution price
+                // resolver -- price from a real session, never from a basis or a guess.
+                std::unordered_map<std::string, double> final_closes = previous_day_close_prices;
+
+                std::vector<std::string> need_final;
+                for (const auto& ev : terminations) {
+                    if (final_closes.find(ev.symbol) == final_closes.end()) {
+                        need_final.push_back(ev.symbol);
+                    }
+                }
+
+                if (!need_final.empty()) {
+                    // Bounded window: the event date is the last day it could have traded.
+                    auto hist = db->get_historical_closes(
+                        need_final, std::string(lifecycle_start_buf), as_of_date);
+                    if (hist.is_ok()) {
+                        for (const auto& [sym, series] : hist.value()) {
+                            if (series.empty()) continue;
+                            const auto& last = *series.rbegin();   // most recent real close
+                            if (last.second > 0.0 && std::isfinite(last.second)) {
+                                final_closes[sym] = last.second;
+                                INFO("Termination price | " + sym + " has no T-1 close (it "
+                                     "stopped trading); using its last real close " +
+                                     std::to_string(last.second) + " from " + last.first);
+                            }
+                        }
+                    } else {
+                        WARN("Could not load final closes for terminating symbols: " +
+                             std::string(hist.error()->what()) +
+                             " -- those positions will be left untouched for operator review.");
+                    }
+                }
+
                 auto exits = CorporateActionsLifecycle::apply_terminations(
-                    previous_positions, terminations, previous_day_close_prices);
+                    previous_positions, terminations, final_closes);
                 lifecycle_log.insert(lifecycle_log.end(), exits.begin(), exits.end());
             }
 

--- a/apps/strategies/live_equity_mean_reversion.cpp
+++ b/apps/strategies/live_equity_mean_reversion.cpp
@@ -573,16 +573,10 @@ int main(int argc, char* argv[]) {
             }
         }
 
-        // Update price manager with bars to extract T-1 and T-2 prices
-        if (price_manager) {
-            auto price_update_result = price_manager->update_from_bars(all_bars, now);
-            if (price_update_result.is_error()) {
-                ERROR("Failed to update price manager with bar data: " +
-                      std::string(price_update_result.error()->what()));
-                return 1;
-            }
-            INFO("Price manager updated - extracted T-1 and T-2 prices from bars");
-        } else {
+        // NOTE: the price manager is deliberately NOT updated here. It is updated below,
+        // immediately after `previous_date` is resolved, so the T-1 price lookup and the
+        // T-1 position book are keyed on the SAME trading day. See E2-F14 there.
+        if (!price_manager) {
             ERROR("Price manager not initialized");
             return 1;
         }
@@ -647,6 +641,37 @@ int main(int argc, char* argv[]) {
             return 1;
         }
         auto previous_date = *prev_day_opt;
+
+        // E2-F14: extract T-1/T-2 prices keyed on the trading day we just resolved, NOT on
+        // `now - 24h`.
+        //
+        // This call used to sit ~70 lines above, before `previous_date` existed, and passed
+        // only `now`. LivePriceManager then derived T-1 as `now - 24h` with no fallback,
+        // while the book being finalized came from find_previous_trading_day(). On a Sunday
+        // or Monday run those disagree -- the book says FRIDAY, the price lookup asks for
+        // Saturday/Sunday, and equities_data.ohlcv_1d has no weekend rows -- so an
+        // already-finalized Friday was re-finalized against an empty price map and its
+        // position rows overwritten with 0/0 by the store_positions call in STEP 1, which
+        // runs outside the `yesterday_total_pnl != 0.0` gate that protects live_results.
+        //
+        // Measured on the 2026-07-24..08-04 weekend-inclusive replay: Sat 08-01 correctly
+        // finalized Friday at $864.759444, then Sun 08-02 and Mon 08-03 each re-zeroed it.
+        // L5 residual was -864.7594 on 07-31 and -14.6574 on 07-24, 0.0000 elsewhere.
+        //
+        // Passing the resolved date makes the two lookups agree by construction and makes
+        // re-finalization idempotent. Futures is unaffected: both futures runners pass no
+        // t1_date and their own book lookup is `now - 24h`, the same value this defaults to.
+        // Do NOT move this call back above the resolution, and do NOT "simplify" it by
+        // dropping the argument.
+        {
+            auto price_update_result = price_manager->update_from_bars(all_bars, now, previous_date);
+            if (price_update_result.is_error()) {
+                ERROR("Failed to update price manager with bar data: " +
+                      std::string(price_update_result.error()->what()));
+                return 1;
+            }
+            INFO("Price manager updated - T-1/T-2 prices keyed on resolved trading day");
+        }
 
         // Check if today itself is a non-trading day
         int today_dow = now_tm->tm_wday;
@@ -1744,7 +1769,27 @@ int main(int argc, char* argv[]) {
                 }
             }
 
-            if (!finalized_to_store.empty()) {
+            // E2-F14 guard: never let a day with NO T-1 prices overwrite a day that was
+            // already finalized correctly.
+            //
+            // store_positions is DELETE-then-INSERT keyed on (strategy, portfolio, T-1
+            // date), and it runs here -- ~480 lines BEFORE the `yesterday_total_pnl != 0.0`
+            // gate that protects the live_results UPDATE. So when finalization degenerates
+            // (every symbol takes the no-T-1-close branch and returns 0/0), live_results is
+            // spared but the position rows are silently replaced with zeros.
+            //
+            // Resolving t1_date from the trading calendar removes the weekend cause, but a
+            // genuine data gap on a real trading day can still empty this map. In that case
+            // the rows being written are all 0/0 and carry no information: the day's own run
+            // already wrote the real rows, so skipping loses nothing and refusing to write
+            // is strictly safer than overwriting. Failing closed here is deliberate.
+            const bool have_t1_prices = !previous_day_close_prices.empty();
+            if (!finalized_to_store.empty() && !have_t1_prices) {
+                WARN("Refusing to write " + std::to_string(finalized_to_store.size()) +
+                     " Day T-1 position rows: no T-1 close prices were resolved, so every "
+                     "row is a degenerate 0/0 that would overwrite an already-finalized day");
+            }
+            if (!finalized_to_store.empty() && have_t1_prices) {
                 // Always save yesterday's finalized positions immediately (not queued)
                 // These are updates to existing positions from the previous day
                 auto update_result = db->store_positions(finalized_to_store, kEquityStrategyId, kEquityStrategyName, portfolio_id, "trading.positions");

--- a/apps/strategies/live_equity_mean_reversion.cpp
+++ b/apps/strategies/live_equity_mean_reversion.cpp
@@ -2885,6 +2885,39 @@ int main(int argc, char* argv[]) {
             }
         }
 
+        // E2-F19 (R-3): clear today's position rows for this book BEFORE queueing the
+        // day-T write, unconditionally.
+        //
+        // store_positions is DELETE-then-INSERT keyed on the date of the rows it is
+        // handed, and save_positions_snapshot returns early on an empty book -- so a day
+        // whose day-T write is EMPTY never deletes anything, and whatever rows already
+        // sit on today's date survive as today's book. Two writers put rows there
+        // before this point: the corp-action placeholder stores (dated today, written
+        // even when zero adjustments applied) and, through the loader's timestamp
+        // drift, a T-1 row that has been rewritten four times. Measured on the pre-fix
+        // chain: TMUS closed on 2026-07-07 with no realized row to keep, the
+        // placeholder row (qty 17.6) survived as the 07-07 book, and the runner sold
+        // the same 17.6 shares again every day through 07-27 while booking mark P&L on
+        // stock it no longer held. Scoped exactly like store_positions' own delete.
+        {
+            const std::string clear_today =
+                "DELETE FROM trading.positions WHERE strategy_id = '" +
+                std::string(kEquityStrategyId) + "' AND strategy_name = '" +
+                std::string(kEquityStrategyName) + "' AND portfolio_id = '" + portfolio_id +
+                "' AND DATE(last_update) = '" + today_date_str + "'";
+            auto cleared = db->execute_direct_query(clear_today);
+            if (cleared.is_error()) {
+                ERROR("Failed to clear today's position rows before the day-T write: " +
+                      std::string(cleared.error()->what()) +
+                      ". Refusing to continue: an empty day-T write would leave stale rows "
+                      "as today's book.");
+                return 1;
+            }
+            INFO("Cleared any existing position rows for " + today_date_str +
+                 " ahead of the day-T write (" + std::to_string(positions_to_save.size()) +
+                 " row(s) queued)");
+        }
+
         if (!positions_to_save.empty()) {
             INFO("Attempting to save " + std::to_string(positions_to_save.size()) + " positions to database");
             DEBUG("Database connection status: " + std::string(db->is_connected() ? "connected" : "disconnected"));
@@ -2893,7 +2926,7 @@ int main(int argc, char* argv[]) {
             results_manager->set_positions(positions_to_save);
             INFO("Queued " + std::to_string(positions_to_save.size()) + " current positions for storage");
         } else {
-            INFO("No positions to save (all positions are zero)");
+            INFO("No positions to save (all positions are zero); today's rows cleared above");
         }
 
         // Compute portfolio-level snapshot metrics using RiskManager on today's state

--- a/apps/strategies/live_equity_mean_reversion.cpp
+++ b/apps/strategies/live_equity_mean_reversion.cpp
@@ -2022,7 +2022,11 @@ int main(int argc, char* argv[]) {
                     INFO("Deleting stale executions for today with matching order_ids: " + std::to_string(order_ids_vector.size()));
 
                     // Use the new delete_stale_executions method
-                    auto del_res = db->delete_stale_executions(order_ids_vector, now, "trading.executions");
+                    // E2-F4: was a 3-arg call putting the table name in the strategy_name
+                    // slot, so it deleted nothing. Now correctly scoped.
+                    auto del_res = db->delete_stale_executions(
+                        order_ids_vector, now, kEquityStrategyName, portfolio_id,
+                        "trading.executions");
                     if (del_res.is_error()) {
                         WARN("Failed to delete stale executions: " + std::string(del_res.error()->what()));
                     } else {

--- a/apps/strategies/live_equity_mean_reversion.cpp
+++ b/apps/strategies/live_equity_mean_reversion.cpp
@@ -793,6 +793,11 @@ int main(int argc, char* argv[]) {
         const std::unordered_map<std::string, Position> previous_positions_pre_action =
             previous_positions;
 
+        // Executions synthesised from corporate actions (terminations), merged into the
+        // day's executions after execute_day_t so their realized P&L reaches live_results
+        // and the equity curve, and so a broker statement has a counterpart (E2-F11).
+        std::vector<ExecutionReport> corp_action_executions;
+
         DEBUG("Previous date used for lookup: " + std::to_string(std::chrono::system_clock::to_time_t(previous_date)));
         DEBUG("Current date: " + std::to_string(std::chrono::system_clock::to_time_t(now)));
         DEBUG("Previous positions loaded: " + std::to_string(previous_positions.size()));
@@ -1315,6 +1320,8 @@ int main(int argc, char* argv[]) {
                           &lifecycle_start_tm);
 
             std::vector<LifecycleAdjustment> lifecycle_log;
+            // Executions synthesised from corporate actions, merged into the day's
+            // executions below so they reach live_results and the equity curve (E2-F11).
 
             // Class 2: re-key positions still held under a superseded ticker.
             auto alias_result = db->get_ticker_aliases();
@@ -1493,6 +1500,53 @@ int main(int argc, char* argv[]) {
                     mutated = true;
                     break;
                 }
+            }
+
+            // A termination closes a real position at a real price, so it is a TRADE and
+            // must be recorded as one. Without an execution row it was invisible twice
+            // over (E2-F11):
+            //
+            //   * live_results is computed from the PnL manager and the day's executions,
+            //     so a corp-action exit's realized P&L had no route into the aggregate.
+            //     The position row said 122.00 and live_results said 0.00 -- rows and
+            //     aggregate disagreeing, the F-D failure shape in a third place, and it
+            //     never reached the equity curve either.
+            //   * A broker statement shows a liquidation or cash-in-lieu event with no
+            //     counterpart in trading.executions, so the two books cannot be reconciled.
+            //
+            // Emitting the execution closes both at once, through the path that already
+            // exists, rather than adding a second private channel into the aggregate.
+            //
+            // exec_id/order_id are DETERMINISTIC (symbol + ex_date, not a clock) so a
+            // replay of the same date regenerates the same ids, delete_stale_executions
+            // matches them, and the re-insert is an overwrite rather than a duplicate.
+            for (const auto& adj : lifecycle_log) {
+                if (adj.outcome != LifecycleOutcome::EXITED_AT_FINAL_CLOSE) continue;
+                if (std::abs(adj.quantity_before) < 1e-9 || !(adj.exit_price > 0.0)) continue;
+
+                ExecutionReport ca_exec;
+                ca_exec.order_id = "CORPACTION_" + adj.symbol + "_" + adj.event_date;
+                ca_exec.exec_id  = "CA_" + adj.symbol + "_" + adj.event_date + "_EXIT";
+                ca_exec.symbol   = adj.symbol;
+                // Closing a long is a SELL; closing a short is a BUY.
+                ca_exec.side = adj.quantity_before > 0.0 ? Side::SELL : Side::BUY;
+                ca_exec.filled_quantity = Quantity(std::abs(adj.quantity_before));
+                ca_exec.fill_price = Price(adj.exit_price);
+                ca_exec.fill_time = now;
+                // A corporate action is not a discretionary trade: the holder pays no
+                // commission and crosses no spread, so every cost component is zero.
+                ca_exec.commissions_fees = Decimal(0.0);
+                ca_exec.implicit_price_impact = Decimal(0.0);
+                ca_exec.slippage_market_impact = Decimal(0.0);
+                ca_exec.total_transaction_costs = Decimal(0.0);
+                ca_exec.is_partial = false;
+
+                corp_action_executions.push_back(ca_exec);
+                INFO("Corp-action exit booked as an execution: " + adj.symbol + " " +
+                     (ca_exec.side == Side::SELL ? "SELL" : "BUY") + " " +
+                     std::to_string(std::abs(adj.quantity_before)) + " @ " +
+                     std::to_string(adj.exit_price) + " (realized " +
+                     std::to_string(adj.realized_delta) + ", zero cost -- corporate action)");
             }
             if (mutated) {
                 std::vector<Position> lifecycle_positions;
@@ -1775,6 +1829,16 @@ int main(int argc, char* argv[]) {
         }
 
         std::vector<ExecutionReport> daily_executions = exec_outcome.executions;
+        // Corporate-action exits are trades too. Appending them here -- before set_executions,
+        // the PnL aggregation and the DB write -- is what gives their realized P&L a route
+        // into live_results and the equity curve, and gives a broker statement something to
+        // reconcile against (E2-F11).
+        if (!corp_action_executions.empty()) {
+            INFO("Merging " + std::to_string(corp_action_executions.size()) +
+                 " corp-action exit execution(s) into the day's executions");
+            daily_executions.insert(daily_executions.end(),
+                                    corp_action_executions.begin(), corp_action_executions.end());
+        }
         INFO("ExecutionManager generated " + std::to_string(daily_executions.size()) +
              " executions");
 

--- a/apps/strategies/live_portfolio.cpp
+++ b/apps/strategies/live_portfolio.cpp
@@ -1935,9 +1935,17 @@ int main(int argc, char* argv[]) {
             int trading_days_count = 1;
             try {
                 // Call PostgreSQL function to calculate trading days
+                // E2-F6: portfolio-scoped (3-arg) form. The 2-arg overload keys on
+                // strategy_id alone with `ORDER BY live_start_date LIMIT 1` and NO portfolio
+                // predicate, so it takes the earliest row across ALL portfolios.
+                // LIVE_TREND_FOLLOWING has a metadata row under both BASE_PORTFOLIO and
+                // CONSERVATIVE_PORTFOLIO; they agree only because both carry
+                // live_start_date = 2025-10-05. Add or edit a BASE row with an earlier date
+                // and the conservative book's annualization changes silently -- no error, no
+                // log line. Definition is versioned in migrations/004.
                 std::string trading_days_query = "SELECT trading.get_trading_days('" +
                                                  combined_strategy_id + "', DATE '" +
-                                                 yesterday_date_ss.str() + "')";
+                                                 yesterday_date_ss.str() + "', '" + portfolio_id + "')";
 
                 INFO("TRADING_DAYS_CALC [Day T-1]: Querying trading days...");
                 INFO("TRADING_DAYS_CALC [Day T-1]: Query: " + trading_days_query);
@@ -2502,9 +2510,17 @@ int main(int argc, char* argv[]) {
             now_date_ss << std::put_time(std::gmtime(&now_time_t_for_query), "%Y-%m-%d");
 
             // Call PostgreSQL function to calculate trading days
+            // E2-F6: portfolio-scoped (3-arg) form. The 2-arg overload keys on
+            // strategy_id alone with `ORDER BY live_start_date LIMIT 1` and NO portfolio
+            // predicate, so it takes the earliest row across ALL portfolios.
+            // LIVE_TREND_FOLLOWING has a metadata row under both BASE_PORTFOLIO and
+            // CONSERVATIVE_PORTFOLIO; they agree only because both carry
+            // live_start_date = 2025-10-05. Add or edit a BASE row with an earlier date
+            // and the conservative book's annualization changes silently -- no error, no
+            // log line. Definition is versioned in migrations/004.
             std::string trading_days_query = "SELECT trading.get_trading_days('" +
                                              combined_strategy_id + "', DATE '" +
-                                             now_date_ss.str() + "')";
+                                             now_date_ss.str() + "', '" + portfolio_id + "')";
 
             INFO("TRADING_DAYS_CALC [Day T]: Querying trading days...");
             INFO("TRADING_DAYS_CALC [Day T]: Query: " + trading_days_query);

--- a/apps/strategies/live_portfolio.cpp
+++ b/apps/strategies/live_portfolio.cpp
@@ -1466,7 +1466,8 @@ int main(int argc, char* argv[]) {
 
                         // Use the delete_stale_executions method with strategy name
                         auto del_res = db->delete_stale_executions(
-                            order_ids_vector, now, strategy_name, "trading.executions");
+                            order_ids_vector, now, strategy_name, portfolio_id,
+                            "trading.executions");
                         if (del_res.is_error()) {
                             WARN("Failed to delete stale executions for strategy " + strategy_name +
                                  ": " + std::string(del_res.error()->what()));

--- a/apps/strategies/live_portfolio_conservative.cpp
+++ b/apps/strategies/live_portfolio_conservative.cpp
@@ -1480,7 +1480,8 @@ int main(int argc, char* argv[]) {
 
                         // Use the delete_stale_executions method with strategy name
                         auto del_res = db->delete_stale_executions(
-                            order_ids_vector, now, strategy_name, "trading.executions");
+                            order_ids_vector, now, strategy_name, portfolio_id,
+                            "trading.executions");
                         if (del_res.is_error()) {
                             WARN("Failed to delete stale executions for strategy " + strategy_name +
                                  ": " + std::string(del_res.error()->what()));

--- a/apps/strategies/live_portfolio_conservative.cpp
+++ b/apps/strategies/live_portfolio_conservative.cpp
@@ -1945,9 +1945,17 @@ int main(int argc, char* argv[]) {
             int trading_days_count = 1;
             try {
                 // Call PostgreSQL function to calculate trading days
+                // E2-F6: portfolio-scoped (3-arg) form. The 2-arg overload keys on
+                // strategy_id alone with `ORDER BY live_start_date LIMIT 1` and NO portfolio
+                // predicate, so it takes the earliest row across ALL portfolios.
+                // LIVE_TREND_FOLLOWING has a metadata row under both BASE_PORTFOLIO and
+                // CONSERVATIVE_PORTFOLIO; they agree only because both carry
+                // live_start_date = 2025-10-05. Add or edit a BASE row with an earlier date
+                // and the conservative book's annualization changes silently -- no error, no
+                // log line. Definition is versioned in migrations/004.
                 std::string trading_days_query = "SELECT trading.get_trading_days('" +
                                                  combined_strategy_id + "', DATE '" +
-                                                 yesterday_date_ss.str() + "')";
+                                                 yesterday_date_ss.str() + "', '" + portfolio_id + "')";
 
                 INFO("TRADING_DAYS_CALC [Day T-1]: Querying trading days...");
                 INFO("TRADING_DAYS_CALC [Day T-1]: Query: " + trading_days_query);
@@ -2520,9 +2528,17 @@ int main(int argc, char* argv[]) {
             now_date_ss << std::put_time(std::gmtime(&now_time_t_for_query), "%Y-%m-%d");
 
             // Call PostgreSQL function to calculate trading days
+            // E2-F6: portfolio-scoped (3-arg) form. The 2-arg overload keys on
+            // strategy_id alone with `ORDER BY live_start_date LIMIT 1` and NO portfolio
+            // predicate, so it takes the earliest row across ALL portfolios.
+            // LIVE_TREND_FOLLOWING has a metadata row under both BASE_PORTFOLIO and
+            // CONSERVATIVE_PORTFOLIO; they agree only because both carry
+            // live_start_date = 2025-10-05. Add or edit a BASE row with an earlier date
+            // and the conservative book's annualization changes silently -- no error, no
+            // log line. Definition is versioned in migrations/004.
             std::string trading_days_query = "SELECT trading.get_trading_days('" +
                                              combined_strategy_id + "', DATE '" +
-                                             now_date_ss.str() + "')";
+                                             now_date_ss.str() + "', '" + portfolio_id + "')";
 
             INFO("TRADING_DAYS_CALC [Day T]: Querying trading days...");
             INFO("TRADING_DAYS_CALC [Day T]: Query: " + trading_days_query);

--- a/apps/test_database_extensions.cpp
+++ b/apps/test_database_extensions.cpp
@@ -66,7 +66,8 @@ int main() {
     std::vector<std::string> order_ids = {"TEST_ORDER_1", "TEST_ORDER_2", "TEST_ORDER_3"};
     auto now = std::chrono::system_clock::now();
 
-    auto delete_result = db->delete_stale_executions(order_ids, now, "trading.executions");
+    auto delete_result = db->delete_stale_executions(order_ids, now, "TEST_STRATEGY",
+                                                     "TEST_PORTFOLIO", "trading.executions");
     if (delete_result.is_error()) {
         std::cout << "  Warning (expected if no matching records): "
                   << delete_result.error()->what() << std::endl;

--- a/include/trade_ngin/backtest/backtest_coordinator.hpp
+++ b/include/trade_ngin/backtest/backtest_coordinator.hpp
@@ -95,6 +95,10 @@ private:
     // CSV exporter for portfolio backtest
     std::unique_ptr<BacktestCSVExporter> csv_exporter_;
     std::unordered_map<std::string, Position> portfolio_previous_positions_;
+    /// E2-F19: the strategy's cumulative realized per (strategy|symbol) at the last bar,
+    /// so a cash-book position row can be written as that bar's realized FLOW -- the same
+    /// definition the live equity runner persists -- rather than the running total.
+    std::unordered_map<std::string, double> last_cumulative_realized_;
 
     // Optional components for portfolio backtest
     std::shared_ptr<RiskManager> risk_manager_;

--- a/include/trade_ngin/backtest/backtest_pnl_manager.hpp
+++ b/include/trade_ngin/backtest/backtest_pnl_manager.hpp
@@ -2,6 +2,7 @@
 
 #include "trade_ngin/live/pnl_manager_base.hpp"
 #include "trade_ngin/core/types.hpp"
+#include "trade_ngin/strategy/types.hpp"  // PnLAccountingMethod (E2-F2)
 #include "trade_ngin/core/logger.hpp"
 #include "trade_ngin/instruments/instrument_registry.hpp"
 #include <memory>
@@ -108,8 +109,61 @@ public:
     };
     
     /**
+     * @brief The unrealized P&L to record on a backtest position row, per the
+     *        strategy's own settlement model. E2-F2.
+     *
+     * REALIZED_ONLY (futures) returns 0.0 -- an identity of the model, not a
+     * convention. Under daily settlement the position is never carried at an
+     * unsettled price, and on a futures row `average_price` IS the prior
+     * settlement close: TrendFollowingStrategy resets it to current_price after
+     * settling (trend_following.cpp:550-556) and get_target_positions() stamps
+     * price_history.back() (:610-624), while the coordinator feeds on_data the
+     * T-1 bars (backtest_coordinator.cpp:547). So
+     * `quantity * (mark - average_price) * point_value` reduces ALGEBRAICALLY to
+     * the realized formula, and writing it into unrealized records the same
+     * settled move in two columns.
+     *
+     * That is exactly what this codebase did until E2-F2: the coordinator gated
+     * realized on the accounting method but left unrealized ungated, and its
+     * inline expression also omitted point_value -- so a futures row carried the
+     * settled move DIVIDED by the contract multiplier. Measured at 2,769 of 3,064
+     * rows on TREND_FOLLOWING (gross magnitude $693,172.27, net -$28,315.21), and
+     * it read as an exact 1/point_value ratio against realized on every symbol:
+     * MYM 2.0 (pv 0.5), MES 0.2 (pv 5), ZN 0.001 (pv 1000), 6A 0.00001 (pv 1e5).
+     * `main` had `unrealized_pnl = Decimal(0.0)` unconditionally; the regression
+     * entered with 76b4ea5d.
+     *
+     * This is the backtest counterpart of LivePnLManager::UnrealizedPolicy
+     * (SETTLED / MARK_TO_MARKET), which fixed the identical defect on the live
+     * side in 5b589ac2 (E2-F3). Live and backtest MUST agree; before this they
+     * did not.
+     *
+     * DO NOT "restore" an ungated unrealized here, and do not drop point_value
+     * from the MIXED branch. If futures ever legitimately needs a non-zero
+     * unrealized, the settlement model has changed and `average_price` must stop
+     * being the prior close first.
+     *
+     * @param method    The strategy's PnL accounting method.
+     * @param quantity  Signed position quantity.
+     * @param average_price Cost basis for MIXED/UNREALIZED_ONLY. Ignored under
+     *                  REALIZED_ONLY. <= 0 means "no basis known" -> 0.0.
+     * @param mark_price Mark to measure against (the day's close).
+     * @param point_value Contract multiplier; 1.0 for equities, applied
+     *                  explicitly rather than assumed.
+     */
+    static double unrealized_for_accounting(PnLAccountingMethod method,
+                                            double quantity,
+                                            double average_price,
+                                            double mark_price,
+                                            double point_value) {
+        if (method == PnLAccountingMethod::REALIZED_ONLY) return 0.0;
+        if (quantity == 0.0 || average_price <= 0.0) return 0.0;
+        return quantity * (mark_price - average_price) * point_value;
+    }
+
+    /**
      * MAIN ENTRY POINT: Calculate daily PnL for all positions
-     * 
+     *
      * This is THE method that should be called to calculate PnL for a given day.
      * It ensures consistent application of:
      * - Date alignment (uses T and T-1 closes correctly)

--- a/include/trade_ngin/core/email_sender.hpp
+++ b/include/trade_ngin/core/email_sender.hpp
@@ -87,7 +87,9 @@ public:
         const std::unordered_map<std::string, Position>& yesterday_positions = {},
         const std::unordered_map<std::string, double>& yesterday_close_prices = {},
         const std::unordered_map<std::string, double>& two_days_ago_close_prices = {},
-        const std::map<std::string, double>& yesterday_daily_metrics = {}
+        const std::map<std::string, double>& yesterday_daily_metrics = {},
+        const std::string& chart_strategy_id = "LIVE_TREND_FOLLOWING",
+        const std::string& chart_portfolio_id = ""
     );
 
     /**

--- a/include/trade_ngin/core/time_utils.hpp
+++ b/include/trade_ngin/core/time_utils.hpp
@@ -86,6 +86,35 @@ inline std::string format_utc_date(std::chrono::system_clock::time_point tp) {
  * timestamp (e.g. SQL INSERT values with second resolution). Same
  * thread-safety guarantees: routes through safe_gmtime.
  */
+/**
+ * E2-F22 -- parse a "YYYY-MM-DD HH:MM:SS[.frac][+00]" string that is KNOWN to be UTC
+ * (a timestamptz read back from a UTC session) into a time_point, without letting
+ * the host timezone in. std::mktime interprets the broken-down time as LOCAL, which on
+ * a New York host shifted every loaded position timestamp +5 h and made each T-1
+ * rewrite migrate the row across midnight after four rewrites. Returns false on a
+ * malformed string.
+ */
+inline bool parse_utc_datetime(const std::string& text,
+                               std::chrono::system_clock::time_point& out) {
+    std::tm tm = {};
+    int year = 0, month = 0, day = 0, hour = 0, minute = 0, second = 0;
+    if (std::sscanf(text.c_str(), "%d-%d-%d %d:%d:%d", &year, &month, &day, &hour, &minute,
+                    &second) != 6) {
+        return false;
+    }
+    tm.tm_year = year - 1900;
+    tm.tm_mon = month - 1;
+    tm.tm_mday = day;
+    tm.tm_hour = hour;
+    tm.tm_min = minute;
+    tm.tm_sec = second;
+    tm.tm_isdst = 0;
+    const time_t t = timegm(&tm);
+    if (t == static_cast<time_t>(-1)) return false;
+    out = std::chrono::system_clock::from_time_t(t);
+    return true;
+}
+
 inline std::string format_utc_datetime(std::chrono::system_clock::time_point tp) {
     auto t = std::chrono::system_clock::to_time_t(tp);
     std::tm tm{};

--- a/include/trade_ngin/data/postgres_database.hpp
+++ b/include/trade_ngin/data/postgres_database.hpp
@@ -434,9 +434,29 @@ public:
      * @param table_name Name of the executions table
      * @return Result indicating success or failure
      */
+    /**
+     * @brief Delete this book's executions for a date so a re-run can re-insert them.
+     *
+     * E2-F4: portfolio_id is REQUIRED and deliberately has no default.
+     *
+     * The predicate used to be (date, strategy_name, order_id) with no portfolio at all,
+     * while trading.executions is keyed (portfolio_id, strategy_id, strategy_name, date,
+     * exec_id). order_id is portfolio-independent -- ExecutionManager builds it as
+     * "DAILY_<symbol>_<date>" (execution_manager.cpp:147) -- and TREND_FOLLOWING is
+     * enabled-live in BOTH the base and conservative books. So a conservative run could
+     * delete BASE_PORTFOLIO's rows for the same symbol and date, and vice versa; the
+     * survivor was whichever book ran last, and the delete leaves no trace of what it took.
+     *
+     * It never fired only because of a SECOND bug that happened to mask it: two call sites
+     * passed table_name into the strategy_name slot, so the predicate matched nothing.
+     * Fixing that alone would have ARMED this one -- the two must move together, which is
+     * why portfolio_id is required rather than defaulted. A default would let a caller be
+     * silently re-armed by omission.
+     */
     virtual Result<void> delete_stale_executions(const std::vector<std::string>& order_ids,
                                                   const Timestamp& date,
                                                   const std::string& strategy_name,
+                                                  const std::string& portfolio_id,
                                                   const std::string& table_name = "trading.executions");
 
     /**

--- a/include/trade_ngin/data/postgres_database.hpp
+++ b/include/trade_ngin/data/postgres_database.hpp
@@ -714,6 +714,38 @@ public:
         const std::string& table_name = "trading.positions");
 
     /**
+     * @brief Latest date this strategy BOUGHT each symbol, on or after `on_or_after`.
+     *
+     * E2-F17 basis provenance. A class-1 corporate action may only restate a cost basis that
+     * was formed BEFORE the ex-date. A fill on run D is priced at close(D-1), so a BUY dated
+     * strictly AFTER the ex-date was struck at a price the market had already adjusted and is
+     * positive evidence that the basis is contaminated.
+     *
+     * A BUY is the only fill that re-forms a long book's cost basis
+     * (base_strategy.cpp on_execution), and this book is long-only -- shorts are refused by the
+     * equity runner -- so BUY side alone is sufficient.
+     *
+     * Symbols with no such BUY are ABSENT from the map. Absence means "no evidence", NEVER
+     * "clean": the caller must resolve it to APPLY, not to skip.
+     *
+     * `on_or_before` is MANDATORY and must be the date of the book being examined (T-1), not
+     * today and never unbounded. On a replay the executions table also holds rows for dates
+     * AFTER the run being processed, so an unbounded query reads the future: it reported
+     * `BUY 2026-07-30` as evidence against a 2026-06-08 ex-date while replaying June, and
+     * skipped a dividend that had to apply.
+     *
+     * @return symbol -> YYYY-MM-DD of the most recent qualifying BUY.
+     */
+    virtual Result<std::unordered_map<std::string, std::string>> get_last_buy_dates(
+        const std::string& strategy_id,
+        const std::string& strategy_name,
+        const std::string& portfolio_id,
+        const std::vector<std::string>& symbols,
+        const std::string& on_or_after,
+        const std::string& on_or_before,
+        const std::string& table_name = "trading.executions");
+
+    /**
      * @brief Raw closes for specific symbols over a date range.
      *
      * Targeted top-up for the corp-action path when a position predates the

--- a/include/trade_ngin/live/corporate_actions_applier.hpp
+++ b/include/trade_ngin/live/corporate_actions_applier.hpp
@@ -54,6 +54,13 @@ struct CorpActionEvent {
     // (ultrareview bug_021). Has NO effect on the actual position quantity
     // (dividends never change qty), nor on splits.
     double qty_at_ex_date{0.0};
+
+    // E2-F17. `qty_at_ex_date == 0` is ambiguous: it means EITHER the book genuinely held
+    // nothing on the ex-date, OR nothing is known about that date (no run on record, a gap in
+    // position history, a legacy caller that never populated the field). Only the first
+    // justifies refusing to apply the event, so the caller must say which it is. False keeps
+    // the historical behaviour -- apply, and warn -- for every caller that does not set it.
+    bool book_state_known_at_ex_date{false};
 };
 
 /**

--- a/include/trade_ngin/live/corporate_actions_applier.hpp
+++ b/include/trade_ngin/live/corporate_actions_applier.hpp
@@ -16,7 +16,12 @@ namespace trade_ngin {
  * Phase 4 plan -- those need basis-cost reallocation logic beyond per-symbol
  * scalar adjustment.
  */
-enum class CorpActionType { SPLIT, ADR_SPLIT, DIVIDEND, UNKNOWN };
+// E2-F13: TERMINATION is a class-3 lifecycle event (delisting / acquisition), not a
+// price-restating class-1 event like SPLIT or DIVIDEND. It is in this enum solely so a
+// termination can be written to trading.corp_action_applied and deduped like any other
+// applied event -- before this, terminations were recorded NOWHERE and left no audit trail.
+// The applier itself never produces one; CorporateActionsLifecycle does.
+enum class CorpActionType { SPLIT, ADR_SPLIT, DIVIDEND, TERMINATION, UNKNOWN };
 
 /**
  * @brief One corporate-action event to apply.

--- a/include/trade_ngin/live/corporate_actions_applier.hpp
+++ b/include/trade_ngin/live/corporate_actions_applier.hpp
@@ -53,14 +53,38 @@ struct CorpActionEvent {
     // ex-date holding even when running a catch-up apply days later
     // (ultrareview bug_021). Has NO effect on the actual position quantity
     // (dividends never change qty), nor on splits.
+    //
+    // E2-F17: this is the DIVIDEND CASH-FLOW figure ONLY. It is deliberately measured at
+    // `ex_date - 1` and is NOT an eligibility signal -- do not gate whether an event applies
+    // on it. Whether the basis may be restated is `basis_provenance` below, which is measured
+    // at end-of-ex_date. Conflating the two dates is exactly how the first attempt at E2-F17
+    // came to skip positions it should have restated.
     double qty_at_ex_date{0.0};
 
-    // E2-F17. `qty_at_ex_date == 0` is ambiguous: it means EITHER the book genuinely held
-    // nothing on the ex-date, OR nothing is known about that date (no run on record, a gap in
-    // position history, a legacy caller that never populated the field). Only the first
-    // justifies refusing to apply the event, so the caller must say which it is. False keeps
-    // the historical behaviour -- apply, and warn -- for every caller that does not set it.
-    bool book_state_known_at_ex_date{false};
+    // E2-F17 (complete). A class-1 event restates a basis into post-event units. That is
+    // correct iff every share now held was acquired at a price the market had NOT yet
+    // adjusted -- i.e. on a run on or before the ex-date, because a fill on run D is priced
+    // at close(D-1).
+    //
+    // NOTE THE DATE. This is the END OF THE EX-DATE, not `ex_date - 1`. `ex_date - 1` is the
+    // cash-eligibility cutoff for a DIVIDEND and belongs to `qty_at_ex_date` above; using it
+    // here skips a position opened ON the ex-date run, whose basis is priced at close(E-1),
+    // is therefore pre-event, and MUST be restated.
+    //
+    // Tri-state on purpose. The predecessor of this field was a bool, which conflated "the
+    // book was observed flat" with "nothing is known", and could only ever justify a skip by
+    // assuming the second meant the first. Dropping a real 25:1 split is far worse than
+    // double-adjusting a basis, so UNKNOWN must APPLY.
+    enum class BasisProvenance {
+        UNKNOWN,                    ///< could not be established -> APPLY and warn. Never skip.
+        FORMED_ON_OR_BEFORE_EX_DATE,///< basis predates the event -> APPLY.
+        FORMED_AFTER_EX_DATE        ///< positive evidence of contamination -> the only skip.
+    };
+
+    BasisProvenance basis_provenance{BasisProvenance::UNKNOWN};
+    /// Human-readable justification, e.g. "BUY 2026-04-17". Printed in the skip warning so the
+    /// decision is auditable from the log alone.
+    std::string basis_provenance_evidence;
 };
 
 /**

--- a/include/trade_ngin/live/corporate_actions_audit_log.hpp
+++ b/include/trade_ngin/live/corporate_actions_audit_log.hpp
@@ -99,6 +99,23 @@ public:
     /**
      * @brief Has this (symbol, ex_date, action) tuple already been applied?
      */
+    /**
+     * @brief The latest ex-date recorded as applied, "" when none.
+     *
+     * E2-F23: a row whose ex-date is on or after the run date cannot have been
+     * written by an earlier session of a forward-only book -- it came from a later
+     * pass (a replay, or a same-day re-run). A run that sees one must refuse rather
+     * than skip the event and finalize the T-1 book in the wrong frame.
+     */
+    std::string latest_applied_ex_date() const {
+        std::string latest;
+        for (const auto& key : applied_) {
+            const std::string& ex = std::get<1>(key);
+            if (ex > latest) latest = ex;
+        }
+        return latest;
+    }
+
     bool is_applied(const std::string& symbol,
                     const std::string& ex_date,
                     CorpActionType action) const;

--- a/include/trade_ngin/live/live_daily_cycle.hpp
+++ b/include/trade_ngin/live/live_daily_cycle.hpp
@@ -316,19 +316,21 @@ public:
     /**
      * @brief Put the LOADED T-1 realized figure back on each finalized T-1 row.
      *
-     * LivePnLManager::finalize_previous_day writes the settlement move
-     * qty x (close(T-1) - close(T-2)) into every finalized row's realized_pnl. Under
-     * SETTLED that is the day's realized. Under MARK_TO_MARKET it is a mark, and
-     * writing it over the trade realized the day's own run recorded is how the
-     * column came to hold price moves; on a weekend it is written three times.
+     * History: LivePnLManager::finalize_previous_day used to write the settlement
+     * move qty x (close(T-1) - close(T-2)) into every finalized row's realized_pnl
+     * regardless of policy. Under SETTLED that is the day's realized; under
+     * MARK_TO_MARKET it is a mark, and writing it over the trade realized the day's
+     * own run recorded is how the column came to hold price moves (three times over
+     * a weekend). Since R-1 (af1bf2c6) the finalizer itself keeps the row's realized
+     * under MARK_TO_MARKET, so this helper is belt and braces on that path.
      *
-     * The row the day-T write produced already holds the correct per-day figure
-     * (seeded from zero, accumulated from that day's fills), so the T-1 rewrite
-     * carries it through unchanged. The finalizer's aggregate fields --
+     * It still matters for one case: select_finalization_book may finalize a symbol
+     * from the RESTATED book (a deferred class-1 event covering T-1, E2-F16), and the
+     * restated entry's realized is not what T-1's own run wrote. Restoring from the
+     * pre-action loaded snapshot keeps the T-1 row's realized equal to the figure
+     * the day itself persisted. The finalizer's aggregate fields --
      * finalized_daily_pnl, position_realized_pnl, finalized_unrealized_pnl -- are
-     * not touched, so yesterday_total_pnl and total_unrealized_pnl stay as they
-     * are. The shared finalizer is not edited: the futures runners persist its rows
-     * directly and must keep the settlement move.
+     * not touched, so yesterday_total_pnl and total_unrealized_pnl stay as they are.
      *
      * A finalized row with no loaded counterpart cannot carry a loaded realized; it
      * gets 0 rather than the mark move.

--- a/include/trade_ngin/live/live_daily_cycle.hpp
+++ b/include/trade_ngin/live/live_daily_cycle.hpp
@@ -221,6 +221,94 @@ public:
         std::sort(unresolved.begin(), unresolved.end());
         return unresolved;
     }
+
+    // -----------------------------------------------------------------------
+    // trading.positions.daily_realized_pnl -- the row-level realized column.
+    //
+    // DEFINITION. The P&L this position realized on this row's date, gross of
+    // transaction costs, under the runner's own accounting model. It is a FLOW:
+    // summing it over dates gives the position's realized P&L over that span.
+    // daily_unrealized_pnl beside it is a LEVEL and must never be summed over
+    // dates.
+    //
+    //   * Settled book (futures, UnrealizedPolicy::SETTLED): the day's settlement
+    //     move qty x (close(D) - close(D-1)) x point_value, written by the T-1
+    //     finalization. The futures runners do not use the helpers below.
+    //   * Cash book (equities, MARK_TO_MARKET): that day's TRADE-realized from
+    //     that date's fills, plus realized locked in by a corporate action on
+    //     that date. Written on the day itself and never revised.
+    //
+    // The helpers below are the equity runner's contract with that definition.
+    // Each is a pure function so the rule can be pinned by a unit test rather
+    // than only by a database replay (E2-F19 / E2-F20).
+    // -----------------------------------------------------------------------
+
+    /** Tolerance below which a quantity or a realized figure counts as zero. */
+    static constexpr double kRowTolerance = 1e-10;
+
+    /**
+     * @brief Whether a position row carries nothing worth persisting.
+     *
+     * Phase 0 stub: today's rule -- a row is dropped on quantity alone.
+     */
+    static bool is_dead_row(const Position& position, double tol = kRowTolerance) {
+        return std::abs(position.quantity.as_double()) <= tol;
+    }
+
+    /**
+     * @brief Partition a loaded book into open rows and closed rows.
+     *
+     * Everything downstream of the load (corporate actions, seeding, execution,
+     * basis resolution, the run-gap guard) is written against a book of held
+     * positions. Closed rows exist only to carry a realized figure on the date
+     * the position closed; they are re-appended to that date's T-1 write set
+     * and go nowhere else.
+     */
+    static void split_open_and_closed(
+        const std::unordered_map<std::string, Position>& loaded,
+        std::unordered_map<std::string, Position>& open,
+        std::unordered_map<std::string, Position>& closed,
+        double tol = kRowTolerance) {
+        open.clear();
+        closed.clear();
+        for (const auto& [symbol, position] : loaded) {
+            if (std::abs(position.quantity.as_double()) <= tol) {
+                closed[symbol] = position;
+            } else {
+                open[symbol] = position;
+            }
+        }
+    }
+
+    /**
+     * @brief Put the LOADED T-1 realized figure back on each finalized T-1 row.
+     *
+     * Phase 0 stub: identity -- the finalizer's output is persisted as-is.
+     */
+    static void restore_loaded_realized(
+        std::vector<Position>& finalized,
+        const std::unordered_map<std::string, Position>& loaded) {
+        (void)finalized;
+        (void)loaded;
+    }
+
+    /**
+     * @brief Give a row to a symbol the strategy realized P&L on that has no
+     *        entry in the day-T book.
+     *
+     * Phase 0 stub: no-op.
+     */
+    static std::vector<std::string> add_rowless_exits(
+        std::unordered_map<std::string, Position>& positions,
+        const std::unordered_map<std::string, Position>& strategy_positions,
+        const Timestamp& now,
+        double tol = kRowTolerance) {
+        (void)positions;
+        (void)strategy_positions;
+        (void)now;
+        (void)tol;
+        return {};
+    }
 };
 
 }  // namespace trade_ngin

--- a/include/trade_ngin/live/live_daily_cycle.hpp
+++ b/include/trade_ngin/live/live_daily_cycle.hpp
@@ -56,7 +56,30 @@ public:
         BaseStrategy& strategy,
         const std::unordered_map<std::string, Position>& previous_positions,
         const std::vector<Bar>& bars) {
-        auto seeded = strategy.seed_positions(previous_positions);
+        // E2-F19 / E2-F20: seed quantity, basis and mark -- never yesterday's realized.
+        //
+        // BaseStrategy::seed_positions is a wholesale copy and on_execution() adds to
+        // whatever it finds, so a seeded realized_pnl made every persisted day-T row
+        // "yesterday's row + today's fills": a running total under a column named
+        // daily. Worse, on a Monday yesterday's row was Friday's, already rewritten by
+        // the Saturday and Sunday finalizations with Friday's MARK MOVE, so a price
+        // move entered a column that is supposed to hold trades (measured: META
+        // 2026-08-04 = 73.35 Friday mark + 31.31 Mon trade + 15.93 Tue trade).
+        //
+        // Zeroing it here makes positions_[sym].realized_pnl mean "realized by this
+        // symbol in this process", i.e. today. metrics_.realized_pnl -- the aggregate
+        // live_results is built from -- was never seeded and does not change.
+        //
+        // unrealized_pnl stays seeded on purpose: update_metrics() sums it into the
+        // drawdown gate, so zeroing it would move a risk limit, not a report.
+        //
+        // Done in the caller rather than in seed_positions(), which the futures
+        // runners call directly: this header is not in their translation units.
+        std::unordered_map<std::string, Position> seed_book = previous_positions;
+        for (auto& [symbol, position] : seed_book) {
+            position.realized_pnl = Decimal(0.0);
+        }
+        auto seeded = strategy.seed_positions(seed_book);
         if (seeded.is_error()) return seeded;
         return strategy.on_data(bars);
     }
@@ -249,10 +272,20 @@ public:
     /**
      * @brief Whether a position row carries nothing worth persisting.
      *
-     * Phase 0 stub: today's rule -- a row is dropped on quantity alone.
+     * A row is dead only when it has neither quantity nor realized P&L. The old rule
+     * dropped on quantity alone, which is right for futures -- an exit there realizes
+     * exactly zero, because average_price is reset to close(T-1) daily and the fill
+     * strikes at close(T-1) -- and wrong for equities, where average_price is a true
+     * cost basis and the exit realizes the whole accumulated gain. Measured
+     * 2026-04-15: TMUS sold out for -402.65, live_results carried it, the positions
+     * table did not (E2-F19 route 3).
+     *
+     * A closed symbol carries realized on the close day only and never has a row
+     * again, so this keeps one row per close event, not one per flat day.
      */
     static bool is_dead_row(const Position& position, double tol = kRowTolerance) {
-        return std::abs(position.quantity.as_double()) <= tol;
+        return std::abs(position.quantity.as_double()) <= tol &&
+               std::abs(position.realized_pnl.as_double()) <= tol;
     }
 
     /**
@@ -283,31 +316,111 @@ public:
     /**
      * @brief Put the LOADED T-1 realized figure back on each finalized T-1 row.
      *
-     * Phase 0 stub: identity -- the finalizer's output is persisted as-is.
+     * LivePnLManager::finalize_previous_day writes the settlement move
+     * qty x (close(T-1) - close(T-2)) into every finalized row's realized_pnl. Under
+     * SETTLED that is the day's realized. Under MARK_TO_MARKET it is a mark, and
+     * writing it over the trade realized the day's own run recorded is how the
+     * column came to hold price moves; on a weekend it is written three times.
+     *
+     * The row the day-T write produced already holds the correct per-day figure
+     * (seeded from zero, accumulated from that day's fills), so the T-1 rewrite
+     * carries it through unchanged. The finalizer's aggregate fields --
+     * finalized_daily_pnl, position_realized_pnl, finalized_unrealized_pnl -- are
+     * not touched, so yesterday_total_pnl and total_unrealized_pnl stay as they
+     * are. The shared finalizer is not edited: the futures runners persist its rows
+     * directly and must keep the settlement move.
+     *
+     * A finalized row with no loaded counterpart cannot carry a loaded realized; it
+     * gets 0 rather than the mark move.
      */
     static void restore_loaded_realized(
         std::vector<Position>& finalized,
         const std::unordered_map<std::string, Position>& loaded) {
-        (void)finalized;
-        (void)loaded;
+        for (auto& position : finalized) {
+            auto it = loaded.find(position.symbol);
+            position.realized_pnl =
+                it != loaded.end() ? it->second.realized_pnl : Decimal(0.0);
+        }
     }
 
     /**
      * @brief Give a row to a symbol the strategy realized P&L on that has no
      *        entry in the day-T book.
      *
-     * Phase 0 stub: no-op.
+     * The day-T book is the strategy's target map, which covers the configured
+     * universe. A held symbol that has LEFT the universe -- contra-merged, renamed
+     * to a name not in config, or simply de-configured -- is still closed out by
+     * ExecutionManager::generate_daily_executions and still booked by
+     * on_execution(), so its realized reaches the aggregate; but nothing iterates
+     * it into a row, so the rows no longer sum to the aggregate. This is the case
+     * the in-run L5 assertion would otherwise trip on.
+     *
+     * @return the symbols given a row, sorted, for the caller to log.
      */
     static std::vector<std::string> add_rowless_exits(
         std::unordered_map<std::string, Position>& positions,
         const std::unordered_map<std::string, Position>& strategy_positions,
         const Timestamp& now,
         double tol = kRowTolerance) {
-        (void)positions;
-        (void)strategy_positions;
-        (void)now;
-        (void)tol;
-        return {};
+        std::vector<std::string> added;
+        for (const auto& [symbol, held] : strategy_positions) {
+            if (positions.find(symbol) != positions.end()) continue;
+            if (std::abs(held.realized_pnl.as_double()) <= tol) continue;
+            Position closed;
+            closed.symbol = symbol;
+            closed.quantity = Quantity(0.0);
+            closed.average_price = Decimal(0.0);  // no basis: the position no longer exists
+            closed.unrealized_pnl = Decimal(0.0);
+            closed.realized_pnl = held.realized_pnl;
+            closed.last_update = now;
+            positions[symbol] = closed;
+            added.push_back(symbol);
+        }
+        std::sort(added.begin(), added.end());
+        return added;
+    }
+
+    /**
+     * @brief The book the Day T-1 finalization should be run from, per symbol.
+     *
+     * T-1 is finalized as the book actually stood on T-1, i.e. from the snapshot
+     * taken before any corporate action touched it (8a1a96ef). The exception is a
+     * DEFERRED class-1 event catching up: when its ex-date is on or before T-1 the
+     * T-1 close is already post-event, so the pre-action basis would be a frame
+     * behind the price (E2-F16); that symbol is finalized from the restated book.
+     *
+     * The restated book is the one taken AFTER the class-1 rescale and BEFORE the
+     * lifecycle handlers. Terminations set quantity to 0 and add a day-T cash flow
+     * to realized_pnl; renames and contra-merges re-key and merge entries. None of
+     * that happened on T-1, and reading the post-lifecycle map here would finalize
+     * a symbol that split and terminated in the same run as a qty-0 row with a
+     * day-T flow on the T-1 date (E2-F19 gap G4).
+     *
+     * @param restated_out symbols taken from the restated book, for the caller's log.
+     */
+    static std::vector<Position> select_finalization_book(
+        const std::unordered_map<std::string, Position>& pre_action,
+        const std::unordered_map<std::string, Position>& post_class1,
+        const std::unordered_map<std::string, std::string>& applied_class1_ex_date,
+        const std::string& t1_date,
+        std::vector<std::string>* restated_out = nullptr) {
+        std::vector<Position> book;
+        book.reserve(pre_action.size());
+        for (const auto& [symbol, position] : pre_action) {
+            auto ex = applied_class1_ex_date.find(symbol);
+            const bool event_covers_t1 =
+                ex != applied_class1_ex_date.end() && ex->second <= t1_date;
+            if (event_covers_t1) {
+                auto restated = post_class1.find(symbol);
+                if (restated != post_class1.end()) {
+                    book.push_back(restated->second);
+                    if (restated_out) restated_out->push_back(symbol);
+                    continue;
+                }
+            }
+            book.push_back(position);
+        }
+        return book;
     }
 };
 

--- a/include/trade_ngin/live/live_pnl_manager.hpp
+++ b/include/trade_ngin/live/live_pnl_manager.hpp
@@ -139,6 +139,23 @@ public:
         double finalized_portfolio_value = 0.0;
         std::unordered_map<std::string, double> position_realized_pnl;
         std::vector<Position> finalized_positions;
+
+        /**
+         * @brief Sum of the finalized rows' unrealized P&L -- the Day T-1 book marked at
+         *        close(T-1). E2-F1.
+         *
+         * This is the aggregate counterpart of the per-row unrealized written below, so
+         * `live_results.total_unrealized_pnl[T-1] == SUM(positions.daily_unrealized_pnl[T-1])`
+         * holds by construction rather than by two code paths happening to agree. Before
+         * this the aggregate was a DAY-T snapshot priced at close(T-2) that finalization
+         * never revisited, so the two differed by exactly that day's P&L (E2-F13).
+         *
+         * Accumulated ONLY under MARK_TO_MARKET. Under SETTLED every finalized row's
+         * unrealized is 0 by the settlement identity, so this is exactly 0.0 for futures --
+         * by construction, not by measurement.
+         */
+        double finalized_unrealized_pnl = 0.0;
+
         bool success = false;
     };
 

--- a/include/trade_ngin/live/live_pnl_manager.hpp
+++ b/include/trade_ngin/live/live_pnl_manager.hpp
@@ -36,6 +36,29 @@ public:
         : PnLManagerBase(initial_capital), registry_(registry) {}
 
     /**
+     * @brief How Day T-1 finalization records unrealized P&L.
+     *
+     * SETTLED (the default) -- futures. Under the T-1 lag model the runner enters a
+     * position at close(T-1) and the next day's run settles it at close(T), booking the
+     * entire move as realized. The position is never carried at an unsettled price, so
+     * there is no unrealized component: 0 is an identity of the model, not a convention.
+     *
+     * This matters because `average_price` on a futures row IS the prior settlement
+     * close, i.e. exactly the `t2_close` the finalizer already uses for realized. So
+     * `quantity * (t1_close - average_price) * point_value` is algebraically the realized
+     * formula, and writing it into unrealized records the same settlement move in two
+     * columns -- E2-F3, measured at up to -12,586.69 in a day, and a violation of the
+     * row-sums-to-aggregate invariant since live_results correctly reports 0.
+     *
+     * MARK_TO_MARKET -- equities. There `average_price` is a true weighted cost basis, so
+     * the same expression is the genuine unrealized P&L.
+     *
+     * The default is SETTLED so that a caller which says nothing keeps the futures
+     * behaviour; both futures runners pass no policy argument.
+     */
+    enum class UnrealizedPolicy { SETTLED, MARK_TO_MARKET };
+
+    /**
      * @brief Unrealized P&L of one position against its own cost basis.
      *
      * The single rule for "what is this position worth versus what it cost", shared by
@@ -129,7 +152,8 @@ public:
         const std::unordered_map<std::string, double>& t1_close_prices,
         const std::unordered_map<std::string, double>& t2_close_prices,
         double previous_portfolio_value,
-        double commissions = 0.0);
+        double commissions = 0.0,
+        UnrealizedPolicy unrealized_policy = UnrealizedPolicy::SETTLED);
 
     /**
      * Calculate PnL for current day positions

--- a/include/trade_ngin/live/live_price_manager.hpp
+++ b/include/trade_ngin/live/live_price_manager.hpp
@@ -4,6 +4,7 @@
 #include "trade_ngin/data/postgres_database.hpp"
 #include "trade_ngin/core/types.hpp"
 #include <memory>
+#include <optional>  // std::optional t1_date (E2-F14)
 
 namespace trade_ngin {
 
@@ -60,10 +61,55 @@ public:
      * Used during live trading to update latest prices
      * @param bars Vector of bars to process
      * @param reference_date The date to use as "today" for T-1 calculation (defaults to system time if not provided)
+     * @param t1_date OPTIONAL explicit Day T-1 trading date. See below -- E2-F14.
+     *
+     * @par Why t1_date exists
+     * Omitted (the default), T-1 is `reference_date - 24h` and only the LAST bar is
+     * considered. That is correct for FUTURES, whose runners resolve the position book
+     * they are finalizing with the SAME arithmetic --
+     * `live_portfolio.cpp:1047` and `live_portfolio_conservative.cpp:1061` both do
+     * `previous_date = now - std::chrono::hours(24)`. Book and prices therefore always
+     * name the same calendar day by construction, each day is finalized exactly once, and
+     * when that day has no bar (a Saturday, or an ag symbol with no Sunday session) zero
+     * genuinely is the right answer. Both futures runners pass no t1_date and MUST keep
+     * getting byte-identical behaviour.
+     *
+     * EQUITIES do not have that property. The equity runner resolves its book with
+     * `holiday_checker.find_previous_trading_day()` (live_equity_mean_reversion.cpp:643),
+     * which is calendar-aware and skips weekends and holidays. On a Sunday or Monday run
+     * that returns FRIDAY, while `reference_date - 24h` asks for Saturday or Sunday and
+     * `equities_data.ohlcv_1d` has no weekend rows at all. The result is that an
+     * already-finalized Friday is re-finalized against an EMPTY price map: every position
+     * takes the `t1_close_prices.end()` branch in LivePnLManager::finalize_previous_day
+     * and is written back with 0/0. `live_results` survives because the
+     * `yesterday_total_pnl != 0.0` gate blocks its UPDATE, but `store_positions` runs
+     * ~480 lines earlier, outside that gate, and its DELETE-then-INSERT is keyed on the
+     * T-1 date -- so Friday's finalized rows are replaced with zeros.
+     *
+     * Measured 2026-09-01 on a weekend-inclusive replay: Sat 08-01 finalized Friday at
+     * $864.759444, then Sun 08-02 and Mon 08-03 each re-finalized the same Friday and
+     * zeroed its three position rows. L5 (rows sum to aggregate) residual was exactly
+     * -864.7594 on 07-31 and -14.6574 on 07-24, and 0.0000 on every other finalized day.
+     * A Monday holiday makes it fire on four consecutive runs.
+     *
+     * @par Two fixes that look right and are NOT
+     * - Adding a T-1 FALLBACK here (use the most recent bar at or before the expected
+     *   date) would DOUBLE-COUNT FUTURES. For an ag future on a Monday run with no Sunday
+     *   bar, T-1 would fall back to Friday and T-2 to Thursday, booking (Fri-Thu) onto the
+     *   Sunday row -- a move the Saturday run already booked onto Friday's row.
+     * - Making this function calendar-aware would also break futures: the futures calendar
+     *   is not the equity calendar. Futures trade Sunday evening; equities do not.
+     *
+     * The only safe shape is for the CALLER to pass the same resolved date it used for the
+     * book, so the two lookups cannot disagree. When t1_date is supplied the bar is
+     * SEARCHED for by date rather than assumed to be `back()` -- on a live run the vendor
+     * may already have posted today's bar, and a back()-only test would then reject a
+     * perfectly good Friday -- and T-2 becomes the bar immediately preceding it.
      */
     Result<void> update_from_bars(
         const std::vector<Bar>& bars,
-        const Timestamp& reference_date = std::chrono::system_clock::now());
+        const Timestamp& reference_date = std::chrono::system_clock::now(),
+        std::optional<Timestamp> t1_date = std::nullopt);
 
     /**
      * Get settlement/close price for a symbol on a date

--- a/include/trade_ngin/portfolio/portfolio_manager.hpp
+++ b/include/trade_ngin/portfolio/portfolio_manager.hpp
@@ -214,6 +214,31 @@ public:
                                          double close_price, double prev_close_price);
 
     /**
+     * @brief Register ADV-tiered equity cost configs on THIS manager's cost model. E2-C9.
+     *
+     * PortfolioManager owns its own TransactionCostManager, separate from the one
+     * BacktestCoordinator holds, and the two cost different things:
+     *
+     *   - This one prices the executions PortfolioManager generates, which are what reach
+     *     backtest.executions AND the equity curve (via calculate_period_transaction_costs).
+     *   - The coordinator's prices the re-costed copies that feed the reported METRICS.
+     *
+     * Only the coordinator's was ever registered (bt_equity_mean_reversion.cpp calls
+     * register_equity_costs_from_bars on it), so the stored executions and the equity curve
+     * were priced from the static hardcoded configs while the metrics used ADV-tiered ones --
+     * two different cost bases inside a single backtest run. It stayed invisible because the
+     * equity universe is exactly the eight symbols initialize_default_configs() hardcodes, so
+     * both managers at least had EQUITY configs; only the tier parameters differed.
+     *
+     * Register both, or they disagree. Futures is unaffected: futures roots are pre-registered
+     * in initialize_default_configs() and this is only called from the equity apps.
+     */
+    int register_equity_cost_configs(
+        const std::vector<std::string>& symbols,
+        const std::unordered_map<std::string, std::vector<Bar>>& bars_by_symbol,
+        int adv_lookback_days = 20);
+
+    /**
      * @brief Get all strategies managed by this portfolio
      * @return Vector of strategy interfaces
      */

--- a/include/trade_ngin/portfolio/portfolio_manager.hpp
+++ b/include/trade_ngin/portfolio/portfolio_manager.hpp
@@ -36,6 +36,13 @@ struct PortfolioConfig : public ConfigBase {
         0.0};  // Minimum allocation to any strategy (keep as double - it's a ratio)
     bool use_optimization{false};     // Whether to use position optimization
     bool use_risk_management{false};  // Whether to use risk management
+    // Whether a fractional target quantity is a legitimate end state for this
+    // portfolio. Futures trade whole contracts and leave this false, so the
+    // optimizer/risk loop keeps iterating until positions are integral, exactly
+    // as it always has. Equities with fractional shares enabled set it true:
+    // there is nothing to converge to, and re-entering the loop would re-apply
+    // the risk scale to an already-scaled book (see E2-F1).
+    bool allow_fractional_positions{false};
     DynamicOptConfig opt_config;      // Optimization configuration
     RiskConfig risk_config;           // Risk management configuration
 
@@ -61,6 +68,7 @@ struct PortfolioConfig : public ConfigBase {
         j["min_strategy_allocation"] = min_strategy_allocation;
         j["use_optimization"] = use_optimization;
         j["use_risk_management"] = use_risk_management;
+        j["allow_fractional_positions"] = allow_fractional_positions;
         j["opt_config"] = opt_config.to_json();
         j["risk_config"] = risk_config.to_json();
         j["version"] = version;
@@ -83,6 +91,9 @@ struct PortfolioConfig : public ConfigBase {
         }
         if (j.contains("use_risk_management")) {
             use_risk_management = j.at("use_risk_management").get<bool>();
+        }
+        if (j.contains("allow_fractional_positions")) {
+            allow_fractional_positions = j.at("allow_fractional_positions").get<bool>();
         }
         if (j.contains("opt_config"))
             opt_config.from_json(j.at("opt_config"));

--- a/include/trade_ngin/transaction_cost/asset_cost_config.hpp
+++ b/include/trade_ngin/transaction_cost/asset_cost_config.hpp
@@ -49,7 +49,26 @@ struct AssetCostConfig {
     double max_commission_per_order = 1e9;  // effectively no cap by default
 
     // Percentage-based commission cap (-1.0 = use flat max_commission_per_order)
-    // IBKR Tiered: 0.5% of trade value; IBKR Fixed: 1.0% of trade value
+    //
+    // E2-C1/C2 -- THE EQUITY SCHEDULE IS IBKR PRO **FIXED**. Do not mix the two tiers.
+    //
+    //   Fixed:  $0.005/share, minimum $1.00/order, maximum **1% of trade value**,
+    //           and ALL-INCLUSIVE of exchange, clearing and regulatory fees.
+    //   Tiered: $0.0005-$0.0035/share (volume-banded), minimum $0.35/order, and fees are
+    //           PASSED THROUGH rather than included.
+    //
+    // Every equity config here sets commission_per_unit = 0.005 and
+    // min_commission_per_order = 1.00 -- both Fixed. The cap was previously 0.005 (0.5%),
+    // which is Tiered's, giving a schedule that took the worse half of each tier. It is now
+    // 0.01, and apply_regulatory_fees is false because Fixed already contains those fees:
+    // charging them separately double-charges.
+    //
+    // The cap is applied AFTER the floor in TransactionCostManager::calculate_costs -- see
+    // the comment there. Reversing that order makes this field dead for any stock above
+    // $0.50, which is how it went unnoticed.
+    //
+    // Switching to Tiered is a three-field change (commission_per_unit -> the tier rate,
+    // min_commission_per_order -> 0.35, apply_regulatory_fees -> true), not a one-field one.
     double max_commission_pct = -1.0;
 
     // Regulatory fees (equity sell-side only)

--- a/migrations/004_get_trading_days_portfolio_scope.sql
+++ b/migrations/004_get_trading_days_portfolio_scope.sql
@@ -1,0 +1,134 @@
+-- 004_get_trading_days_portfolio_scope.sql
+--
+-- Bring trading.get_trading_days() under version control, and repoint the futures runners at
+-- the portfolio-scoped overload (E2-F6 / B5).
+--
+-- WHY THIS MIGRATION EXISTS AT ALL
+--
+-- Both overloads were created by hand against the live server and have never existed in the
+-- repository. `grep -rl get_trading_days migrations/ scripts/ docs/migrations/` returns
+-- nothing. The 3-arg scoped form was added during the B4/B6 work the same way.
+--
+-- That matters because the failure mode when the function is absent is SILENT. The runners
+-- initialise `trading_days_count = 1` and only overwrite it if the query succeeds
+-- (live_portfolio_conservative.cpp, live_portfolio.cpp, live_equity_mean_reversion.cpp). A
+-- missing function makes execute_query error, the branch is skipped, the count stays at 1,
+-- nothing throws and the run exits 0 -- poisoning five stored columns:
+-- total_annualized_return, sharpe_ratio, sortino_ratio, total_days and win_rate (which
+-- becomes winning_days * 100, roughly 9000%).
+--
+-- So a DB rebuild, restore, or fresh environment would silently corrupt reported futures
+-- performance. This migration makes the definitions travel with the code.
+--
+-- BOTH BODIES ARE VERBATIM COPIES of what is running on the live server, taken with
+-- pg_get_functiondef() on 2026-09-01 -- not reconstructions. CREATE OR REPLACE only; nothing
+-- is dropped, and the 2-arg overload is deliberately retained for compatibility.
+--
+-- EXPECTED EFFECT ON NUMBERS: NONE, today. Both LIVE_TREND_FOLLOWING metadata rows carry the
+-- same live_start_date (2025-10-05), so scoped and unscoped agree at 211 trading days. That
+-- falsifiable zero IS the test: if any futures annualized figure moves after the runners are
+-- repointed, the coincidence assumption was wrong and it must be investigated before
+-- proceeding.
+--
+-- The latent risk this closes: the unscoped lookup is `ORDER BY live_start_date LIMIT 1` with
+-- no portfolio predicate, so it takes the EARLIEST row across all portfolios. The moment a
+-- BASE_PORTFOLIO row is added or edited with an earlier date, the conservative book's
+-- annualization changes with no error and no log line.
+
+BEGIN;
+
+-- ---------------------------------------------------------------------------
+-- 2-arg form: ORIGINAL, unscoped. Retained for compatibility; unused once the
+-- futures runners are repointed. Do not delete -- external callers may exist.
+-- ---------------------------------------------------------------------------
+CREATE OR REPLACE FUNCTION trading.get_trading_days(
+    p_strategy_id character varying,
+    p_target_date date)
+ RETURNS integer
+ LANGUAGE plpgsql
+AS $function$
+DECLARE
+    v_start_date DATE;
+    v_trading_days INTEGER;
+BEGIN
+    SELECT live_start_date INTO v_start_date
+    FROM trading.strategy_trading_days_metadata
+    WHERE strategy_id = p_strategy_id
+    ORDER BY live_start_date
+    LIMIT 1;
+
+    IF v_start_date IS NULL THEN
+        SELECT MIN(DATE(date)) INTO v_start_date
+        FROM trading.live_results
+        WHERE strategy_id = p_strategy_id;
+    END IF;
+
+    IF v_start_date IS NULL THEN
+        RETURN 1;
+    END IF;
+
+    v_trading_days := (p_target_date - v_start_date) + 1;
+    RETURN GREATEST(1, v_trading_days);
+END;
+$function$;
+
+-- ---------------------------------------------------------------------------
+-- 3-arg form: portfolio-scoped. This is what every runner should call.
+--
+-- Note the fail-safe on a missing metadata row: it does NOT fall back to the
+-- unscoped lookup. It tries the portfolio-scoped live_results fallback and, if
+-- that is also empty, returns 1. A strategy moved onto a new portfolio therefore
+-- needs its strategy_trading_days_metadata row seeded BEFORE its first run, or
+-- annualization anchors to nothing.
+-- ---------------------------------------------------------------------------
+CREATE OR REPLACE FUNCTION trading.get_trading_days(
+    p_strategy_id character varying,
+    p_target_date date,
+    p_portfolio_id character varying)
+ RETURNS integer
+ LANGUAGE plpgsql
+AS $function$
+DECLARE
+    v_start_date DATE;
+    v_trading_days INTEGER;
+BEGIN
+    -- Scoped by portfolio. The 2-arg form keys on strategy_id alone, which is ambiguous the
+    -- moment one strategy_id runs under two portfolios (LIVE_TREND_FOLLOWING has a row for
+    -- BASE_PORTFOLIO and one for CONSERVATIVE_PORTFOLIO), and its live_results fallback can
+    -- anchor to a different portfolio's history entirely -- which is how the equity book
+    -- came to report 356 days against a 10-day series (E2/B4).
+    SELECT live_start_date INTO v_start_date
+    FROM trading.strategy_trading_days_metadata
+    WHERE strategy_id = p_strategy_id
+      AND portfolio_id = p_portfolio_id
+    ORDER BY live_start_date
+    LIMIT 1;
+
+    IF v_start_date IS NULL THEN
+        SELECT MIN(DATE(date)) INTO v_start_date
+        FROM trading.live_results
+        WHERE strategy_id = p_strategy_id
+          AND portfolio_id = p_portfolio_id;
+    END IF;
+
+    IF v_start_date IS NULL THEN
+        RETURN 1;
+    END IF;
+
+    v_trading_days := (p_target_date - v_start_date) + 1;
+    RETURN GREATEST(1, v_trading_days);
+END;
+$function$;
+
+COMMIT;
+
+-- ---------------------------------------------------------------------------
+-- VERIFICATION -- run after applying, before repointing any runner.
+-- Expect 211 / 211 / 211 for LIVE_TREND_FOLLOWING at 2026-05-03. Any other
+-- result means the metadata rows have changed and the no-movement prediction
+-- for the code repoint no longer holds.
+--
+--   SELECT trading.get_trading_days('LIVE_TREND_FOLLOWING', DATE '2026-05-03')                            AS unscoped,
+--          trading.get_trading_days('LIVE_TREND_FOLLOWING', DATE '2026-05-03', 'CONSERVATIVE_PORTFOLIO')  AS scoped_cons,
+--          trading.get_trading_days('LIVE_TREND_FOLLOWING', DATE '2026-05-03', 'BASE_PORTFOLIO')          AS scoped_base;
+-- ---------------------------------------------------------------------------

--- a/migrations/004_get_trading_days_portfolio_scope_rollback.sql
+++ b/migrations/004_get_trading_days_portfolio_scope_rollback.sql
@@ -1,0 +1,39 @@
+-- 004_get_trading_days_portfolio_scope_rollback.sql
+--
+-- Rollback for 004. Restores trading.get_trading_days() to the 2-arg form alone.
+--
+-- READ THIS BEFORE RUNNING IT.
+--
+-- Dropping the 3-arg overload while any runner still calls it does NOT produce an error the
+-- operator will notice. The runners initialise `trading_days_count = 1` and only overwrite it
+-- when the query succeeds, so a missing function leaves the count at 1 and the run exits 0
+-- with five corrupted columns: total_annualized_return, sharpe_ratio, sortino_ratio,
+-- total_days, and win_rate (which becomes winning_days * 100, roughly 9000%).
+--
+-- So the order matters and is the reverse of the forward migration:
+--
+--   1. Revert the CODE first -- point every runner back at the 2-arg call.
+--   2. Rebuild and confirm no source calls the 3-arg form:
+--        grep -rn "get_trading_days" apps/ src/ | grep -c "portfolio_id"     -> expect 0
+--   3. Only then run this file.
+--
+-- The equity runner (live_equity_mean_reversion.cpp) has called the 3-arg form since
+-- 232b619e and depends on it for correct annualization: unscoped, LIVE_EQUITY_MEAN_REVERSION
+-- anchors to a stale 2025-08-15 BASE_PORTFOLIO row and reports 356 trading days against a
+-- 10-day series -- a 36x understatement of annualized return (E2/B4). Rolling back the
+-- function without also reverting the equity runner reintroduces that defect.
+
+BEGIN;
+
+DROP FUNCTION IF EXISTS trading.get_trading_days(character varying, date, character varying);
+
+-- The 2-arg form is left exactly as it is. It was never modified by 004 -- that migration
+-- only brought its existing definition under version control -- so there is nothing to
+-- restore here.
+
+COMMIT;
+
+-- Verify the 2-arg form still answers and the 3-arg form is gone:
+--   SELECT trading.get_trading_days('LIVE_TREND_FOLLOWING', DATE '2026-05-03');   -- expect 211
+--   SELECT count(*) FROM pg_proc p JOIN pg_namespace n ON n.oid = p.pronamespace
+--    WHERE n.nspname = 'trading' AND p.proname = 'get_trading_days';             -- expect 1

--- a/src/backtest/backtest_coordinator.cpp
+++ b/src/backtest/backtest_coordinator.cpp
@@ -658,9 +658,36 @@ Result<void> BacktestCoordinator::process_portfolio_day(
         // written by on_execution -- coordinator must NOT stamp realized_pnl
         // here for equities).
         std::unordered_map<std::string, PnLAccountingMethod> pnl_method_by_strategy;
+        // E2-F8: and a lookup of each strategy's OWN fill-maintained holdings, which is
+        // where a real cost basis lives.
+        //
+        // The positions this loop iterates come from get_strategy_positions() ==
+        // info.current_positions == the TARGET positions the strategy produced, and
+        // MeanReversionStrategy::get_target_positions() sets
+        // `pos.average_price = inst_data.current_price` (mean_reversion.cpp:214) -- a MARK,
+        // not a basis. Measured: the mark implied by day D's stored unrealized equals day
+        // D+1's stored average_price on ~87% of consecutive rows, i.e. the column was a
+        // one-day mark change rather than a position-lifetime unrealized.
+        //
+        // BaseStrategy::on_execution() is the sole legitimate writer of a volume-weighted
+        // basis (base_strategy.cpp:216-252) and keeps it in positions_, which
+        // get_target_positions() deliberately does NOT read. on_execution has already run
+        // for this bar by the time we get here (executions are applied ~40 lines above), so
+        // positions_ carries the post-fill basis.
+        //
+        // This is the backtest half of the fix documented in docs/AVERAGE_PRICE_LIFECYCLE.md
+        // -- the live path closes the same gap in LiveDailyCycle::resolve_and_apply_basis
+        // (its "step 8"), and the backtest never had an equivalent.
+        //
+        // Futures are unaffected: TrendFollowingStrategy::on_execution only bumps a counter
+        // and never populates positions_, so the lookup misses and the basis is untouched --
+        // and under REALIZED_ONLY the basis is not consulted at all.
+        std::unordered_map<std::string, const std::unordered_map<std::string, Position>*>
+            fill_positions_by_strategy;
         for (const auto& s : portfolio->get_strategies()) {
             if (auto bs = std::dynamic_pointer_cast<BaseStrategy>(s)) {
                 pnl_method_by_strategy[bs->get_metadata().id] = bs->get_pnl_accounting().method;
+                fill_positions_by_strategy[bs->get_metadata().id] = &bs->get_positions();
             }
         }
 
@@ -708,6 +735,35 @@ Result<void> BacktestCoordinator::process_portfolio_day(
                     if (method == PnLAccountingMethod::REALIZED_ONLY) {
                         updated_pos.realized_pnl = Decimal(pnl_result.daily_pnl);
                     }
+                    // E2-F8: prefer the strategy's fill-maintained basis over the target
+                    // position's average_price, which for mean reversion is the day's close
+                    // (a mark) rather than what the position cost. A basis of 0 means "no
+                    // basis known" and is left as such -- it must never be replaced by a
+                    // mark, which is the substitution this fix exists to remove.
+                    double cost_basis = static_cast<double>(pos.average_price);
+                    if (method != PnLAccountingMethod::REALIZED_ONLY) {
+                        auto fp_it = fill_positions_by_strategy.find(strategy_id);
+                        if (fp_it != fill_positions_by_strategy.end() && fp_it->second) {
+                            auto held = fp_it->second->find(symbol);
+                            if (held != fp_it->second->end()) {
+                                cost_basis = static_cast<double>(held->second.average_price);
+                            }
+                        }
+                        // Keep the stored row self-consistent: a reader recomputing
+                        // qty * (close - average_price) from backtest.final_positions must
+                        // get the unrealized_pnl we wrote. Leaving average_price as a mark
+                        // while measuring unrealized against a basis is what made the two
+                        // disagree.
+                        //
+                        // Deliberately gated on the accounting method rather than relying on
+                        // TrendFollowingStrategy::on_execution being a no-op
+                        // (trend_following.cpp:103-115, which never populates positions_).
+                        // That is true today, but futures must be untouched here by
+                        // CONSTRUCTION, not by a property of another class that a future
+                        // edit could quietly change.
+                        updated_pos.average_price = Decimal(cost_basis);
+                    }
+
                     // E2-F2: unrealized is gated on the SAME accounting method as
                     // realized, and dollarised with point_value. Both were missing here:
                     // futures rows carried the settled move a second time, divided by the
@@ -716,8 +772,7 @@ Result<void> BacktestCoordinator::process_portfolio_day(
                     // changing this line.
                     updated_pos.unrealized_pnl =
                         Decimal(BacktestPnLManager::unrealized_for_accounting(
-                            method, qty, static_cast<double>(pos.average_price), current_close,
-                            pnl_result.point_value));
+                            method, qty, cost_basis, current_close, pnl_result.point_value));
 
                     auto update_result =
                         portfolio->update_strategy_position(strategy_id, symbol, updated_pos);

--- a/src/backtest/backtest_coordinator.cpp
+++ b/src/backtest/backtest_coordinator.cpp
@@ -772,6 +772,17 @@ Result<void> BacktestCoordinator::process_portfolio_day(
                                                      : PnLAccountingMethod::REALIZED_ONLY;
                     if (method == PnLAccountingMethod::REALIZED_ONLY) {
                         updated_pos.realized_pnl = Decimal(pnl_result.daily_pnl);
+                    } else {
+                        // E2-F19: trading.positions.daily_realized_pnl is a per-bar FLOW.
+                        // The strategy's own record is a running total over the whole
+                        // backtest; persist the increment since the previous bar so the
+                        // stored rows mean the same thing live rows do (and sum correctly
+                        // over dates). The strategy's in-memory total is untouched.
+                        const std::string key = strategy_id + "|" + symbol;
+                        const double cumulative = static_cast<double>(pos.realized_pnl);
+                        double& last = last_cumulative_realized_[key];
+                        updated_pos.realized_pnl = Decimal(cumulative - last);
+                        last = cumulative;
                     }
                     // E2-F8: prefer the strategy's fill-maintained basis over the target
                     // position's average_price, which for mean reversion is the day's close

--- a/src/backtest/backtest_coordinator.cpp
+++ b/src/backtest/backtest_coordinator.cpp
@@ -708,14 +708,16 @@ Result<void> BacktestCoordinator::process_portfolio_day(
                     if (method == PnLAccountingMethod::REALIZED_ONLY) {
                         updated_pos.realized_pnl = Decimal(pnl_result.daily_pnl);
                     }
-                    // For equities: unrealized = (current_price - cost_basis) * qty
-                    // For futures: unrealized = 0 (mark-to-market settles daily)
-                    double avg_price = static_cast<double>(pos.average_price);
-                    if (avg_price > 0.0 && std::abs(qty) > 1e-8) {
-                        updated_pos.unrealized_pnl = Decimal((current_close - avg_price) * qty);
-                    } else {
-                        updated_pos.unrealized_pnl = Decimal(0.0);
-                    }
+                    // E2-F2: unrealized is gated on the SAME accounting method as
+                    // realized, and dollarised with point_value. Both were missing here:
+                    // futures rows carried the settled move a second time, divided by the
+                    // contract multiplier. The rule and the full rationale live in
+                    // BacktestPnLManager::unrealized_for_accounting -- read it before
+                    // changing this line.
+                    updated_pos.unrealized_pnl =
+                        Decimal(BacktestPnLManager::unrealized_for_accounting(
+                            method, qty, static_cast<double>(pos.average_price), current_close,
+                            pnl_result.point_value));
 
                     auto update_result =
                         portfolio->update_strategy_position(strategy_id, symbol, updated_pos);

--- a/src/backtest/backtest_coordinator.cpp
+++ b/src/backtest/backtest_coordinator.cpp
@@ -787,19 +787,32 @@ Result<void> BacktestCoordinator::process_portfolio_day(
                                 cost_basis = static_cast<double>(held->second.average_price);
                             }
                         }
-                        // Keep the stored row self-consistent: a reader recomputing
-                        // qty * (close - average_price) from backtest.final_positions must
-                        // get the unrealized_pnl we wrote. Leaving average_price as a mark
-                        // while measuring unrealized against a basis is what made the two
-                        // disagree.
+                        // DELIBERATELY NOT WRITTEN BACK: `updated_pos.average_price` keeps
+                        // whatever the target position carried. The basis is used ONLY to
+                        // measure unrealized, just above.
                         //
-                        // Deliberately gated on the accounting method rather than relying on
-                        // TrendFollowingStrategy::on_execution being a no-op
-                        // (trend_following.cpp:103-115, which never populates positions_).
-                        // That is true today, but futures must be untouched here by
-                        // CONSTRUCTION, not by a property of another class that a future
-                        // edit could quietly change.
-                        updated_pos.average_price = Decimal(cost_basis);
+                        // Writing the basis into average_price looks right -- it would make
+                        // the stored row self-consistent, so a reader recomputing
+                        // qty * (close - average_price) would reproduce unrealized_pnl. It is
+                        // wrong, and measurably so. This position goes to
+                        // PortfolioManager::update_strategy_position() -> current_positions,
+                        // and RiskManager reads average_price off those as a MARK to size
+                        // notional and leverage (risk_manager.cpp:64, :236, :243). On a book
+                        // holding gains the basis sits below the mark, so leverage is
+                        // understated, less risk scaling is applied, and positions come out
+                        // bigger.
+                        //
+                        // NOTE ON EVIDENCE: an equity-backtest sizing shift of 1.29x-1.75x was
+                        // observed in the same run this was written in, and initially blamed on
+                        // this line. Reverting it did NOT restore the baseline, so this is NOT
+                        // the cause of that shift -- the reasoning below stands on the code
+                        // path alone, not on a measurement.
+                        //
+                        // This is exactly the ambiguity docs/AVERAGE_PRICE_LIFECYCLE.md maps:
+                        // the field carries THREE meanings and risk wants the mark while P&L
+                        // wants the basis. Consuming the basis locally is safe; storing it is
+                        // not. If the stored row must ever be made self-consistent, the basis
+                        // needs its OWN column -- do not reuse this one.
                     }
 
                     // E2-F2: unrealized is gated on the SAME accounting method as

--- a/src/backtest/backtest_coordinator.cpp
+++ b/src/backtest/backtest_coordinator.cpp
@@ -440,8 +440,27 @@ Result<void> BacktestCoordinator::process_day(
                 }
             }
             if (!found_prev) {
-                WARN("No T-1 bar found for " + bar.symbol + " -- skipping market data update");
-                continue;
+                // E2-F3: record the VOLUME anyway; omit only the return.
+                //
+                // This used to `continue`, dropping update_volume along with the log return.
+                // Today's volume is a valid, correct observation regardless of whether a
+                // prior bar exists, and ADV is what sizes market impact. Dropping it left a
+                // 20-observation ADV window that systematically excluded Mondays for the ten
+                // agricultural/livestock symbols, which have no Sunday session while the rest
+                // of the universe does -- 6.7% of all symbol-days, but ~21% of trading days
+                // for those ten. KE.v.0 sits on the 20,000 ADV bucket boundary (20,092 with
+                // Mondays, 19,948 without), so its impact coefficient flipped 60 -> 80 bps
+                // purely as a function of which days got counted.
+                //
+                // Passing prev_close = 0.0 is deliberate and sufficient: update_market_data
+                // records volume unconditionally and gates update_log_returns on
+                // `prev_close_price > 0.0`, so the return is omitted rather than fabricated.
+                //
+                // Do NOT restore `prev_close = close` (what main does). That injects a
+                // log(close/close) = 0 return -- a false observation that biases the
+                // volatility estimate downward on 1 day in 5 for the affected symbols.
+                WARN("No T-1 bar found for " + bar.symbol +
+                     " -- recording volume, omitting the return");
             }
 
             execution_manager_->update_market_data(bar.symbol, volume, close, prev_close);
@@ -523,8 +542,27 @@ Result<void> BacktestCoordinator::process_portfolio_day(
                 }
             }
             if (!found_prev) {
-                WARN("No T-1 bar found for " + bar.symbol + " -- skipping market data update");
-                continue;
+                // E2-F3: record the VOLUME anyway; omit only the return.
+                //
+                // This used to `continue`, dropping update_volume along with the log return.
+                // Today's volume is a valid, correct observation regardless of whether a
+                // prior bar exists, and ADV is what sizes market impact. Dropping it left a
+                // 20-observation ADV window that systematically excluded Mondays for the ten
+                // agricultural/livestock symbols, which have no Sunday session while the rest
+                // of the universe does -- 6.7% of all symbol-days, but ~21% of trading days
+                // for those ten. KE.v.0 sits on the 20,000 ADV bucket boundary (20,092 with
+                // Mondays, 19,948 without), so its impact coefficient flipped 60 -> 80 bps
+                // purely as a function of which days got counted.
+                //
+                // Passing prev_close = 0.0 is deliberate and sufficient: update_market_data
+                // records volume unconditionally and gates update_log_returns on
+                // `prev_close_price > 0.0`, so the return is omitted rather than fabricated.
+                //
+                // Do NOT restore `prev_close = close` (what main does). That injects a
+                // log(close/close) = 0 return -- a false observation that biases the
+                // volatility estimate downward on 1 day in 5 for the affected symbols.
+                WARN("No T-1 bar found for " + bar.symbol +
+                     " -- recording volume, omitting the return");
             }
 
             execution_manager_->update_market_data(bar.symbol, volume, close, prev_close);

--- a/src/core/chart_generator.cpp
+++ b/src/core/chart_generator.cpp
@@ -346,7 +346,12 @@ ChartData ChartGenerator::fetch_pnl_by_symbol_data(
             "FROM trading.positions "
             "WHERE strategy_id = '" + strategy_id + "' "
             "AND portfolio_id = '" + portfolio_id + "' "
-            "AND DATE(last_update) = DATE('" + date + "') - INTERVAL '1 day' "
+            // E2-F19 R-6: the previous SESSION, not the previous calendar day -- a Monday
+            // report used to read Sunday's carried rows.
+            "AND DATE(last_update) = (SELECT MAX(DATE(last_update)) FROM trading.positions "
+            "                         WHERE strategy_id = '" + strategy_id + "' "
+            "                           AND portfolio_id = '" + portfolio_id + "' "
+            "                           AND DATE(last_update) < DATE('" + date + "')) "
             "ORDER BY last_update DESC";
 
         INFO("Querying realized PnL by symbol with: " + query);

--- a/src/core/email_sender.cpp
+++ b/src/core/email_sender.cpp
@@ -519,7 +519,9 @@ std::string EmailSender::generate_trading_report_body(
     const std::unordered_map<std::string, Position>& yesterday_positions,
     const std::unordered_map<std::string, double>& yesterday_close_prices,
     const std::unordered_map<std::string, double>& two_days_ago_close_prices,
-    const std::map<std::string, double>& yesterday_daily_metrics) {
+    const std::map<std::string, double>& yesterday_daily_metrics,
+    const std::string& chart_strategy_id,
+    const std::string& chart_portfolio_id) {
     (void)risk_metrics;
     std::ostringstream html;
 
@@ -754,13 +756,13 @@ std::string EmailSender::generate_trading_report_body(
 
     html << "<h2>Charts</h2>\n";
     if (db) {
-        // This overload has no portfolio_name parameter and no production callers; passing
-        // empty portfolio_id means chart queries filter by strategy_id + empty portfolio_id
-        // (returns no rows). Kept compiling for legacy / future use.
-        const std::string chart_portfolio_id_legacy = "";
+        // E2-F11: the caller names the book the charts query. This overload IS used in
+        // production (the live equity runner); with the old hardcoded trend-following
+        // strategy id and empty portfolio every chart query returned no rows.
+        const std::string chart_portfolio_id_legacy = chart_portfolio_id;
         // Generate equity curve chart
         chart_base64_ = ChartGenerator::generate_equity_curve_chart(
-            db, "LIVE_TREND_FOLLOWING", chart_portfolio_id_legacy, 30);
+            db, chart_strategy_id, chart_portfolio_id_legacy, 30);
         if (!chart_base64_.empty()) {
             html << "<h3 style=\"margin-top: 20px; color: #333;\">Equity Curve</h3>\n";
             html << "<div style=\"width: 100%; max-width: 1000px; margin: 20px auto; text-align: "
@@ -775,7 +777,7 @@ std::string EmailSender::generate_trading_report_body(
         if (show_yesterday_pnl) {
             pnl_by_symbol_base64_ =
                 ChartGenerator::generate_pnl_by_symbol_chart(
-                    db, "LIVE_TREND_FOLLOWING", chart_portfolio_id_legacy, date);
+                    db, chart_strategy_id, chart_portfolio_id_legacy, date);
             if (!pnl_by_symbol_base64_.empty()) {
                 html << "<h3 style=\"margin-top: 20px; color: #333;\">Yesterday's PnL by "
                         "Symbol</h3>\n";
@@ -791,7 +793,7 @@ std::string EmailSender::generate_trading_report_body(
         // Generate daily PnL chart
         daily_pnl_base64_ =
             ChartGenerator::generate_daily_pnl_chart(
-                db, "LIVE_TREND_FOLLOWING", chart_portfolio_id_legacy, date, 30);
+                db, chart_strategy_id, chart_portfolio_id_legacy, date, 30);
         if (!daily_pnl_base64_.empty()) {
             html << "<h3 style=\"margin-top: 20px; color: #333;\">Daily PnL (Last 30 Days)</h3>\n";
             html << "<div style=\"width: 100%; max-width: 1000px; margin: 20px auto; text-align: "

--- a/src/data/postgres_database.cpp
+++ b/src/data/postgres_database.cpp
@@ -231,7 +231,13 @@ Result<void> PostgresDatabase::store_executions(const std::vector<ExecutionRepor
 
             // Use the date from the first execution's fill_time
             Timestamp date_for_delete = executions.front().fill_time;
-            auto del_result = delete_stale_executions(order_ids, date_for_delete, table_name);
+            // E2-F4: this passed `table_name` into the strategy_name slot -- a 3-arg call
+            // against a 4-arg signature -- so the predicate matched nothing and the
+            // defensive pre-insert cleanup silently deleted zero rows for years. Fixing
+            // the argument order without also scoping by portfolio would have ARMED the
+            // cross-portfolio delete this masked; both land together.
+            auto del_result = delete_stale_executions(order_ids, date_for_delete, strategy_name,
+                                                      portfolio_id, table_name);
             if (del_result.is_error()) {
                 std::cout << "DEBUG: Pre-insert delete_stale_executions failed: "
                           << del_result.error()->what() << std::endl;
@@ -402,23 +408,36 @@ Result<void> PostgresDatabase::store_positions_in(pqxx::work& txn,
                          pqxx::params{strategy_id, strategy_name, portfolio_id, position_date});
             }
         } catch (const std::exception& e) {
-            // If strategy_id/strategy_name columns don't exist, clear all positions for the
-            // position date only
-            WARN(
-                "strategy_id/strategy_name columns may not exist, clearing all positions for "
-                "position date: " +
-                std::string(e.what()));
-
-            if (!positions.empty()) {
-                // Phase 5 §5c: UTC date-string contract.
-                const std::string position_date =
-                    trade_ngin::core::format_utc_date(positions[0].last_update);
-
-                // Phase 5 §5b: parameterized date binding.
-                const std::string delete_query =
-                    "DELETE FROM " + table_name + " WHERE DATE(last_update) = $1";
-                txn.exec(delete_query, pqxx::params{position_date});
-            }
+            // E2-F5: FAIL, do not "recover" by deleting more.
+            //
+            // This used to fall back to `DELETE FROM <table> WHERE DATE(last_update) = $1`
+            // -- unscoped across EVERY strategy and EVERY portfolio -- and then INSERT and
+            // commit in the same transaction, so the damage committed. The scoped delete
+            // directly above carries the comment "CRITICAL: Must filter by BOTH strategy_id
+            // and strategy_name, otherwise positions from other strategies with the same
+            // combined strategy_id will be deleted!", and this handler did exactly that,
+            // and also dropped the portfolio filter.
+            //
+            // The premise was that the only way to get here is missing strategy_id /
+            // strategy_name columns. That is false: pqxx throws on ANY SQL error --
+            // deadlock, serialization failure, type mismatch, a dropped connection. Under
+            // any of those the "recovery" destroys a day of positions for every strategy
+            // and every portfolio in the table.
+            //
+            // A schema that genuinely lacks those columns is a deployment fault to fix
+            // once, not something to silently absorb on every run at the cost of an
+            // unscoped delete. Aborting loses nothing: the transaction is not committed,
+            // so the book on disk is whatever the last good run wrote.
+            ERROR("store_positions failed while deleting existing rows for " + table_name +
+                  ": " + std::string(e.what()));
+            ERROR("Refusing to fall back to an unscoped DELETE across all strategies and "
+                  "portfolios. If " + table_name + " is genuinely missing strategy_id / "
+                  "strategy_name / portfolio_id, fix the schema -- do not let a transient "
+                  "SQL error destroy another book's positions.");
+            return make_error<void>(ErrorCode::DATABASE_ERROR,
+                                    "Failed to delete existing positions for " + table_name +
+                                        ": " + std::string(e.what()),
+                                    "PostgresDatabase");
         }
 
         // Insert new positions using direct SQL like backtest does

--- a/src/data/postgres_database.cpp
+++ b/src/data/postgres_database.cpp
@@ -778,12 +778,11 @@ Result<std::unordered_map<std::string, Position>> PostgresDatabase::load_positio
             try {
                 // Try to parse as timestamp
                 std::string last_update_str = row[5].as<std::string>();
-                std::tm tm = {};
-                std::istringstream ss(last_update_str);
-                ss >> std::get_time(&tm, "%Y-%m-%d %H:%M:%S");
-                if (!ss.fail()) {
-                    auto time_c = std::mktime(&tm);
-                    last_update = std::chrono::system_clock::from_time_t(time_c);
+                // E2-F22: the column is timestamptz read from a UTC session; parse it as
+                // UTC. std::mktime here treated it as host-local time and drifted every
+                // loaded row +5 h, which the T-1 rewrite then persisted.
+                if (trade_ngin::core::parse_utc_datetime(last_update_str, last_update)) {
+                    // parsed
                 } else {
                     // Fall back to current time if parsing fails
                     WARN("Failed to parse timestamp: " + last_update_str + ", using current time");

--- a/src/data/postgres_database.cpp
+++ b/src/data/postgres_database.cpp
@@ -2767,6 +2767,58 @@ PostgresDatabase::get_position_inception_dates(const std::string& strategy_id,
     }
 }
 
+Result<std::unordered_map<std::string, std::string>>
+PostgresDatabase::get_last_buy_dates(const std::string& strategy_id,
+                                     const std::string& strategy_name,
+                                     const std::string& portfolio_id,
+                                     const std::vector<std::string>& symbols,
+                                     const std::string& on_or_after,
+                                     const std::string& on_or_before,
+                                     const std::string& table_name) {
+    using Map = std::unordered_map<std::string, std::string>;
+
+    auto validation = validate_connection();
+    if (validation.is_error()) {
+        return make_error<Map>(validation.error()->code(), validation.error()->what());
+    }
+    if (symbols.empty()) return Result<Map>(Map{});
+
+    // table_name is an internal default (trading.executions), never user input --
+    // same contract as get_position_inception_dates above.
+
+    try {
+        pqxx::work txn(*connection_);
+
+        // BUY only: it is the sole fill that re-forms a long book's weighted cost basis. A SELL
+        // reduces quantity and realizes P&L but leaves average_price untouched, so it carries no
+        // information about the basis frame.
+        auto result = txn.exec(
+            "SELECT symbol, max(date)::text AS last_buy "
+            "FROM " + table_name +
+                " WHERE strategy_id = $1 AND strategy_name = $2 AND portfolio_id = $3 "
+                "  AND symbol = ANY($4) AND side = 'BUY' "
+                "  AND date >= $5 AND date <= $6 "
+                "GROUP BY symbol",
+            pqxx::params{strategy_id, strategy_name, portfolio_id, symbols,
+                         on_or_after, on_or_before});
+
+        Map out;
+        for (const auto& row : result) {
+            if (row["last_buy"].is_null()) continue;
+            out.emplace(row["symbol"].c_str(), row["last_buy"].c_str());
+        }
+
+        txn.commit();
+        return Result<Map>(std::move(out));
+
+    } catch (const std::exception& e) {
+        return make_error<Map>(
+            ErrorCode::DATABASE_ERROR,
+            "Failed to fetch last BUY dates: " + std::string(e.what()),
+            "PostgresDatabase");
+    }
+}
+
 Result<std::unordered_map<std::string, std::map<std::string, double>>>
 PostgresDatabase::get_historical_closes(const std::vector<std::string>& symbols,
                                         const std::string& start_date,

--- a/src/data/postgres_database_extensions.cpp
+++ b/src/data/postgres_database_extensions.cpp
@@ -17,6 +17,7 @@ namespace trade_ngin {
 Result<void> PostgresDatabase::delete_stale_executions(const std::vector<std::string>& order_ids,
                                                        const Timestamp& date,
                                                        const std::string& strategy_name,
+                                                       const std::string& portfolio_id,
                                                        const std::string& table_name) {
     std::lock_guard<std::mutex> lock(mutex_);
 
@@ -48,14 +49,18 @@ Result<void> PostgresDatabase::delete_stale_executions(const std::vector<std::st
             in_list += txn.quote(order_ids[i]);
         }
 
+        // E2-F4: scoped by portfolio_id. Without it this reaches across books -- order_id
+        // is portfolio-independent and TREND_FOLLOWING runs in both. See the header.
         std::string query = "DELETE FROM " + table_name +
                             " WHERE DATE(execution_time) = $1 "
                             " AND strategy_name = $2 "
+                            " AND portfolio_id = $3 "
                             " AND order_id IN (" +
                             in_list + ")";
 
         // Execute delete for the specified date (YYYY-MM-DD)
-        txn.exec(query, pqxx::params{format_timestamp(date).substr(0, 10), strategy_name});
+        txn.exec(query, pqxx::params{format_timestamp(date).substr(0, 10), strategy_name,
+                                     portfolio_id});
 
         txn.commit();
 

--- a/src/data/postgres_database_extensions.cpp
+++ b/src/data/postgres_database_extensions.cpp
@@ -51,16 +51,19 @@ Result<void> PostgresDatabase::delete_stale_executions(const std::vector<std::st
 
         // E2-F4: scoped by portfolio_id. Without it this reaches across books -- order_id
         // is portfolio-independent and TREND_FOLLOWING runs in both. See the header.
+        // F-C: no calendar-date predicate. order_id is deterministic and already carries
+        // the trading date (DAILY_<symbol>_<yyyymmdd>, CORPACTION_<symbol>_<ex_date>), while
+        // execution_time is a wall-clock instant: a run at 19:00 EDT stores Monday UTC and a
+        // re-run at 21:00 EDT asked for Tuesday UTC, so the first run's rows never matched
+        // and the re-run inserted duplicates. Scoping by portfolio and strategy_name stays.
+        (void)date;
         std::string query = "DELETE FROM " + table_name +
-                            " WHERE DATE(execution_time) = $1 "
-                            " AND strategy_name = $2 "
-                            " AND portfolio_id = $3 "
+                            " WHERE strategy_name = $1 "
+                            " AND portfolio_id = $2 "
                             " AND order_id IN (" +
                             in_list + ")";
 
-        // Execute delete for the specified date (YYYY-MM-DD)
-        txn.exec(query, pqxx::params{format_timestamp(date).substr(0, 10), strategy_name,
-                                     portfolio_id});
+        txn.exec(query, pqxx::params{strategy_name, portfolio_id});
 
         txn.commit();
 

--- a/src/live/corporate_actions_applier.cpp
+++ b/src/live/corporate_actions_applier.cpp
@@ -11,6 +11,7 @@ const char* CorporateActionsApplier::type_to_string(CorpActionType t) {
         case CorpActionType::SPLIT:     return "SPLIT";
         case CorpActionType::ADR_SPLIT: return "ADR_SPLIT";
         case CorpActionType::DIVIDEND:  return "DIVIDEND";
+        case CorpActionType::TERMINATION: return "TERMINATION";
         case CorpActionType::UNKNOWN:   return "UNKNOWN";
     }
     return "UNKNOWN";
@@ -20,6 +21,7 @@ CorpActionType CorporateActionsApplier::type_from_type_string(const std::string&
     if (type_name == "SPLIT") return CorpActionType::SPLIT;
     if (type_name == "ADR_SPLIT") return CorpActionType::ADR_SPLIT;
     if (type_name == "DIVIDEND") return CorpActionType::DIVIDEND;
+    if (type_name == "TERMINATION") return CorpActionType::TERMINATION;
     return CorpActionType::UNKNOWN;
 }
 
@@ -159,6 +161,13 @@ std::vector<PositionAdjustment> CorporateActionsApplier::apply(
                 adj.ratio_change = ratio;
                 break;
             }
+            case CorpActionType::TERMINATION:
+                // E2-F13: class-3 lifecycle events are CorporateActionsLifecycle's business,
+                // not the applier's. A TERMINATION reaching here means an event was mis-typed
+                // upstream; skip it rather than apply price-restating logic to it.
+                WARN("CorporateActionsApplier: TERMINATION is a lifecycle class, not a "
+                     "price-restating action -- skipping " + ev.symbol + " on " + ev.ex_date);
+                continue;
             case CorpActionType::UNKNOWN:
                 continue;  // handled above
         }

--- a/src/live/corporate_actions_applier.cpp
+++ b/src/live/corporate_actions_applier.cpp
@@ -61,6 +61,36 @@ std::vector<PositionAdjustment> CorporateActionsApplier::apply(
             continue;
         }
 
+        // E2-F17: refuse an event for a position the book did NOT hold on the ex-date.
+        //
+        // A class-1 event restates a basis into post-event units. That is only right when the
+        // basis was formed BEFORE the event. A position opened after the ex-date was bought at
+        // a price the market had already adjusted, so restating it a second time is a pure
+        // fabrication -- and it is not exotic. Measured over an 82-day live replay, FOUR of the
+        // six dividends applied were applied to positions held on no part of their ex-date:
+        //
+        //   ABT   ex 2026-04-15, applied 04-18   AAPL  ex 2026-05-11, applied 06-11
+        //   DD    ex 2026-05-15, applied 06-12   TMUS  ex 2026-05-29, applied 06-05
+        //
+        // ABT alone moved the basis 95.47 -> 94.881429 and put +$33.79 of unrealized that does
+        // not exist onto the equity curve, permanently once the position is sold. The applier
+        // walks CURRENTLY-held symbols and applies anything inside the fetch window, so any
+        // name bought within 14 days after an ex-date lands here. Magnitude scales with the
+        // event: 0.62% for that dividend, 2400% for a 25:1 split.
+        //
+        // Gated on book_state_known_at_ex_date so a thin or missing position history is NOT
+        // read as "flat" -- that would silently DROP real adjustments, which is the worse
+        // failure. Unknown keeps the old behaviour and the dividend warning below.
+        if (ev.book_state_known_at_ex_date && !(std::abs(ev.qty_at_ex_date) > 1e-9)) {
+            WARN("CorporateActionsApplier: skipping " + std::string(type_to_string(ev.type)) +
+                 " for " + ev.symbol + " (ex_date " + ev.ex_date + "): the book is on record as "
+                 "holding nothing in this symbol at the ex-date, so the " +
+                 std::to_string(qty_before) + " shares held now were bought AFTER it, at a price "
+                 "the market had already adjusted. Restating this basis would double-adjust it "
+                 "(E2-F17).");
+            continue;
+        }
+
         PositionAdjustment adj;
         adj.symbol = ev.symbol;
         adj.event_date = ev.ex_date;

--- a/src/live/corporate_actions_applier.cpp
+++ b/src/live/corporate_actions_applier.cpp
@@ -78,17 +78,30 @@ std::vector<PositionAdjustment> CorporateActionsApplier::apply(
         // name bought within 14 days after an ex-date lands here. Magnitude scales with the
         // event: 0.62% for that dividend, 2400% for a 25:1 split.
         //
-        // Gated on book_state_known_at_ex_date so a thin or missing position history is NOT
-        // read as "flat" -- that would silently DROP real adjustments, which is the worse
-        // failure. Unknown keeps the old behaviour and the dividend warning below.
-        if (ev.book_state_known_at_ex_date && !(std::abs(ev.qty_at_ex_date) > 1e-9)) {
+        // Decided by BASIS PROVENANCE, not by a quantity, and it runs for EVERY class-1 type.
+        // The predecessor gated on `book_state_known_at_ex_date && qty_at_ex_date == 0`, which
+        // the runner only ever populated inside its DIVIDEND branch -- so the guard was inert
+        // for SPLITS, the case where the magnitude is catastrophic rather than small.
+        //
+        // Only POSITIVE evidence of contamination may skip. UNKNOWN applies, because dropping a
+        // real 25:1 split leaves basis and mark 25x apart, which is strictly worse than the
+        // double-adjustment this is preventing.
+        if (ev.basis_provenance == CorpActionEvent::BasisProvenance::FORMED_AFTER_EX_DATE) {
             WARN("CorporateActionsApplier: skipping " + std::string(type_to_string(ev.type)) +
-                 " for " + ev.symbol + " (ex_date " + ev.ex_date + "): the book is on record as "
-                 "holding nothing in this symbol at the ex-date, so the " +
-                 std::to_string(qty_before) + " shares held now were bought AFTER it, at a price "
-                 "the market had already adjusted. Restating this basis would double-adjust it "
-                 "(E2-F17).");
+                 " for " + ev.symbol + " (ex_date " + ev.ex_date + "): the " +
+                 std::to_string(qty_before) + " shares held now were acquired AFTER the ex-date, "
+                 "at a price the market had already adjusted, so restating this basis would "
+                 "double-adjust it. Evidence: " +
+                 (ev.basis_provenance_evidence.empty() ? std::string("(none recorded)")
+                                                       : ev.basis_provenance_evidence) +
+                 " (E2-F17).");
             continue;
+        }
+        if (ev.basis_provenance == CorpActionEvent::BasisProvenance::UNKNOWN) {
+            WARN("CorporateActionsApplier: basis provenance for " + ev.symbol + " (ex_date " +
+                 ev.ex_date + ", " + std::string(type_to_string(ev.type)) + ") is UNKNOWN; "
+                 "APPLYING, because dropping a real adjustment is worse than a double-adjusted "
+                 "basis. Investigate if this repeats (E2-F17).");
         }
 
         PositionAdjustment adj;

--- a/src/live/corporate_actions_applier.cpp
+++ b/src/live/corporate_actions_applier.cpp
@@ -133,10 +133,26 @@ std::vector<PositionAdjustment> CorporateActionsApplier::apply(
                 //       also the desired behavior for shorts (the short
                 //       owes the dividend; we record |qty| via the abs in
                 //       calculate_commission elsewhere).
-                const double basis_qty =
-                    (ev.qty_at_ex_date > 0.0 && std::isfinite(ev.qty_at_ex_date))
-                        ? ev.qty_at_ex_date
-                        : qty_before;
+                const bool have_ex_date_qty =
+                    (ev.qty_at_ex_date > 0.0 && std::isfinite(ev.qty_at_ex_date));
+                const double basis_qty = have_ex_date_qty ? ev.qty_at_ex_date : qty_before;
+
+                // The fallback is deliberate (see above) but it must not be SILENT. It only
+                // affects the audit cash-flow figure -- qty_held and total_cash on the
+                // trading.corp_action_applied row -- and never the basis adjustment, which
+                // is computed from the ratio above. But a dividend recorded against today's
+                // share count instead of the ex-date holding gives a wrong total_cash with
+                // nothing to indicate it, and the two differ precisely when they matter
+                // most: during a catch-up over a period where position history is thin, or
+                // right after a position was resized. Say so, and print both numbers so the
+                // discrepancy is measurable rather than merely suspected.
+                if (!have_ex_date_qty && std::abs(qty_before) > 1e-9) {
+                    WARN("CorporateActionsApplier: dividend for " + ev.symbol + " (ex_date " +
+                         ev.ex_date + "): no holding recorded at ex_date-1, so the cash-flow "
+                         "basis falls back to today's quantity " + std::to_string(qty_before) +
+                         ". qty_held and total_cash on the dedup row reflect that fallback, "
+                         "not the ex-date holding. The basis adjustment is unaffected.");
+                }
                 adj.quantity_before = basis_qty;
                 adj.quantity_after = basis_qty;  // unchanged
                 adj.avg_price_after = avg_after;

--- a/src/live/corporate_actions_lifecycle.cpp
+++ b/src/live/corporate_actions_lifecycle.cpp
@@ -184,8 +184,51 @@ std::vector<LifecycleAdjustment> CorporateActionsLifecycle::apply_terminations(
             continue;
         }
 
-        const bool terms_usable = ev.has_terms && !ev.contra_ticker.empty() &&
+        // Stock-for-stock rollover is DISABLED. Two independent reasons, both measured
+        // against equities_data.corporate_action (E2-F9):
+        //
+        // 1. `contraticker` carries the sentinel "N/A" on 546,662 rows -- the dominant
+        //    value in the table. An `!empty()` test passes it, and the successor position
+        //    was then keyed on a symbol literally named "N/A", which fails symbol
+        //    validation and aborts the entire run. Any delisting of a held name hit this.
+        //
+        // 2. `ev.ratio` comes from corporate_action.value, which is NOT a share exchange
+        //    ratio. On acquisition rows it averages 2,051 and reaches 133,846.7 -- deal
+        //    values in millions. A real stock-for-stock ratio is ~0.1-3.0. Applying it
+        //    would have turned 40 DFS shares into 40 x 50343.3 = 2,013,732 COF shares at a
+        //    basis of $0.0039, against a real and currently-trading symbol, with nothing to
+        //    catch it. Reason 1 was masking reason 2: fixing the sentinel alone converts a
+        //    loud abort into a silent 50,000x position.
+        //
+        // There is no trustworthy ratio column in this feed, so CONVERTED_TO_CONTRA cannot
+        // be made safe with the data that exists. Every termination therefore exits at the
+        // last real close, which is conservative, correct, and reconcilable with a broker:
+        // the position was held, the symbol stopped trading, the holder is out at the last
+        // price. Re-enabling this requires a verified deal-terms source, not a code change.
+        // Same root cause as NEW-5 (spinoff child-share receipt), which stays data-blocked.
+        const bool contra_is_usable =
+            !ev.contra_ticker.empty() && ev.contra_ticker != "N/A" &&
+            ev.contra_ticker != ev.symbol &&
+            std::all_of(ev.contra_ticker.begin(), ev.contra_ticker.end(),
+                        [](unsigned char c) { return std::isalnum(c) || c == '.' || c == '-'; });
+
+        // The handler still performs the rollover when it is handed genuine terms -- that
+        // capability is deliberately preserved so a revived deal-terms feed activates it
+        // with no code change (tests/live/corp_actions/test_effect_classes.cpp:324).
+        // The protection lives at the CALLER: the runner must not manufacture `has_terms`
+        // and `ratio` out of corporate_action.value, which is a deal value, not a ratio.
+        // Trust is a question of provenance, not of magnitude -- a plausibility band cannot
+        // separate a real 0.5 ratio from a $0.6m deal value, so the judgement belongs where
+        // the source is known.
+        const bool terms_usable = ev.has_terms && contra_is_usable &&
                                   ev.ratio > 0.0 && std::isfinite(ev.ratio);
+
+        if (!terms_usable && ev.has_terms && !contra_is_usable) {
+            WARN("Termination for " + ev.symbol + " (" + ev.event_date +
+                 "): successor '" + ev.contra_ticker +
+                 "' is not a usable ticker (sentinel or malformed) -- exiting at the final "
+                 "close rather than rolling into it (E2-F9).");
+        }
 
         if (terms_usable) {
             // Stock-for-stock: roll into the successor. Cost basis divides by

--- a/src/live/live_metrics_calculator.cpp
+++ b/src/live/live_metrics_calculator.cpp
@@ -288,6 +288,11 @@ CalculatedMetrics LiveMetricsCalculator::calculate_all_metrics(
     int trading_days,
     double daily_transaction_costs) const {
 
+    // E2-C8: intentionally unused. The caller passes daily_pnl ALREADY net of costs
+    // (live_equity_mean_reversion.cpp computes `(realized - costs) + change in mark` before
+    // calling), so subtracting daily_transaction_costs again here would double-charge it.
+    // The parameter is retained for signature stability across both asset classes' callers
+    // and as documentation of what the caller has already applied.
     (void)daily_transaction_costs;
     CalculatedMetrics metrics;
 
@@ -334,6 +339,8 @@ CalculatedMetrics LiveMetricsCalculator::calculate_finalization_metrics(
     int trading_days,
     double commissions) const {
 
+    // E2-C8: intentionally unused, same reason as above -- realized_pnl arrives net of
+    // costs, so applying `commissions` here would subtract them a second time.
     (void)commissions;
     CalculatedMetrics metrics;
 

--- a/src/live/live_pnl_manager.cpp
+++ b/src/live/live_pnl_manager.cpp
@@ -115,6 +115,11 @@ Result<LivePnLManager::FinalizationResult> LivePnLManager::finalize_previous_day
                 (avg_price > 0.0 && quantity != 0.0)
                     ? Decimal(quantity * (day_t1_close - avg_price) * point_value)
                     : Decimal(0.0);
+            // E2-F1: carry the same figure into the aggregate so the row-sums-to-aggregate
+            // invariant (protocol L5) holds by construction. Deliberately accumulated inside
+            // the MARK_TO_MARKET branch only -- under SETTLED this stays 0.0 for futures
+            // without needing a second guard anywhere.
+            result.finalized_unrealized_pnl += finalized_pos.unrealized_pnl.as_double();
         } else {
             finalized_pos.unrealized_pnl = Decimal(0.0);
         }

--- a/src/live/live_pnl_manager.cpp
+++ b/src/live/live_pnl_manager.cpp
@@ -9,7 +9,8 @@ Result<LivePnLManager::FinalizationResult> LivePnLManager::finalize_previous_day
     const std::unordered_map<std::string, double>& t1_close_prices,
     const std::unordered_map<std::string, double>& t2_close_prices,
     double previous_portfolio_value,
-    double commissions) {
+    double commissions,
+    UnrealizedPolicy unrealized_policy) {
 
     FinalizationResult result;
 
@@ -98,13 +99,22 @@ Result<LivePnLManager::FinalizationResult> LivePnLManager::finalize_previous_day
         Position finalized_pos = position;
         finalized_pos.realized_pnl = Decimal(yesterday_position_pnl);
 
-        // Compute unrealized PnL from cost basis (average_price).
-        // For futures: average_price resets to close after daily settlement, so this is ~0.
-        // For equities: average_price is the weighted average purchase price (cost basis),
-        // so this gives the correct mark-to-market unrealized PnL.
-        double avg_price = position.average_price.as_double();
-        if (avg_price > 0.0 && quantity != 0.0) {
-            finalized_pos.unrealized_pnl = Decimal(quantity * (day_t1_close - avg_price) * point_value);
+        // Unrealized P&L, per the caller's settlement model -- see UnrealizedPolicy.
+        //
+        // SETTLED (futures, the default): the position was entered at close(T-1) and is
+        // being settled here at close(T); that whole move is booked as realized just
+        // above, so there is no unrealized component. Writing one would record the same
+        // settlement move twice, because on a futures row average_price IS day_t2_close
+        // and the expression below reduces exactly to the realized formula (E2-F3).
+        //
+        // MARK_TO_MARKET (equities): average_price is a true weighted cost basis, so the
+        // expression is the genuine unrealized P&L.
+        if (unrealized_policy == UnrealizedPolicy::MARK_TO_MARKET) {
+            double avg_price = position.average_price.as_double();
+            finalized_pos.unrealized_pnl =
+                (avg_price > 0.0 && quantity != 0.0)
+                    ? Decimal(quantity * (day_t1_close - avg_price) * point_value)
+                    : Decimal(0.0);
         } else {
             finalized_pos.unrealized_pnl = Decimal(0.0);
         }

--- a/src/live/live_pnl_manager.cpp
+++ b/src/live/live_pnl_manager.cpp
@@ -38,16 +38,30 @@ Result<LivePnLManager::FinalizationResult> LivePnLManager::finalize_previous_day
         // T-1 data is REQUIRED - if missing, add position with 0 PnL to maintain continuity
         auto t1_it = t1_close_prices.find(symbol);
         if (t1_it == t1_close_prices.end()) {
-            WARN("No T-1 close price for " + symbol + ", recording position with 0 PnL (no Day T-1 data available)");
-            
-            // Still add this position to database with 0 PnL to maintain position continuity
             Position finalized_pos = position;
-            finalized_pos.realized_pnl = Decimal(0.0);
-            finalized_pos.unrealized_pnl = Decimal(0.0);
             result.position_realized_pnl[symbol] = 0.0;
+            if (unrealized_policy == UnrealizedPolicy::MARK_TO_MARKET) {
+                // E2-F19 R-1 / R-2 (cash book): a symbol with no T-1 print -- a halt, a
+                // thin name, a feed gap -- realized nothing today (its trade flow is what
+                // the day's own run recorded, kept as-is) and is still worth its last
+                // known mark. Writing 0/0 here erased a real level for a day and had it
+                // reappear the next session as a phantom jump in daily unrealized.
+                finalized_pos.realized_pnl = position.realized_pnl;
+                finalized_pos.unrealized_pnl = position.unrealized_pnl;
+                result.finalized_unrealized_pnl += finalized_pos.unrealized_pnl.as_double();
+                WARN("No T-1 close price for " + symbol +
+                     ": carrying its last known mark (unrealized " +
+                     std::to_string(position.unrealized_pnl.as_double()) +
+                     ") and its recorded realized. A symbol missing a print on a trading "
+                     "day is a halt or a feed gap -- investigate if it persists.");
+            } else {
+                WARN("No T-1 close price for " + symbol + ", recording position with 0 PnL (no Day T-1 data available)");
+                // Settled book: no settlement move can be booked without the print.
+                finalized_pos.realized_pnl = Decimal(0.0);
+                finalized_pos.unrealized_pnl = Decimal(0.0);
+            }
             result.finalized_positions.push_back(finalized_pos);
-            
-            INFO("Added " + symbol + " to finalized positions with 0 PnL (position continuity maintained)");
+            INFO("Added " + symbol + " to finalized positions (position continuity maintained)");
             continue;
         }
         double day_t1_close = t1_it->second;
@@ -56,16 +70,27 @@ Result<LivePnLManager::FinalizationResult> LivePnLManager::finalize_previous_day
         // T-2 can fall back to older data if needed (e.g., skip weekends for agriculture futures)
         auto t2_it = t2_close_prices.find(symbol);
         if (t2_it == t2_close_prices.end()) {
-            WARN("No T-2 close price for " + symbol + ", recording position with 0 PnL (T-2 data unavailable)");
-            
-            // Still add this position to database with 0 PnL to maintain position continuity
             Position finalized_pos = position;
-            finalized_pos.realized_pnl = Decimal(0.0);
-            finalized_pos.unrealized_pnl = Decimal(0.0);
             result.position_realized_pnl[symbol] = 0.0;
+            if (unrealized_policy == UnrealizedPolicy::MARK_TO_MARKET) {
+                // Cash book with a T-1 close but no T-2 close: the mark IS computable from
+                // the cost basis, and realized is the day's trade flow (R-1 / R-2).
+                double avg_price = position.average_price.as_double();
+                finalized_pos.realized_pnl = position.realized_pnl;
+                finalized_pos.unrealized_pnl =
+                    (avg_price > 0.0 && quantity != 0.0)
+                        ? Decimal(quantity * (day_t1_close - avg_price) * get_point_value(symbol))
+                        : position.unrealized_pnl;
+                result.finalized_unrealized_pnl += finalized_pos.unrealized_pnl.as_double();
+                WARN("No T-2 close price for " + symbol +
+                     ": no settlement move to report; marked at T-1 against the cost basis.");
+            } else {
+                WARN("No T-2 close price for " + symbol + ", recording position with 0 PnL (T-2 data unavailable)");
+                finalized_pos.realized_pnl = Decimal(0.0);
+                finalized_pos.unrealized_pnl = Decimal(0.0);
+            }
             result.finalized_positions.push_back(finalized_pos);
-            
-            INFO("Added " + symbol + " to finalized positions with 0 PnL (position continuity maintained)");
+            INFO("Added " + symbol + " to finalized positions (position continuity maintained)");
             continue;
         }
         double day_t2_close = t2_it->second;
@@ -95,9 +120,19 @@ Result<LivePnLManager::FinalizationResult> LivePnLManager::finalize_previous_day
         INFO("DEBUG FINALIZATION: Added " + symbol + " PnL=" + std::to_string(yesterday_position_pnl) +
              " to running sum, new total=" + std::to_string(total_finalized_pnl));
 
-        // Create finalized position with realized PnL
+        // Create finalized position with realized PnL.
+        //
+        // E2-F19 R-1: what lands in the ROW's realized_pnl follows the settlement model.
+        // SETTLED (futures): the settlement move IS the day's realized. MARK_TO_MARKET
+        // (equities): the row keeps the trade realized the day's own run recorded; the
+        // move is a mark and belongs in unrealized_pnl below. The aggregate fields
+        // (position_realized_pnl, finalized_daily_pnl) still carry the move in both
+        // models -- that is what the T-1 live_results update and the equity curve read.
         Position finalized_pos = position;
-        finalized_pos.realized_pnl = Decimal(yesterday_position_pnl);
+        finalized_pos.realized_pnl =
+            (unrealized_policy == UnrealizedPolicy::MARK_TO_MARKET)
+                ? position.realized_pnl
+                : Decimal(yesterday_position_pnl);
 
         // Unrealized P&L, per the caller's settlement model -- see UnrealizedPolicy.
         //

--- a/src/live/live_price_manager.cpp
+++ b/src/live/live_price_manager.cpp
@@ -64,7 +64,9 @@ Result<void> LivePriceManager::load_two_days_ago_prices(
     return Result<void>();
 }
 
-Result<void> LivePriceManager::update_from_bars(const std::vector<Bar>& bars, const Timestamp& reference_date) {
+Result<void> LivePriceManager::update_from_bars(const std::vector<Bar>& bars,
+                                                const Timestamp& reference_date,
+                                                std::optional<Timestamp> t1_date) {
     // Group bars by symbol and sort by timestamp to extract T-1 and T-2 prices
     std::unordered_map<std::string, std::vector<Bar>> bars_by_symbol;
     for (const auto& bar : bars) {
@@ -76,8 +78,17 @@ Result<void> LivePriceManager::update_from_bars(const std::vector<Bar>& bars, co
     two_days_ago_prices_.clear();
     latest_prices_.clear();
 
-    // Calculate expected T-1 date (should be yesterday relative to reference_date)
-    auto expected_t1_date = reference_date - std::chrono::hours(24);
+    // Calculate expected T-1 date.
+    //
+    // E2-F14: when the caller supplies t1_date it is authoritative -- it is the SAME
+    // resolved trading day the caller used to load the position book, so the price lookup
+    // and the book cannot name different days. Omitted, this is `reference_date - 24h`,
+    // which is what both futures runners compute for their own book
+    // (live_portfolio.cpp:1047, live_portfolio_conservative.cpp:1061) and therefore leaves
+    // the futures path unchanged. See the header for why a fallback here would instead
+    // double-count futures.
+    auto expected_t1_date = t1_date.has_value() ? *t1_date
+                                                : reference_date - std::chrono::hours(24);
     auto expected_t1_date_only = std::chrono::floor<std::chrono::days>(expected_t1_date);
 
     for (auto& [symbol, symbol_bars] : bars_by_symbol) {
@@ -86,6 +97,48 @@ Result<void> LivePriceManager::update_from_bars(const std::vector<Bar>& bars, co
             std::sort(symbol_bars.begin(), symbol_bars.end(),
                      [](const Bar& a, const Bar& b) { return a.timestamp < b.timestamp; });
 
+            if (t1_date.has_value()) {
+                // ---- Caller-resolved T-1 (equities) -------------------------------
+                // SEARCH for the bar on the resolved trading day rather than testing
+                // back() alone. On a live run the vendor may already have posted today's
+                // bar, and a back()-only test would then reject a perfectly good Friday.
+                // T-2 is the bar immediately preceding the T-1 bar, so the pair is always
+                // two consecutive sessions of THIS symbol.
+                std::size_t t1_idx = symbol_bars.size();
+                for (std::size_t i = symbol_bars.size(); i-- > 0;) {
+                    auto d = std::chrono::floor<std::chrono::days>(symbol_bars[i].timestamp);
+                    if (d == expected_t1_date_only) { t1_idx = i; break; }
+                    if (d < expected_t1_date_only) break;  // sorted ascending: gone past it
+                }
+
+                if (t1_idx < symbol_bars.size()) {
+                    double yesterday_close = static_cast<double>(symbol_bars[t1_idx].close);
+                    previous_day_prices_[symbol] = yesterday_close;
+                    latest_prices_[symbol] = yesterday_close;
+                    DEBUG("Day T-1 close for " + symbol + ": " + std::to_string(yesterday_close) +
+                          " (caller-resolved trading day)");
+
+                    if (t1_idx >= 1) {
+                        two_days_ago_prices_[symbol] =
+                            static_cast<double>(symbol_bars[t1_idx - 1].close);
+                    } else {
+                        WARN("No T-2 bar available for " + symbol +
+                             " - T-1 is the earliest bar in the window");
+                    }
+                } else {
+                    // A genuine data gap on a real trading day, not a weekend artifact.
+                    WARN("No bar for " + symbol +
+                         " on the resolved Day T-1 trading date - finalization will skip it");
+                    latest_prices_[symbol] = static_cast<double>(symbol_bars.back().close);
+                    if (symbol_bars.size() >= 2) {
+                        two_days_ago_prices_[symbol] =
+                            static_cast<double>(symbol_bars[symbol_bars.size() - 2].close);
+                    }
+                }
+                continue;  // futures block below is deliberately not shared
+            }
+
+            // ---- Default path (futures): UNCHANGED -------------------------------
             // CRITICAL FIX: Only use last bar as T-1 if it's ACTUALLY from Day T-1
             // Do NOT fall back to older data - if no T-1 data exists, symbol should be skipped in finalization
             auto last_bar_date_only = std::chrono::floor<std::chrono::days>(symbol_bars.back().timestamp);

--- a/src/portfolio/portfolio_manager.cpp
+++ b/src/portfolio/portfolio_manager.cpp
@@ -1456,6 +1456,15 @@ void PortfolioManager::clear_all_executions() {
     filled_positions_.clear();
 }
 
+int PortfolioManager::register_equity_cost_configs(
+    const std::vector<std::string>& symbols,
+    const std::unordered_map<std::string, std::vector<Bar>>& bars_by_symbol,
+    int adv_lookback_days) {
+    // E2-C9 -- see the header for why both cost managers must be registered.
+    return cost_manager_.register_equity_costs_from_bars(symbols, bars_by_symbol,
+                                                         adv_lookback_days);
+}
+
 void PortfolioManager::update_cost_manager_market_data(const std::string& symbol, double volume,
                                                        double close_price,
                                                        double prev_close_price) {

--- a/src/portfolio/portfolio_manager.cpp
+++ b/src/portfolio/portfolio_manager.cpp
@@ -322,9 +322,16 @@ Result<void> PortfolioManager::process_market_data(const std::vector<Bar>& data,
                      std::to_string(iteration));
             }
 
-            // Check for partial contracts in final positions
+            // Check for partial contracts in final positions.
+            // When the portfolio permits fractional positions there is nothing to
+            // converge to, so a fraction is the answer rather than a reason to
+            // iterate. Re-entering the loop would re-apply the risk scale to an
+            // already-scaled book, compounding it once per lap (E2-F1); the gate
+            // is scale-invariant (E2-F2) so shrinking never satisfies it and the
+            // position decays to zero. Futures leave the flag false and are
+            // unaffected: whole contracts already converge on the first pass.
             bool partials_found = false;
-            {
+            if (!config_.allow_fractional_positions) {
                 std::lock_guard<std::mutex> lock(mutex_);
                 for (const auto& [id, info] : strategies_) {
                     for (const auto& [symbol, pos] : info.target_positions) {
@@ -344,8 +351,14 @@ Result<void> PortfolioManager::process_market_data(const std::vector<Bar>& data,
             }
 
             if (!partials_found) {
-                INFO("No partial contracts after iteration " + std::to_string(iteration) +
-                     ". Converged!");
+                if (config_.allow_fractional_positions) {
+                    INFO("Fractional positions permitted; accepting iteration " +
+                         std::to_string(iteration) +
+                         " output as final (risk scale applied once). Converged!");
+                } else {
+                    INFO("No partial contracts after iteration " + std::to_string(iteration) +
+                         ". Converged!");
+                }
                 done = true;
             }
         }

--- a/src/portfolio/portfolio_manager.cpp
+++ b/src/portfolio/portfolio_manager.cpp
@@ -1453,6 +1453,19 @@ void PortfolioManager::clear_all_executions() {
     recent_executions_.clear();
     strategy_executions_.clear();
     // Keep the filled-position ledger in lockstep with strategy_executions_.
+    // E2-P3-a: the filled-position ledger MUST be cleared with the executions it mirrors.
+    //
+    // filled_positions_ records what this manager has actually traded into, and order sizing
+    // is `target - filled`. Clearing the execution history without clearing the ledger would
+    // leave sizing measuring against fills that no longer exist, so the next cycle would
+    // under-trade by exactly the discarded quantity.
+    //
+    // This is the ONLY reset. BacktestCoordinator::reset() does not touch PortfolioManager at
+    // all, so a coordinator reset does not clear this -- safe today because run_portfolio has
+    // a single period loop and each process builds a fresh PortfolioManager, but it means a
+    // second backtest period against a reused manager would size against stale fills. If a
+    // period loop is ever added, reset the manager here too rather than assuming this covers
+    // it.
     filled_positions_.clear();
 }
 
@@ -1565,9 +1578,21 @@ double PortfolioManager::get_portfolio_value(
             double avg_price = static_cast<double>(pos.average_price);
             double quantity = static_cast<double>(pos.quantity);
 
-            // Only calculate fresh unrealized if position has non-zero unrealized stored
-            // For REALIZED_ONLY accounting (futures), unrealized_pnl is always 0
-            // and this fresh calculation would be incorrect (missing point_value multiplier)
+            // Only recompute unrealized if the position has a non-zero value stored.
+            //
+            // E2-P3-b: the original comment asserted "For REALIZED_ONLY accounting (futures),
+            // unrealized_pnl is always 0" as though it were a system-wide invariant. It is
+            // not. It held for the STRATEGY's own positions_ -- which is what
+            // get_positions_internal() returns here, and which TrendFollowingStrategy never
+            // populates -- but the backtest coordinator wrote a NON-zero unrealized onto
+            // futures rows until E2-F2 fixed it. The invariant this guard leans on was false
+            // for two commits and nobody noticed, because this function has no production
+            // caller (tests only).
+            //
+            // The guard itself is fine: it skips the recompute unless something is stored. But
+            // if this function ever gains a caller, check where its positions came from first
+            // -- the expression below omits point_value and is therefore valid for equities
+            // only.
             if (std::abs(static_cast<double>(pos.unrealized_pnl)) > 1e-6) {
                 // For equities: unrealized_pnl = quantity * (current_price - avg_price)
                 double unrealized_pnl = quantity * (current_price - avg_price);

--- a/src/portfolio/portfolio_manager.cpp
+++ b/src/portfolio/portfolio_manager.cpp
@@ -388,16 +388,22 @@ Result<void> PortfolioManager::process_market_data(const std::vector<Bar>& data,
                  " iterations.");
         }
 
-        // Final verification of all positions for partial contracts
+        // Final verification of all positions for partial contracts.
+        // Diagnostic only -- it reports, it does not alter the position. Skipped when the
+        // portfolio permits fractional positions, where a fraction is the intended result
+        // and not an anomaly: reporting it would emit an ERROR per symbol per bar (1,702
+        // in one equity run) and bury the errors that do matter.
         {
             std::lock_guard<std::mutex> lock(mutex_);
-            for (const auto& [id, info] : strategies_) {
-                for (const auto& [symbol, pos] : info.target_positions) {
-                    double fractional = std::abs(static_cast<double>(pos.quantity) -
-                                                 std::round(static_cast<double>(pos.quantity)));
-                    if (fractional > 1e-6) {
-                        ERROR("FINAL CHECK: Fractional contract detected for " + symbol +
-                              " after all iterations. Quantity=" + std::to_string(pos.quantity));
+            if (!config_.allow_fractional_positions) {
+                for (const auto& [id, info] : strategies_) {
+                    for (const auto& [symbol, pos] : info.target_positions) {
+                        double fractional = std::abs(static_cast<double>(pos.quantity) -
+                                                     std::round(static_cast<double>(pos.quantity)));
+                        if (fractional > 1e-6) {
+                            ERROR("FINAL CHECK: Fractional contract detected for " + symbol +
+                                  " after all iterations. Quantity=" + std::to_string(pos.quantity));
+                        }
                     }
                 }
             }

--- a/src/storage/live_results_manager.cpp
+++ b/src/storage/live_results_manager.cpp
@@ -137,7 +137,17 @@ Result<void> LiveResultsManager::delete_stale_data(const Timestamp& date) {
             order_ids.push_back(exec.order_id);
         }
 
-        result = db_->delete_stale_executions(order_ids, date, strategy_id_, "trading.executions");
+        // The DELETE filters on trading.executions.strategy_name, so it must be given the
+        // NAME, not the id. Passing strategy_id_ here matched nothing wherever the two
+        // differ -- for equities the rows carry strategy_name 'EQUITY_MEAN_REVERSION' while
+        // strategy_id_ is 'LIVE_EQUITY_MEAN_REVERSION' -- so the stale rows survived and the
+        // re-insert failed on executions_pkey (portfolio_id, strategy_id, strategy_name,
+        // date, exec_id). That made a date impossible to re-run, which breaks both
+        // idempotency (protocol 3f) and the replay-the-missed-day remedy for a run gap.
+        //
+        // strategy_name_ falls back to strategy_id_ when unset, so callers that never
+        // populate the name -- the futures runners -- pass exactly what they passed before.
+        result = db_->delete_stale_executions(order_ids, date, strategy_name_, "trading.executions");
         if (result.is_error()) {
             WARN("Failed to delete stale executions: " + std::string(result.error()->what()));
         }

--- a/src/storage/live_results_manager.cpp
+++ b/src/storage/live_results_manager.cpp
@@ -147,7 +147,8 @@ Result<void> LiveResultsManager::delete_stale_data(const Timestamp& date) {
         //
         // strategy_name_ falls back to strategy_id_ when unset, so callers that never
         // populate the name -- the futures runners -- pass exactly what they passed before.
-        result = db_->delete_stale_executions(order_ids, date, strategy_name_, "trading.executions");
+        result = db_->delete_stale_executions(order_ids, date, strategy_name_, portfolio_id_,
+                                             "trading.executions");
         if (result.is_error()) {
             WARN("Failed to delete stale executions: " + std::string(result.error()->what()));
         }

--- a/src/strategy/base_strategy.cpp
+++ b/src/strategy/base_strategy.cpp
@@ -255,10 +255,25 @@ Result<void> BaseStrategy::on_execution(const ExecutionReport& report) {
 
         pos.last_update = report.fill_time;
 
-        // Always subtract transaction costs from realized PnL (for all trades, not just closing)
-        // This ensures transaction costs are accounted for in opening positions too
+        // E2-F1 / E2-F9: `pos.realized_pnl` is GROSS trade P&L. Transaction costs are NOT
+        // netted into it.
+        //
+        // This field is persisted as trading.positions.daily_realized_pnl (via
+        // LiveDailyCycle::resolve_and_apply_basis), while live_results carries costs in
+        // their own column. Netting costs here made the row net-of-cost and the aggregate
+        // net-of-commission-only, so the two reconciled against different cost bases in the
+        // same run and the row-sums-to-aggregate check could never be exact.
+        //
+        // The reporting model now mirrors futures: realized is gross, costs are a separate
+        // column, and the consumer subtracts once --
+        //     daily_pnl = (daily_realized_pnl - daily_transaction_costs) + daily_unrealized_pnl
+        // Netting here as well would subtract them twice.
+        //
+        // metrics_ is deliberately left net. It is internal strategy bookkeeping, and
+        // metrics_.total_pnl feeds the drawdown gate in check_risk_limits(); making that
+        // gross would quietly loosen a risk limit, which is outside this fix. The asymmetry
+        // is intentional: metrics_ is a risk input, pos.realized_pnl is a reported figure.
         double transaction_cost = static_cast<double>(report.total_transaction_costs);
-        pos.realized_pnl -= Decimal(transaction_cost);
         metrics_.realized_pnl -= transaction_cost;
         metrics_.total_pnl -= transaction_cost;
 

--- a/src/transaction_cost/asset_cost_config.cpp
+++ b/src/transaction_cost/asset_cost_config.cpp
@@ -596,8 +596,8 @@ void AssetCostConfigRegistry::initialize_default_configs() {
         config.commission_per_unit = 0.005;   // IBKR Pro: $0.005/share
         config.min_commission_per_order = 1.00;
         config.max_commission_per_order = 1e9;
-        config.max_commission_pct = 0.005;    // 0.5% of trade value (IBKR Tiered cap)
-        config.apply_regulatory_fees = true;
+        config.max_commission_pct = 0.01;   // E2-C1: IBKR Fixed 1%; 0.5% is the Tiered cap
+        config.apply_regulatory_fees = false;  // E2-C3: IBKR Fixed is all-inclusive
         config.max_impact_bps = 50.0;
         config.max_total_implicit_bps = 75.0;
         configs_[config.symbol] = config;
@@ -616,8 +616,8 @@ void AssetCostConfigRegistry::initialize_default_configs() {
         config.commission_per_unit = 0.005;
         config.min_commission_per_order = 1.00;
         config.max_commission_per_order = 1e9;
-        config.max_commission_pct = 0.005;
-        config.apply_regulatory_fees = true;
+        config.max_commission_pct = 0.01;   // E2-C1: IBKR Fixed 1%; 0.5% is the Tiered cap
+        config.apply_regulatory_fees = false;  // E2-C3: IBKR Fixed is all-inclusive
         config.max_impact_bps = 75.0;
         config.max_total_implicit_bps = 100.0;
         configs_[config.symbol] = config;
@@ -636,8 +636,8 @@ void AssetCostConfigRegistry::initialize_default_configs() {
         config.commission_per_unit = 0.005;
         config.min_commission_per_order = 1.00;
         config.max_commission_per_order = 1e9;
-        config.max_commission_pct = 0.005;
-        config.apply_regulatory_fees = true;
+        config.max_commission_pct = 0.01;   // E2-C1: IBKR Fixed 1%; 0.5% is the Tiered cap
+        config.apply_regulatory_fees = false;  // E2-C3: IBKR Fixed is all-inclusive
         config.max_impact_bps = 100.0;
         config.max_total_implicit_bps = 150.0;
         configs_[config.symbol] = config;
@@ -715,8 +715,8 @@ AssetCostConfig AssetCostConfigRegistry::get_equity_default_config() {
     config.commission_per_unit = 0.005;    // IBKR Pro: $0.005/share
     config.min_commission_per_order = 1.00;
     config.max_commission_per_order = 1e9;
-    config.max_commission_pct = 0.005;     // 0.5% of trade value cap
-    config.apply_regulatory_fees = true;   // SEC + FINRA on sells
+    config.max_commission_pct = 0.01;   // E2-C1: IBKR Fixed 1%; 0.5% is the Tiered cap
+    config.apply_regulatory_fees = false;  // E2-C3: IBKR Fixed is all-inclusive
     config.max_impact_bps = 100.0;
     config.max_total_implicit_bps = 200.0;
     return config;

--- a/src/transaction_cost/transaction_cost_manager.cpp
+++ b/src/transaction_cost/transaction_cost_manager.cpp
@@ -121,6 +121,27 @@ TransactionCostResult TransactionCostManager::calculate_costs(
     result.implicit_price_impact =
         result.spread_price_impact + result.market_impact_price_impact;
 
+    // E2-C5: enforce max_total_implicit_bps.
+    //
+    // This field is set on EVERY asset config (75-200 bps depending on tier) and was read by
+    // NOTHING -- the documented cap on total implicit cost did not exist. max_impact_bps
+    // bounds the market-impact term alone; nothing bounded spread + impact together.
+    //
+    // It should not bind in normal conditions: the impact term is already capped below this
+    // value and futures spreads are a tick or two, so the sum stays well under. That is
+    // precisely why it went unnoticed. It is a tail guard, so when it DOES bind that is worth
+    // seeing rather than absorbing silently -- hence the warning.
+    if (asset_config.max_total_implicit_bps >= 0.0 && reference_price > 0.0) {
+        const double cap = (asset_config.max_total_implicit_bps / 10000.0) * reference_price;
+        if (result.implicit_price_impact > cap) {
+            WARN("Implicit cost cap binding for " + symbol + ": " +
+                 std::to_string((result.implicit_price_impact / reference_price) * 10000.0) +
+                 " bps clamped to " + std::to_string(asset_config.max_total_implicit_bps) +
+                 " bps (spread + market impact)");
+            result.implicit_price_impact = cap;
+        }
+    }
+
     // 5. Convert implicit to dollars
     // slippage_market_impact = implicit_price_impact * |qty| * point_value
     result.slippage_market_impact =

--- a/src/transaction_cost/transaction_cost_manager.cpp
+++ b/src/transaction_cost/transaction_cost_manager.cpp
@@ -65,14 +65,33 @@ TransactionCostResult TransactionCostManager::calculate_costs(
         double raw_commission = abs_qty * asset_config.commission_per_unit;
         double effective_max;
         if (asset_config.max_commission_pct >= 0.0) {
-            // Percentage-based cap: e.g., 0.5% of trade value (IBKR Tiered)
-            // IBKR Fixed uses 1.0% -- configurable via max_commission_pct
+            // Percentage-based cap. The equity configs are IBKR Pro FIXED, so this is 1.0%
+            // of trade value (0.5% is the Tiered cap -- see the field's comment in
+            // asset_cost_config.hpp before changing it).
             effective_max = asset_config.max_commission_pct * abs_qty * reference_price;
         } else {
             effective_max = asset_config.max_commission_per_order;
         }
-        result.commissions_fees = std::max(asset_config.min_commission_per_order,
-                                           std::min(effective_max, raw_commission));
+        // E2-C2: the cap is a CEILING and must be applied last.
+        //
+        // This was `max(floor, min(cap, raw))`, which lets the floor override the cap. IBKR
+        // publishes the schedule as "Minimum per order: USD 1.00 / Maximum per order: 1
+        // percent of trade value" -- a maximum that a minimum can exceed is not a maximum.
+        //
+        // The old order also made max_commission_pct DEAD for any normal stock: the inner
+        // min(cap, raw) picks the cap only when `pct * price < commission_per_unit`, i.e.
+        // below $0.50 a share, so above that the expression collapsed to max(floor, raw) and
+        // the configured cap could not change a single output value.
+        //
+        // The two only collide on very small orders, which is exactly what a fractional-share
+        // book trades. Measured 2026-07-24..08-03: the cap should have bound on 5 of 15
+        // executions and did not -- an $18.70 AMZN trade paid $1.00 (535 bps) where the 1%
+        // cap says $0.187. 21% over-charge, concentrated on the smallest clips.
+        //
+        // The floor protects the broker on small-but-normal orders; the cap protects the
+        // client on tiny ones. Both belong here, in this order.
+        result.commissions_fees = std::min(
+            effective_max, std::max(asset_config.min_commission_per_order, raw_commission));
     } else {
         // Global fee per contract (futures default)
         result.commissions_fees = abs_qty * config_.explicit_fee_per_contract;
@@ -164,8 +183,33 @@ int TransactionCostManager::register_equity_costs_from_bars(
     for (const auto& symbol : symbols) {
         auto it = bars_by_symbol.find(symbol);
         if (it == bars_by_symbol.end() || it->second.empty()) {
+            // E2-F14: register the untiered equity default rather than skipping.
+            //
+            // Skipping left the symbol ABSENT from configs_, and an absent symbol does NOT
+            // fall back to the equity default -- AssetCostConfigRegistry::get_config() only
+            // reaches get_equity_default_config() when the caller passes
+            // AssetType::EQUITY, and NONE of the nine production call sites passes an
+            // AssetType at all. So an unregistered equity resolved to the FUTURES default:
+            // $1.50 per SHARE instead of $0.005, and point_value 100 instead of 1, i.e. 100x
+            // the slippage. The old WARN here claimed "will use equity default if traded",
+            // which was simply untrue.
+            //
+            // Worse, configs_ is one flat symbol->config map shared across asset classes, and
+            // real tickers collide with futures roots: CL is Colgate-Palmolive AND Crude Oil,
+            // ES is Eversource AND the E-mini S&P. An unregistered CL equity would have
+            // resolved to the Crude Oil config -- point_value 1000.
+            //
+            // Registering the default keeps every configured equity inside the equity cost
+            // model, so the futures fallthrough is unreachable for them regardless of what
+            // any call site passes. Fail-safe by construction rather than by every caller
+            // remembering an argument.
             WARN("register_equity_costs_from_bars: no bars for " + symbol +
-                 " -- skipping (will use equity default if traded)");
+                 " -- registering the untiered equity default so it can never resolve to a "
+                 "futures cost config");
+            AssetCostConfig fallback = AssetCostConfigRegistry::get_equity_default_config();
+            fallback.symbol = symbol;
+            asset_configs_.register_config(fallback);
+            ++registered;
             continue;
         }
 
@@ -180,8 +224,15 @@ int TransactionCostManager::register_equity_costs_from_bars(
         const double adv = volume_sum / static_cast<double>(n);
 
         if (adv <= 0.0) {
+            // E2-F14: same reasoning as the no-bars branch above -- never leave a configured
+            // equity unregistered, or it inherits futures pricing.
             WARN("register_equity_costs_from_bars: zero ADV for " + symbol +
-                 " over " + std::to_string(n) + " bars -- skipping");
+                 " over " + std::to_string(n) + " bars -- registering the untiered equity "
+                 "default rather than leaving it to resolve as a future");
+            AssetCostConfig fallback = AssetCostConfigRegistry::get_equity_default_config();
+            fallback.symbol = symbol;
+            asset_configs_.register_config(fallback);
+            ++registered;
             continue;
         }
 

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -60,6 +60,7 @@ set(TEST_SOURCES
     instruments/test_futures_margin_overload.cpp
     portfolio/test_portfolio_aggregation.cpp
     portfolio/test_portfolio_manager_internals.cpp
+    portfolio/test_fractional_position_convergence.cpp
     storage/test_backtest_results_manager.cpp
     storage/test_live_results_manager.cpp
     storage/test_live_results_key_roundtrip_db.cpp

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -17,6 +17,7 @@ set(TEST_SOURCES
     data/test_postgres_database.cpp
     data/test_database_pooling.cpp
     data/test_db_transaction_atomicity.cpp
+    data/test_delete_stale_executions_scope_db.cpp
     data/test_market_data_bus.cpp
     data/test_credential_store.cpp
     data/test_bar_close_uses_adjusted.cpp

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -18,6 +18,7 @@ set(TEST_SOURCES
     data/test_database_pooling.cpp
     data/test_db_transaction_atomicity.cpp
     data/test_delete_stale_executions_scope_db.cpp
+    data/test_get_trading_days_scope_db.cpp
     data/test_market_data_bus.cpp
     data/test_credential_store.cpp
     data/test_bar_close_uses_adjusted.cpp

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -1,6 +1,7 @@
 # Set test source files
 set(TEST_SOURCES
     core/test_decimal.cpp
+    core/test_time_utils_parse.cpp
     core/test_result.cpp
     core/test_state_manager.cpp
     core/test_logger.cpp

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -52,6 +52,7 @@ set(TEST_SOURCES
     backtest/test_backtest_data_loader.cpp
     backtest/test_backtest_csv_exporter.cpp
     backtest/test_backtest_coordinator.cpp
+    backtest/test_backtest_unrealized_accounting.cpp
     execution/test_execution_engine.cpp
     portfolio/test_portfolio_manager.cpp
     core/test_equity_portfolio_namespace.cpp

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -38,6 +38,8 @@ set(TEST_SOURCES
     transaction_cost/test_impact_model.cpp
     live/corp_actions/test_applier.cpp
     live/corp_actions/test_effect_classes.cpp
+    live/corp_actions/test_frame_horizon.cpp
+    live/corp_actions/test_ex_date_eligibility.cpp
     live/corp_actions/test_rename_eras.cpp
     live/corp_actions/test_denominator_frame.cpp
     live/corp_actions/test_denominator_range_db.cpp

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -72,6 +72,7 @@ set(TEST_SOURCES
     live/test_margin_manager.cpp
     live/test_live_metrics_calculator.cpp
     live/test_live_pnl_manager.cpp
+    live/test_finalize_unrealized_policy.cpp
     live/test_unrealized_cost_basis.cpp
     live/test_live_data_loader.cpp
     live/test_csv_exporter.cpp

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -78,6 +78,8 @@ set(TEST_SOURCES
     live/test_live_metrics_calculator.cpp
     live/test_live_pnl_manager.cpp
     live/test_finalize_unrealized_policy.cpp
+    live/test_finalize_realized_policy.cpp
+    live/test_realized_row_retention.cpp
     live/test_unrealized_cost_basis.cpp
     live/test_live_data_loader.cpp
     live/test_csv_exporter.cpp

--- a/tests/backtest/test_backtest_unrealized_accounting.cpp
+++ b/tests/backtest/test_backtest_unrealized_accounting.cpp
@@ -1,0 +1,160 @@
+// E2-F2 regression pins — backtest unrealized P&L must be gated on the settlement model.
+//
+// BacktestCoordinator gated `realized_pnl` on PnLAccountingMethod but left `unrealized_pnl`
+// ungated, and its inline expression also omitted point_value:
+//
+//     updated_pos.unrealized_pnl = Decimal((current_close - avg_price) * qty);
+//
+// Two defects on one line. On a futures backtest row `average_price` IS the prior close --
+// TrendFollowingStrategy resets it to current_price after settling
+// (trend_following.cpp:550-556) and get_target_positions() stamps price_history.back()
+// (:610-624), while the coordinator feeds on_data the T-1 bars
+// (backtest_coordinator.cpp:547). So the expression reduces algebraically to the realized
+// formula and records the same settled move twice -- then divides it by the contract
+// multiplier, because point_value is absent.
+//
+// Measured on TREND_FOLLOWING_20260901_060030_828: 2,769 of 3,064 backtest.final_positions
+// rows non-zero, gross magnitude $693,172.27, net -$28,315.21. The ratio
+// unrealized/realized was EXACTLY 1/point_value on every symbol -- MYM 2.0 (pv 0.5),
+// MNQ 0.5 (pv 2), MES 0.2 (pv 5), ZN 0.001 (pv 1000), 6A 0.00001 (pv 100000). MYM only
+// looked like a "2x" because its point value happens to be 0.5.
+//
+// `main` has `unrealized_pnl = Decimal(0.0)` unconditionally; the regression entered with
+// 76b4ea5d, and 7e3d07c2 later gated realized but not unrealized.
+//
+// This is the backtest twin of E2-F3 (commit 5b589ac2), which fixed the identical defect on
+// the live side via LivePnLManager::UnrealizedPolicy. Live and backtest must agree; before
+// this they did not -- live said 0, backtest said settled-move / point_value.
+
+#include <gtest/gtest.h>
+
+#include "trade_ngin/backtest/backtest_pnl_manager.hpp"
+#include "trade_ngin/strategy/types.hpp"
+
+using namespace trade_ngin;
+using trade_ngin::backtest::BacktestPnLManager;
+
+namespace {
+
+// Real numbers from the MYM.v.0 row on 2026-08-06 in run
+// TREND_FOLLOWING_20260901_060030_828, so the fixture cannot drift from what production
+// actually produced.
+constexpr double kQty        = 3.0;
+constexpr double kPrevClose  = 54583.0;   // close 2026-08-05 -- what average_price holds
+constexpr double kClose      = 53998.0;   // close 2026-08-06
+constexpr double kPointValue = 0.5;       // MYM contract size
+
+// (53998 - 54583) * 3 * 0.5 == -877.50, the value stored in realized_pnl.
+constexpr double kSettledMove = (kClose - kPrevClose) * kQty * kPointValue;
+
+// What the pre-fix line produced: the same move, with point_value dropped. -1755.00.
+constexpr double kBuggyValue = (kClose - kPrevClose) * kQty;
+
+}  // namespace
+
+// ---------------------------------------------------------------------------
+// Futures invariant. This is the one that must never move.
+// ---------------------------------------------------------------------------
+
+TEST(BacktestUnrealizedAccounting, RealizedOnlyYieldsZeroUnrealized) {
+    const double u = BacktestPnLManager::unrealized_for_accounting(
+        PnLAccountingMethod::REALIZED_ONLY, kQty, kPrevClose, kClose, kPointValue);
+
+    EXPECT_DOUBLE_EQ(u, 0.0)
+        << "A REALIZED_ONLY (futures) position recorded a non-zero unrealized P&L. Under "
+           "daily settlement average_price IS the prior settlement close, so any value here "
+           "is the settled move already booked in realized_pnl -- the same day counted "
+           "twice (E2-F2).";
+}
+
+// The specific pre-fix value, pinned so the exact regression cannot come back unnoticed.
+TEST(BacktestUnrealizedAccounting, RealizedOnlyDoesNotReproduceTheUngatedExpression) {
+    const double u = BacktestPnLManager::unrealized_for_accounting(
+        PnLAccountingMethod::REALIZED_ONLY, kQty, kPrevClose, kClose, kPointValue);
+
+    EXPECT_NE(u, kBuggyValue)
+        << "The ungated pre-fix expression has returned. This is the literal value the "
+           "defect wrote to MYM.v.0 on 2026-08-06 (-1755.00): the settled move (-877.50) "
+           "recorded a second time and divided by the 0.5 contract multiplier.";
+}
+
+// average_price must be ignored entirely under REALIZED_ONLY -- not merely happen to be
+// close to the mark. A futures row whose basis has drifted must still report 0.
+TEST(BacktestUnrealizedAccounting, RealizedOnlyIgnoresAveragePriceEvenWhenItDiffersWidely) {
+    const double u = BacktestPnLManager::unrealized_for_accounting(
+        PnLAccountingMethod::REALIZED_ONLY, kQty, /*average_price=*/1.0, kClose, kPointValue);
+
+    EXPECT_DOUBLE_EQ(u, 0.0)
+        << "REALIZED_ONLY consulted average_price. The futures result must be 0 by the "
+           "settlement identity regardless of what the basis holds.";
+}
+
+// ---------------------------------------------------------------------------
+// Equity behaviour: a genuine mark against a cost basis, dollarised.
+// ---------------------------------------------------------------------------
+
+TEST(BacktestUnrealizedAccounting, MixedMeasuresAgainstTheCostBasis) {
+    // 10 shares bought at 100.00, marked at 105.50, equities point_value 1.0.
+    const double u = BacktestPnLManager::unrealized_for_accounting(
+        PnLAccountingMethod::MIXED, 10.0, 100.0, 105.50, 1.0);
+
+    EXPECT_DOUBLE_EQ(u, 55.0)
+        << "MIXED (equity) accounting did not measure the position against its cost basis.";
+}
+
+TEST(BacktestUnrealizedAccounting, UnrealizedOnlyBehavesLikeMixed) {
+    const double u = BacktestPnLManager::unrealized_for_accounting(
+        PnLAccountingMethod::UNREALIZED_ONLY, 10.0, 100.0, 105.50, 1.0);
+
+    EXPECT_DOUBLE_EQ(u, 55.0)
+        << "UNREALIZED_ONLY must mark against the cost basis exactly as MIXED does; only "
+           "REALIZED_ONLY is the settled case.";
+}
+
+// The second half of the defect: point_value was absent from the expression. This fails if
+// anyone drops the multiplier again.
+TEST(BacktestUnrealizedAccounting, PointValueIsAppliedNotAssumedToBeOne) {
+    const double u = BacktestPnLManager::unrealized_for_accounting(
+        PnLAccountingMethod::MIXED, kQty, kPrevClose, kClose, kPointValue);
+
+    EXPECT_DOUBLE_EQ(u, kSettledMove)
+        << "point_value was not applied. With the multiplier dropped this returns "
+        << kBuggyValue << " instead of " << kSettledMove << " -- exactly the 1/point_value "
+           "ratio the defect produced across every futures symbol.";
+}
+
+TEST(BacktestUnrealizedAccounting, ShortPositionMarksWithTheCorrectSign) {
+    // Short 10 at 100.00, mark falls to 95.00 -> +50 unrealized.
+    const double u = BacktestPnLManager::unrealized_for_accounting(
+        PnLAccountingMethod::MIXED, -10.0, 100.0, 95.0, 1.0);
+
+    EXPECT_DOUBLE_EQ(u, 50.0) << "A short position did not gain when the mark fell.";
+}
+
+// ---------------------------------------------------------------------------
+// "No basis known" cases. 0.0 means "cannot measure", not "no gain".
+// ---------------------------------------------------------------------------
+
+TEST(BacktestUnrealizedAccounting, NoCostBasisYieldsZeroRatherThanMarkAsBasis) {
+    EXPECT_DOUBLE_EQ(
+        BacktestPnLManager::unrealized_for_accounting(PnLAccountingMethod::MIXED, 10.0, 0.0,
+                                                      105.50, 1.0),
+        0.0)
+        << "An unset average_price must yield 0, never a mark measured against zero. "
+           "Substituting a mark for a basis is the root defect mapped in "
+           "docs/AVERAGE_PRICE_LIFECYCLE.md.";
+
+    EXPECT_DOUBLE_EQ(
+        BacktestPnLManager::unrealized_for_accounting(PnLAccountingMethod::MIXED, 10.0, -1.0,
+                                                      105.50, 1.0),
+        0.0)
+        << "A negative average_price must be treated as 'no basis known'.";
+}
+
+TEST(BacktestUnrealizedAccounting, ZeroQuantityYieldsZero) {
+    EXPECT_DOUBLE_EQ(
+        BacktestPnLManager::unrealized_for_accounting(PnLAccountingMethod::MIXED, 0.0, 100.0,
+                                                      105.50, 1.0),
+        0.0)
+        << "A flat position must carry no unrealized P&L.";
+}

--- a/tests/core/test_time_utils_parse.cpp
+++ b/tests/core/test_time_utils_parse.cpp
@@ -1,0 +1,71 @@
+// tests/core/test_time_utils_parse.cpp
+//
+// E2-F22: a timestamptz read back from a UTC session must round-trip exactly on ANY host.
+// std::mktime interpreted the broken-down UTC time as host-local, so on a New York host a
+// loaded position timestamp came back +5 h; the T-1 rewrite persisted the shift, and four
+// rewrites (a holiday adjacent to a weekend) walked the row across midnight onto the next
+// date, where the date-keyed DELETE replaced that day's rows with a copy of T-1's.
+
+#include <gtest/gtest.h>
+
+#include <cstdlib>
+#include <string>
+
+#include "trade_ngin/core/time_utils.hpp"
+
+using namespace trade_ngin::core;
+
+namespace {
+
+struct ForceTimezone {
+    std::string previous;
+    bool had_previous = false;
+    explicit ForceTimezone(const char* tz) {
+        if (const char* p = std::getenv("TZ")) { previous = p; had_previous = true; }
+        setenv("TZ", tz, 1);
+        tzset();
+    }
+    ~ForceTimezone() {
+        if (had_previous) setenv("TZ", previous.c_str(), 1); else unsetenv("TZ");
+        tzset();
+    }
+};
+
+}  // namespace
+
+// The load-bearing case: the host is New York, the string is UTC.
+TEST(TimeUtilsParse, UtcStringRoundTripsExactlyOnANewYorkHost) {
+    ForceTimezone tz("America/New_York");
+    std::chrono::system_clock::time_point tp;
+    ASSERT_TRUE(parse_utc_datetime("2026-06-18 05:00:00+00", tp));
+    EXPECT_EQ(format_utc_datetime(tp), "2026-06-18 05:00:00")
+        << "a UTC timestamp must not pick up the host offset (mktime did: +5 h)";
+}
+
+// Fractional seconds and the +00 suffix pqxx hands back are tolerated.
+TEST(TimeUtilsParse, ToleratesFractionAndOffsetSuffix) {
+    ForceTimezone tz("America/New_York");
+    std::chrono::system_clock::time_point tp;
+    ASSERT_TRUE(parse_utc_datetime("2026-07-02 20:00:00.123456+00", tp));
+    EXPECT_EQ(format_utc_date(tp), "2026-07-02");
+    EXPECT_EQ(format_utc_datetime(tp), "2026-07-02 20:00:00");
+}
+
+// Four re-parses of the same string stay on the same date -- the migration that produced
+// the duplicate Juneteenth row cannot start.
+TEST(TimeUtilsParse, RepeatedParseFormatIsAFixedPoint) {
+    ForceTimezone tz("America/New_York");
+    std::string s = "2026-07-02 20:00:00+00";
+    for (int i = 0; i < 4; ++i) {
+        std::chrono::system_clock::time_point tp;
+        ASSERT_TRUE(parse_utc_datetime(s, tp));
+        s = format_utc_datetime(tp) + "+00";
+    }
+    EXPECT_EQ(s, "2026-07-02 20:00:00+00");
+}
+
+TEST(TimeUtilsParse, MalformedStringIsRejected) {
+    std::chrono::system_clock::time_point tp;
+    EXPECT_FALSE(parse_utc_datetime("not a timestamp", tp));
+    EXPECT_FALSE(parse_utc_datetime("2026-07-02", tp));
+}

--- a/tests/data/test_db_utils.hpp
+++ b/tests/data/test_db_utils.hpp
@@ -381,9 +381,9 @@ public:
 
     Result<void> delete_stale_executions(
         const std::vector<std::string>& order_ids, const Timestamp& date,
-        const std::string& strategy_name,
+        const std::string& strategy_name, const std::string& portfolio_id,
         const std::string& table_name = "trading.executions") override {
-        (void)order_ids; (void)date; (void)strategy_name; (void)table_name;
+        (void)order_ids; (void)date; (void)strategy_name; (void)portfolio_id; (void)table_name;
         return record_call("delete_stale_executions");
     }
 

--- a/tests/data/test_delete_stale_executions_scope_db.cpp
+++ b/tests/data/test_delete_stale_executions_scope_db.cpp
@@ -207,3 +207,22 @@ TEST_F(DeleteStaleExecutionsScopeTest, DeleteThenReinsertSucceedsForTheSameKey) 
            "idempotency (protocol 3f) and the replay-the-missed-day remedy for a run gap.";
     EXPECT_EQ(count_for(kPortfolioA), 1) << "Re-insert should leave exactly one row, not two.";
 }
+
+// F-C: the cleanup is keyed on order_id, strategy_name and portfolio -- never on the
+// calendar date of execution_time. A run at 19:00 EDT stores a Monday-UTC instant; a re-run
+// at 21:00 EDT asked for "Tuesday" and never matched it, so the re-run duplicated the row.
+TEST_F(DeleteStaleExecutionsScopeTest, CleanupIgnoresTheCalendarDateOfExecutionTime) {
+    std::vector<ExecutionReport> execs{make_exec("F4PROBE")};
+    ASSERT_FALSE(
+        db_->store_executions(execs, kStrategyId, kStrategyName, kPortfolioA, "trading.executions")
+            .is_error());
+    ASSERT_EQ(count_for(kPortfolioA), 1);
+
+    // Ask with a date that is NOT the execution's UTC date: the row must still go.
+    auto del = db_->delete_stale_executions({kSharedOrderId}, date_at(2026, 5, 5), kStrategyName,
+                                            kPortfolioA, "trading.executions");
+    ASSERT_FALSE(del.is_error()) << del.error()->what();
+    EXPECT_EQ(count_for(kPortfolioA), 0)
+        << "a deterministic order_id already carries its date; a wall-clock date predicate "
+           "only ever caused duplicates across the 20:00 EDT boundary";
+}

--- a/tests/data/test_delete_stale_executions_scope_db.cpp
+++ b/tests/data/test_delete_stale_executions_scope_db.cpp
@@ -1,0 +1,209 @@
+// E2-F4 end-to-end: can one book's stale-execution cleanup delete another book's rows?
+//
+// delete_stale_executions() used to key on (DATE(execution_time), strategy_name, order_id)
+// with NO portfolio predicate, while trading.executions is keyed
+// (portfolio_id, strategy_id, strategy_name, date, exec_id). order_id is
+// portfolio-independent -- ExecutionManager builds it as "DAILY_<symbol>_<date>"
+// (execution_manager.cpp:147) -- and TREND_FOLLOWING is enabled-live in BOTH the base and
+// conservative books. So a conservative run's pre-insert cleanup could delete
+// BASE_PORTFOLIO's rows for the same symbol and date, and vice versa. The survivor was
+// whichever book ran last, and a DELETE leaves no trace of what it removed.
+//
+// It never fired only because two call sites passed table_name into the strategy_name slot,
+// so the predicate matched nothing. Fixing THAT alone would have armed THIS -- which is why
+// the two changes ship together and why portfolio_id is a required parameter rather than a
+// defaulted one.
+//
+// A mock can only prove the argument reaches the call. Whether the DELETE actually spares
+// the other portfolio's rows is a property of the SQL, so it needs a real server: write two
+// rows that differ ONLY by portfolio_id, delete one book's, and assert the other survives.
+//
+// Writes touch trading.executions only under the scratch identities below, which no live or
+// backtest book uses; every row is removed in TearDown.
+//
+// Reachability gate matches tests/data/test_db_transaction_atomicity.cpp:
+//   * TRADE_NGIN_REQUIRE_DB=1 -- unreachable database FAILS rather than skips.
+//   * unset -- skip (local dev without a server).
+
+#include <gtest/gtest.h>
+#include <pqxx/pqxx>
+#include <chrono>
+#include <cstdlib>
+#include <filesystem>
+#include <fstream>
+#include <memory>
+#include <nlohmann/json.hpp>
+#include <string>
+
+#include "trade_ngin/core/types.hpp"
+#include "trade_ngin/data/postgres_database.hpp"
+
+using namespace trade_ngin;
+
+namespace {
+
+// Deliberately unlike any configured book, but sharing strategy_name and order_id across
+// two portfolios -- which is exactly the collision the live books have for TREND_FOLLOWING.
+constexpr const char* kStrategyId = "F4_SCOPE_PROBE_ID";
+constexpr const char* kStrategyName = "F4_SCOPE_PROBE_NAME";
+constexpr const char* kPortfolioA = "F4_SCOPE_PROBE_PORTFOLIO_A";
+constexpr const char* kPortfolioB = "F4_SCOPE_PROBE_PORTFOLIO_B";
+constexpr const char* kSharedOrderId = "DAILY_F4PROBE_2026-05-04";
+
+std::string discover_connection_string() {
+    namespace fs = std::filesystem;
+    fs::path dir = fs::current_path();
+    for (int i = 0; i < 8 && !dir.empty(); ++i) {
+        fs::path candidate = dir / "config" / "defaults.json";
+        if (fs::exists(candidate)) {
+            try {
+                std::ifstream in(candidate);
+                nlohmann::json j = nlohmann::json::parse(in);
+                const auto& d = j.at("database");
+                return "postgresql://" + d.at("username").get<std::string>() + ":" +
+                       d.at("password").get<std::string>() + "@" +
+                       d.at("host").get<std::string>() + ":" + d.at("port").get<std::string>() +
+                       "/" + d.at("name").get<std::string>();
+            } catch (const std::exception&) {
+                return {};
+            }
+        }
+        dir = dir.parent_path();
+    }
+    return {};
+}
+
+Timestamp date_at(int year, int month, int day) {
+    std::tm tm{};
+    tm.tm_year = year - 1900;
+    tm.tm_mon = month - 1;
+    tm.tm_mday = day;
+    tm.tm_hour = 12;
+    return std::chrono::system_clock::from_time_t(timegm(&tm));
+}
+
+ExecutionReport make_exec(const std::string& symbol) {
+    ExecutionReport e;
+    e.symbol = symbol;
+    e.order_id = kSharedOrderId;
+    e.exec_id = "F4_SCOPE_PROBE_EXEC";
+    e.side = Side::BUY;
+    e.filled_quantity = Quantity(1.0);
+    e.fill_price = Price(100.0);
+    e.fill_time = date_at(2026, 5, 4);
+    e.commissions_fees = Decimal(1.0);
+    e.implicit_price_impact = Decimal(0.0);
+    e.slippage_market_impact = Decimal(0.0);
+    e.total_transaction_costs = Decimal(1.0);
+    e.is_partial = false;
+    return e;
+}
+
+}  // namespace
+
+class DeleteStaleExecutionsScopeTest : public ::testing::Test {
+protected:
+    void SetUp() override {
+        const bool require_db = [] {
+            const char* v = std::getenv("TRADE_NGIN_REQUIRE_DB");
+            return v && std::string(v) == "1";
+        }();
+
+        conn_ = discover_connection_string();
+        if (conn_.empty()) {
+            if (require_db) {
+                FAIL() << "TRADE_NGIN_REQUIRE_DB=1 but config/defaults.json is not reachable, "
+                          "so the E2-F4 portfolio scoping goes unverified";
+            }
+            GTEST_SKIP() << "config/defaults.json not reachable; no database to exercise";
+        }
+        db_ = std::make_shared<PostgresDatabase>(conn_);
+        auto connected = db_->connect();
+        if (connected.is_error() || !db_->is_connected()) {
+            if (require_db) {
+                FAIL() << "TRADE_NGIN_REQUIRE_DB=1 but the database is unreachable, so the "
+                          "E2-F4 portfolio scoping goes unverified";
+            }
+            GTEST_SKIP() << "database unreachable; skipping";
+        }
+        purge();
+    }
+
+    void TearDown() override {
+        if (db_ && db_->is_connected()) purge();
+    }
+
+    void purge() {
+        try {
+            pqxx::connection c(conn_);
+            pqxx::work txn(c);
+            txn.exec("DELETE FROM trading.executions WHERE strategy_id = " +
+                     txn.quote(kStrategyId));
+            txn.commit();
+        } catch (const std::exception&) {
+            // Best-effort cleanup; a failure here must not mask the assertion above.
+        }
+    }
+
+    int count_for(const std::string& portfolio) {
+        pqxx::connection c(conn_);
+        pqxx::work txn(c);
+        auto r = txn.exec("SELECT COUNT(*) FROM trading.executions WHERE strategy_id = " +
+                          txn.quote(kStrategyId) + " AND portfolio_id = " + txn.quote(portfolio));
+        return r[0][0].as<int>();
+    }
+
+    std::string conn_;
+    std::shared_ptr<PostgresDatabase> db_;
+};
+
+// THE REGRESSION. Two rows differing only by portfolio_id; deleting one must spare the other.
+TEST_F(DeleteStaleExecutionsScopeTest, DeletingOnePortfolioLeavesTheOtherIntact) {
+    std::vector<ExecutionReport> execs{make_exec("F4PROBE")};
+
+    ASSERT_FALSE(
+        db_->store_executions(execs, kStrategyId, kStrategyName, kPortfolioA, "trading.executions")
+            .is_error());
+    ASSERT_FALSE(
+        db_->store_executions(execs, kStrategyId, kStrategyName, kPortfolioB, "trading.executions")
+            .is_error());
+
+    ASSERT_EQ(count_for(kPortfolioA), 1) << "setup: portfolio A row did not persist";
+    ASSERT_EQ(count_for(kPortfolioB), 1) << "setup: portfolio B row did not persist";
+
+    // Portfolio A cleans up its own stale executions, using the SAME order_id, strategy_name
+    // and date that portfolio B's row carries.
+    auto del = db_->delete_stale_executions({kSharedOrderId}, date_at(2026, 5, 4), kStrategyName,
+                                            kPortfolioA, "trading.executions");
+    ASSERT_FALSE(del.is_error()) << del.error()->what();
+
+    EXPECT_EQ(count_for(kPortfolioA), 0)
+        << "The delete did not remove its OWN portfolio's row, so the cleanup no longer works "
+           "and a re-run will collide on executions_pkey.";
+    EXPECT_EQ(count_for(kPortfolioB), 1)
+        << "The delete reached across into another portfolio. order_id is portfolio-"
+           "independent and TREND_FOLLOWING runs in both the base and conservative books, so "
+           "without the portfolio predicate a conservative run silently destroys BASE's "
+           "executions for the same symbol and date -- with no trace of what it took.";
+}
+
+// The cleanup must still do its job: a re-run of the same date has to be able to re-insert.
+TEST_F(DeleteStaleExecutionsScopeTest, DeleteThenReinsertSucceedsForTheSameKey) {
+    std::vector<ExecutionReport> execs{make_exec("F4PROBE")};
+
+    ASSERT_FALSE(
+        db_->store_executions(execs, kStrategyId, kStrategyName, kPortfolioA, "trading.executions")
+            .is_error());
+    ASSERT_EQ(count_for(kPortfolioA), 1);
+
+    auto del = db_->delete_stale_executions({kSharedOrderId}, date_at(2026, 5, 4), kStrategyName,
+                                            kPortfolioA, "trading.executions");
+    ASSERT_FALSE(del.is_error()) << del.error()->what();
+
+    auto again =
+        db_->store_executions(execs, kStrategyId, kStrategyName, kPortfolioA, "trading.executions");
+    EXPECT_FALSE(again.is_error())
+        << "Re-insert after cleanup failed, so the date is not re-runnable -- which breaks "
+           "idempotency (protocol 3f) and the replay-the-missed-day remedy for a run gap.";
+    EXPECT_EQ(count_for(kPortfolioA), 1) << "Re-insert should leave exactly one row, not two.";
+}

--- a/tests/data/test_get_trading_days_scope_db.cpp
+++ b/tests/data/test_get_trading_days_scope_db.cpp
@@ -1,0 +1,155 @@
+// E2-F6: trading.get_trading_days() must exist in BOTH forms, and the scoped form must scope.
+//
+// Two distinct things are pinned here, and the first is the one that bites hardest.
+//
+// 1. THE FUNCTION MUST EXIST. Both overloads were created by hand against the live server and
+//    lived nowhere in the repository until migrations/004. That matters because the failure
+//    mode when it is absent is SILENT: the runners initialise `trading_days_count = 1` and
+//    only overwrite it if the query succeeds, so a missing function leaves the count at 1,
+//    nothing throws, the run exits 0, and five stored columns are corrupted --
+//    total_annualized_return, sharpe_ratio, sortino_ratio, total_days, and win_rate (which
+//    becomes winning_days * 100, roughly 9000%). A DB rebuilt without 004 fails exactly this
+//    way, and this test is what catches it.
+//
+// 2. THE SCOPED FORM MUST SCOPE. The 2-arg form keys on strategy_id alone with
+//    `ORDER BY live_start_date LIMIT 1` and no portfolio predicate, so it takes the earliest
+//    row across ALL portfolios. LIVE_EQUITY_MEAN_REVERSION unscoped anchors to a stale
+//    2025-08-15 BASE_PORTFOLIO row and reports 356 days against a 10-day series -- a 36x
+//    understatement of annualized return (E2/B4).
+//
+// Read-only: calls the function, touches no table.
+//
+// Reachability gate matches tests/data/test_db_transaction_atomicity.cpp:
+//   * TRADE_NGIN_REQUIRE_DB=1 -- unreachable database FAILS rather than skips.
+//   * unset -- skip (local dev without a server).
+
+#include <gtest/gtest.h>
+#include <pqxx/pqxx>
+#include <cstdlib>
+#include <filesystem>
+#include <fstream>
+#include <nlohmann/json.hpp>
+#include <string>
+
+namespace {
+
+std::string discover_connection_string() {
+    namespace fs = std::filesystem;
+    fs::path dir = fs::current_path();
+    for (int i = 0; i < 8 && !dir.empty(); ++i) {
+        fs::path candidate = dir / "config" / "defaults.json";
+        if (fs::exists(candidate)) {
+            try {
+                std::ifstream in(candidate);
+                nlohmann::json j = nlohmann::json::parse(in);
+                const auto& d = j.at("database");
+                return "postgresql://" + d.at("username").get<std::string>() + ":" +
+                       d.at("password").get<std::string>() + "@" +
+                       d.at("host").get<std::string>() + ":" + d.at("port").get<std::string>() +
+                       "/" + d.at("name").get<std::string>();
+            } catch (const std::exception&) {
+                return {};
+            }
+        }
+        dir = dir.parent_path();
+    }
+    return {};
+}
+
+}  // namespace
+
+class GetTradingDaysScopeTest : public ::testing::Test {
+protected:
+    void SetUp() override {
+        const bool require_db = [] {
+            const char* v = std::getenv("TRADE_NGIN_REQUIRE_DB");
+            return v && std::string(v) == "1";
+        }();
+        conn_ = discover_connection_string();
+        if (conn_.empty()) {
+            if (require_db) FAIL() << "TRADE_NGIN_REQUIRE_DB=1 but config/defaults.json is "
+                                      "unreachable; E2-F6 scoping goes unverified";
+            GTEST_SKIP() << "config/defaults.json not reachable";
+        }
+        try {
+            c_ = std::make_unique<pqxx::connection>(conn_);
+        } catch (const std::exception& e) {
+            if (require_db) FAIL() << "TRADE_NGIN_REQUIRE_DB=1 but the database is unreachable: "
+                                   << e.what();
+            GTEST_SKIP() << "database unreachable";
+        }
+    }
+
+    int overload_count() {
+        pqxx::work txn(*c_);
+        return txn
+            .exec("SELECT count(*) FROM pg_proc p JOIN pg_namespace n ON n.oid = p.pronamespace "
+                  "WHERE n.nspname='trading' AND p.proname='get_trading_days'")[0][0]
+            .as<int>();
+    }
+
+    std::string conn_;
+    std::unique_ptr<pqxx::connection> c_;
+};
+
+// The migrations/004 guarantee. If this fails on a fresh environment, 004 was not applied and
+// every futures annualization figure is about to be silently wrong.
+TEST_F(GetTradingDaysScopeTest, BothOverloadsExist) {
+    EXPECT_EQ(overload_count(), 2)
+        << "trading.get_trading_days does not have both a 2-arg and a 3-arg overload. The "
+           "runners will leave trading_days_count at 1 and exit 0 with corrupted "
+           "total_annualized_return / sharpe_ratio / sortino_ratio / total_days / win_rate. "
+           "Apply migrations/004_get_trading_days_portfolio_scope.sql.";
+}
+
+// The scoped form must actually consult portfolio_id, not merely accept it.
+TEST_F(GetTradingDaysScopeTest, ScopedFormDistinguishesPortfolios) {
+    pqxx::work txn(*c_);
+    // LIVE_EQUITY_MEAN_REVERSION has a real EQUITY_MR_PORTFOLIO row and a stale legacy
+    // BASE_PORTFOLIO row, so the two scopes must disagree. If they agree, the predicate is
+    // being ignored.
+    const int eq = txn.exec("SELECT trading.get_trading_days('LIVE_EQUITY_MEAN_REVERSION', "
+                            "DATE '2026-05-03', 'EQUITY_MR_PORTFOLIO')")[0][0]
+                       .as<int>();
+    const int base = txn.exec("SELECT trading.get_trading_days('LIVE_EQUITY_MEAN_REVERSION', "
+                              "DATE '2026-05-03', 'BASE_PORTFOLIO')")[0][0]
+                         .as<int>();
+
+    EXPECT_NE(eq, base)
+        << "The 3-arg form returned the same answer for two different portfolios, so it is "
+           "not scoping. Unscoped, this strategy anchors to a stale 2025-08-15 BASE_PORTFOLIO "
+           "row and reports 356 days against a 10-day series (E2/B4).";
+}
+
+// The repoint's falsifiable prediction: futures numbers must NOT move. Both
+// LIVE_TREND_FOLLOWING metadata rows carry live_start_date = 2025-10-05, so scoped and
+// unscoped agree -- today. If this ever fails, that coincidence has ended and the futures
+// annualization has silently changed.
+TEST_F(GetTradingDaysScopeTest, FuturesScopedAndUnscopedStillAgree) {
+    pqxx::work txn(*c_);
+    for (const char* date : {"2026-05-03", "2026-09-01", "2027-01-01"}) {
+        const std::string d = std::string("DATE '") + date + "'";
+
+        const int cons_old =
+            txn.exec("SELECT trading.get_trading_days('LIVE_TREND_FOLLOWING', " + d + ")")[0][0]
+                .as<int>();
+        const int cons_new = txn.exec("SELECT trading.get_trading_days('LIVE_TREND_FOLLOWING', " +
+                                      d + ", 'CONSERVATIVE_PORTFOLIO')")[0][0]
+                                 .as<int>();
+        EXPECT_EQ(cons_old, cons_new)
+            << "Conservative futures annualization moved at " << date
+            << " when the runners were repointed to the scoped form. The two "
+               "LIVE_TREND_FOLLOWING metadata rows no longer share live_start_date, so the "
+               "no-movement assumption behind E2-F6 has ended -- investigate before shipping.";
+
+        const int base_old = txn.exec("SELECT trading.get_trading_days('LIVE_TREND_FOLLOWING_"
+                                      "TREND_FOLLOWING_FAST', " +
+                                      d + ")")[0][0]
+                                 .as<int>();
+        const int base_new = txn.exec("SELECT trading.get_trading_days('LIVE_TREND_FOLLOWING_"
+                                      "TREND_FOLLOWING_FAST', " +
+                                      d + ", 'BASE_PORTFOLIO')")[0][0]
+                                 .as<int>();
+        EXPECT_EQ(base_old, base_new) << "Base futures annualization moved at " << date << ".";
+    }
+}

--- a/tests/live/corp_actions/test_effect_classes.cpp
+++ b/tests/live/corp_actions/test_effect_classes.cpp
@@ -383,3 +383,72 @@ TEST(CorpActionClass3, EventForAnUnheldSymbolIsANoOp) {
     EXPECT_EQ(positions.size(), 1u);
     EXPECT_DOUBLE_EQ(positions["HELD"].quantity.as_double(), 10.0);
 }
+
+// ===========================================================================
+// E2-F13: TERMINATION round-trips through the dedup record.
+//
+// Class-3 lifecycle events (delisting / acquisition) were recorded NOWHERE. audit_log.record()
+// was called only from the class-1 applier block, so a termination left no row in
+// trading.corp_action_applied -- no audit trail, and nothing to stop a replay re-applying it.
+// Class-1 events have been deduped since the dedup table landed; class 3 never was.
+//
+// The dedup key is (symbol, event_date, type) and the type is persisted as a STRING, so the
+// enum <-> string round trip is what makes a recorded termination findable again. If
+// type_from_type_string does not know "TERMINATION" it silently degrades to UNKNOWN, the key
+// no longer matches, and the dedup protection evaporates without any error.
+// ===========================================================================
+
+TEST(CorpActionTypeRoundTrip, TerminationSurvivesTheStringRoundTrip) {
+    const char* s = CorporateActionsApplier::type_to_string(CorpActionType::TERMINATION);
+    EXPECT_STREQ(s, "TERMINATION");
+
+    EXPECT_EQ(CorporateActionsApplier::type_from_type_string(s), CorpActionType::TERMINATION)
+        << "A recorded TERMINATION does not round-trip, so its dedup key will not match on the "
+           "next run and the event can be applied twice.";
+}
+
+TEST(CorpActionTypeRoundTrip, ExistingTypesAreUnaffectedByTheNewValue) {
+    // Adding an enum value must not disturb the values already persisted in
+    // trading.corp_action_applied.
+    for (auto t : {CorpActionType::SPLIT, CorpActionType::ADR_SPLIT, CorpActionType::DIVIDEND,
+                   CorpActionType::UNKNOWN}) {
+        EXPECT_EQ(CorporateActionsApplier::type_from_type_string(
+                      CorporateActionsApplier::type_to_string(t)),
+                  t)
+            << "An existing corp-action type stopped round-tripping when TERMINATION was added.";
+    }
+}
+
+TEST(CorpActionTypeRoundTrip, UnknownStringsStillDegradeToUnknown) {
+    EXPECT_EQ(CorporateActionsApplier::type_from_type_string("NOT_A_TYPE"),
+              CorpActionType::UNKNOWN)
+        << "An unrecognised type string must degrade to UNKNOWN so an older binary reading a "
+           "newer row fails safe rather than mis-classifying it.";
+}
+
+// The applier must not try to price-restate a lifecycle event. TERMINATION exists in the enum
+// only so class-3 events can be recorded and deduped; CorporateActionsLifecycle applies them.
+TEST(CorpActionTypeRoundTrip, ApplierSkipsTerminationRatherThanRestatingPrice) {
+    std::unordered_map<std::string, Position> positions;
+    Position p;
+    p.symbol = "DEAD";
+    p.quantity = Quantity(10.0);
+    p.average_price = Decimal(100.0);
+    positions["DEAD"] = p;
+
+    CorpActionEvent ev;
+    ev.symbol = "DEAD";
+    ev.ex_date = "2026-04-09";
+    ev.type = CorpActionType::TERMINATION;
+    ev.value = 50.0;  // would be read as a split factor if the applier mishandled it
+
+    auto adjustments = CorporateActionsApplier::apply(positions, {ev});
+
+    EXPECT_TRUE(adjustments.empty())
+        << "The applier produced an adjustment for a TERMINATION. Class-3 events belong to "
+           "CorporateActionsLifecycle; treating one as price-restating would multiply the "
+           "quantity by the exit price.";
+    EXPECT_DOUBLE_EQ(static_cast<double>(positions["DEAD"].quantity), 10.0)
+        << "The applier mutated a position on a TERMINATION event.";
+    EXPECT_DOUBLE_EQ(static_cast<double>(positions["DEAD"].average_price), 100.0);
+}

--- a/tests/live/corp_actions/test_ex_date_eligibility.cpp
+++ b/tests/live/corp_actions/test_ex_date_eligibility.cpp
@@ -1,37 +1,36 @@
-// E2-F17 regression pins — a corporate action must not restate a position the book did not
-// hold on the ex-date.
+// E2-F17 regression pins — a corporate action must not restate a cost basis that was formed
+// AFTER its ex-date.
 //
-// THE FAILURE, measured over an 82-day live replay (2026-04-10 .. 2026-06-30), the same run
-// that validated the E2-F15 horizon gate. FOUR of the six dividends applied were applied to
-// positions held on no part of their ex-date:
-//
-//   symbol  ex_date       applied on    held at ex-date?
-//   ABT     2026-04-15    2026-04-18    no  -- first held 04-17, two days AFTER
-//   AAPL    2026-05-11    2026-06-11    no  -- a month late
-//   DD      2026-05-15    2026-06-12    no
-//   TMUS    2026-05-29    2026-06-05    no
-//   GOOGL   2026-06-08    2026-06-09    YES -- legitimate
-//   META    2026-06-15    2026-06-16    YES -- legitimate
-//
-// The book was verifiably flat 2026-05-04..05-16 while runs were happening, so these are not
-// missing-history artefacts. ABT alone moved the basis 95.47 -> 94.881429 and put +$33.79 of
+// THE ORIGINAL FAILURE, measured over an 82-day live replay: FOUR of six dividends applied were
+// applied to positions held on no part of their ex-date. ABT's 04-15 dividend restated a
+// position first held on 04-17, moving the basis 95.47 -> 94.881429 and putting +$33.79 of
 // unrealized that does not exist onto the equity curve -- permanently, once the position sells,
 // because the sale's realized is then struck against a fabricated basis.
 //
-// WHY IT HAPPENED. The applier walks CURRENTLY-held symbols and applies any event inside the
-// fetch window [ex_date-14d, today]. A position opened after the ex-date was bought at a price
-// the market had ALREADY adjusted, so restating it is a second, unearned adjustment. For a
-// strategy that opens and closes names continuously this is ordinary, not exotic.
+// THE FIRST FIX WAS WRONG IN TWO WAYS, and this file exists in its current form because of them:
 //
-// The engine already detected it -- `qty_at_ex_date` was 0 and it logged a warning on exactly
-// those four and on neither of the other two -- but the fallback only substituted today's
-// quantity into the CASH figure. The old comment said so outright: "The basis adjustment is
-// unaffected." That sentence was the bug.
+//   1. It was INERT FOR SPLITS. The runner only populated the signal inside its DIVIDEND
+//      branch, so splits and ADR splits always reached the applier with the default and the
+//      guard could never fire -- leaving the catastrophic case (a 25:1 split restating a
+//      post-ex-date basis by 2400%) unguarded while the dividend case looked covered.
 //
-// WHY THE FIX IS GATED. `qty_at_ex_date == 0` alone is ambiguous: it means either "genuinely
-// flat" or "nothing is known about that date". Skipping on the second would DROP real
-// adjustments, which is the worse failure. `book_state_known_at_ex_date` is the positive
-// signal that the book state was actually observed.
+//      *** THE PREVIOUS VERSION OF THIS FILE HAD A TEST NAMED "TheRuleCoversSplitsNotJustDividends"
+//      *** AND IT PASSED THE WHOLE TIME. It constructed the event directly, so it proved the
+//      *** APPLIER was type-agnostic -- which was true -- while production could never reach
+//      *** that state. Every test below has the same blind spot BY CONSTRUCTION: they pin the
+//      *** applier's RULE, and they cannot see whether the runner populates the input. Only the
+//      *** live replay can. Do not read a green run here as coverage of the wiring.
+//
+//   2. Its cutoff date was OFF BY ONE, in the drop-a-real-adjustment direction. It measured the
+//      book at `ex_date - 1`, which is the cash-eligibility cutoff for a DIVIDEND, not the
+//      basis frame. A fill on run D is priced at close(D-1), so a position opened ON the
+//      ex-date run has a PRE-event basis and must still be restated; the old rule called it
+//      "flat at the ex-date" and skipped it.
+//
+// THE RULE NOW: contaminated <=> the basis was formed after the ex-date, carried as a tri-state
+// so that "no evidence" can never be mistaken for "verifiably flat". Dropping a real 25:1 split
+// leaves basis and mark 25x apart -- strictly worse than the double-adjustment being prevented
+// -- so UNKNOWN must APPLY.
 
 #include <gtest/gtest.h>
 
@@ -44,6 +43,8 @@
 using namespace trade_ngin;
 
 namespace {
+
+using Provenance = CorpActionEvent::BasisProvenance;
 
 // Real ABT numbers from the failure.
 constexpr double kQtyNow = 57.412048;
@@ -60,111 +61,124 @@ Position held(const std::string& sym, double qty, double avg) {
     return p;
 }
 
-CorpActionEvent dividend_event(double qty_at_ex, bool book_known) {
+CorpActionEvent dividend_event(Provenance prov) {
     CorpActionEvent ev;
     ev.symbol = "ABT";
     ev.ex_date = kExDate;
     ev.type = CorpActionType::DIVIDEND;
     ev.value = kDividend;
     ev.close_at_ex_date = kCloseAtEx;
-    ev.qty_at_ex_date = qty_at_ex;
-    ev.book_state_known_at_ex_date = book_known;
+    ev.qty_at_ex_date = kQtyNow;   // cash-flow figure only; must NOT gate eligibility
+    ev.basis_provenance = prov;
     return ev;
 }
 
-CorpActionEvent split_event(double qty_at_ex, bool book_known) {
+CorpActionEvent split_event(Provenance prov) {
     CorpActionEvent ev;
     ev.symbol = "BKNG";
     ev.ex_date = "2026-04-06";
     ev.type = CorpActionType::SPLIT;
     ev.value = 25.0;
-    ev.qty_at_ex_date = qty_at_ex;
-    ev.book_state_known_at_ex_date = book_known;
+    ev.basis_provenance = prov;
     return ev;
 }
 
 }  // namespace
 
 // ---------------------------------------------------------------------------
-// THE FIX. Verifiably flat at the ex-date -> the event must not touch the basis.
+// 1. THE FIX. Positive evidence of a post-ex-date basis -> refuse.
 // ---------------------------------------------------------------------------
 
-TEST(CorpActionExDateEligibility, VerifiablyFlatAtExDateSkipsTheEvent) {
+TEST(CorpActionExDateEligibility, BasisFormedAfterExDateSkipsTheEvent) {
     std::unordered_map<std::string, Position> positions{
         {"ABT", held("ABT", kQtyNow, kBasisPostEx)}};
 
-    auto adjustments =
-        CorporateActionsApplier::apply(positions, {dividend_event(0.0, /*book_known=*/true)});
+    auto adjustments = CorporateActionsApplier::apply(
+        positions, {dividend_event(Provenance::FORMED_AFTER_EX_DATE)});
 
     EXPECT_TRUE(adjustments.empty())
-        << "A dividend was applied to a position the book is on record as not holding at the "
-           "ex-date. This is the ABT case: bought 04-17 at a price already ex-dividend.";
-
+        << "A dividend was applied to a basis formed after the ex-date. This is the ABT case: "
+           "bought 04-17 at a price already ex-dividend.";
     EXPECT_DOUBLE_EQ(static_cast<double>(positions["ABT"].average_price), kBasisPostEx)
         << "The basis was restated for a dividend never received. Pre-fix this moved "
            "95.47 -> 94.881429, worth +$33.79 of unrealized that does not exist.";
-    EXPECT_DOUBLE_EQ(static_cast<double>(positions["ABT"].quantity), kQtyNow);
 }
 
-// The same rule must cover splits, where the magnitude is catastrophic rather than small.
-TEST(CorpActionExDateEligibility, TheRuleCoversSplitsNotJustDividends) {
+TEST(CorpActionExDateEligibility, TheApplierRuleIsTypeAgnostic) {
+    // NOTE: this proves the APPLIER treats a split like a dividend. It does NOT prove the
+    // runner populates provenance for splits -- the exact gap that shipped. See the header.
     std::unordered_map<std::string, Position> positions{
-        {"BKNG", held("BKNG", 30.0, 167.7724)}};   // bought AFTER the split, post-split price
+        {"BKNG", held("BKNG", 30.0, 167.7724)}};   // bought post-split, at post-split prices
 
-    auto adjustments =
-        CorporateActionsApplier::apply(positions, {split_event(0.0, /*book_known=*/true)});
+    auto adjustments = CorporateActionsApplier::apply(
+        positions, {split_event(Provenance::FORMED_AFTER_EX_DATE)});
 
     EXPECT_TRUE(adjustments.empty());
     EXPECT_DOUBLE_EQ(static_cast<double>(positions["BKNG"].quantity), 30.0)
         << "A 25:1 split was applied to a position bought after the ex-date at post-split "
-           "prices. That multiplies a correct book by 25 -- the same class of error as F15, "
-           "reached from the other direction.";
+           "prices, multiplying a correct book by 25.";
     EXPECT_DOUBLE_EQ(static_cast<double>(positions["BKNG"].average_price), 167.7724);
 }
 
 // ---------------------------------------------------------------------------
-// THE TWO WAYS THE FIX COULD BE WORSE THAN THE BUG.
+// 2. THE TWO WAYS THE FIX COULD BE WORSE THAN THE BUG. Both must hold.
 // ---------------------------------------------------------------------------
 
-// 1. A position genuinely held at the ex-date must still be adjusted. GOOGL and META in the
-//    replay are this case, and they were correct before the fix and must stay correct.
-TEST(CorpActionExDateEligibility, HeldAtExDateStillApplies) {
+// A basis formed on or before the ex-date is exactly what the event is FOR.
+TEST(CorpActionExDateEligibility, BasisFormedOnOrBeforeExDateStillApplies) {
     std::unordered_map<std::string, Position> positions{
         {"ABT", held("ABT", kQtyNow, kBasisPostEx)}};
 
-    auto adjustments =
-        CorporateActionsApplier::apply(positions, {dividend_event(kQtyNow, /*book_known=*/true)});
+    auto adjustments = CorporateActionsApplier::apply(
+        positions, {dividend_event(Provenance::FORMED_ON_OR_BEFORE_EX_DATE)});
 
     ASSERT_EQ(adjustments.size(), 1u)
-        << "A dividend on a position genuinely held at the ex-date was skipped. The fix must "
-           "not drop real adjustments -- that is worse than the bug it replaces.";
+        << "A dividend on a legitimately pre-event basis was skipped. Dropping a real "
+           "adjustment is worse than the bug this replaces.";
 
-    // 1e-6 not 1e-9: the applier rounds the restated basis, so the two differ at the 9th
-    // decimal. That is a rounding artefact, not a basis error -- the defect this file exists
-    // for moves the basis by 0.59, six orders of magnitude above this tolerance.
+    // 1e-6 not 1e-9: the applier rounds the restated basis. The defect this file exists for
+    // moves the basis by 0.59, six orders of magnitude above this tolerance.
     const double ratio = 1.0 + kDividend / kCloseAtEx;
     EXPECT_NEAR(static_cast<double>(positions["ABT"].average_price), kBasisPostEx / ratio, 1e-6);
 }
 
-// 2. UNKNOWN must not be read as flat. A thin or absent position history is exactly when a
-//    catch-up matters most, and silently skipping there would lose real adjustments with
-//    nothing to indicate it. Unknown keeps the historical behaviour: apply, and warn.
-TEST(CorpActionExDateEligibility, UnknownBookStateStillAppliesAndDoesNotSilentlyDrop) {
+// UNKNOWN must APPLY. This is the tri-state's entire reason for existing: the predecessor was a
+// bool, and a bool cannot tell "observed flat" from "nothing known".
+TEST(CorpActionExDateEligibility, UnknownProvenanceAppliesAndNeverSilentlyDrops) {
+    std::unordered_map<std::string, Position> positions{
+        {"ABT", held("ABT", kQtyNow, kBasisPostEx)},
+        {"BKNG", held("BKNG", 10.0, 4194.31)}};
+
+    auto adjustments = CorporateActionsApplier::apply(
+        positions, {dividend_event(Provenance::UNKNOWN), split_event(Provenance::UNKNOWN)});
+
+    ASSERT_EQ(adjustments.size(), 2u)
+        << "An unknown basis provenance was treated as contaminated and the events were "
+           "dropped. Only POSITIVE evidence may skip -- a missing signal must apply, because "
+           "a dropped 25:1 split leaves basis and mark 25x apart.";
+    EXPECT_NEAR(static_cast<double>(positions["BKNG"].quantity), 250.0, 1e-9);
+}
+
+TEST(CorpActionExDateEligibility, DefaultProvenanceIsUnknownSoLegacyCallersApply) {
+    CorpActionEvent ev;
+    EXPECT_EQ(ev.basis_provenance, Provenance::UNKNOWN)
+        << "The default must be UNKNOWN. A caller that does not populate provenance must keep "
+           "applying events, never start skipping them.";
+}
+
+// The cash-flow figure must not be re-purposed as an eligibility signal -- conflating the two
+// dates is precisely how the shipped guard came to skip positions it should have restated.
+TEST(CorpActionExDateEligibility, QtyAtExDateDoesNotGateEligibility) {
     std::unordered_map<std::string, Position> positions{
         {"ABT", held("ABT", kQtyNow, kBasisPostEx)}};
 
-    auto adjustments =
-        CorporateActionsApplier::apply(positions, {dividend_event(0.0, /*book_known=*/false)});
+    auto ev = dividend_event(Provenance::FORMED_ON_OR_BEFORE_EX_DATE);
+    ev.qty_at_ex_date = 0.0;    // no holding on the register at ex_date-1 ...
+
+    auto adjustments = CorporateActionsApplier::apply(positions, {ev});
 
     ASSERT_EQ(adjustments.size(), 1u)
-        << "An unknown ex-date book state was treated as 'flat' and the event was dropped. "
-           "Only a POSITIVE observation that the book held nothing may skip an event.";
-}
-
-// The default must be the safe one, so any caller that never sets the field keeps working.
-TEST(CorpActionExDateEligibility, DefaultIsUnknownSoLegacyCallersAreUnaffected) {
-    CorpActionEvent ev;
-    EXPECT_FALSE(ev.book_state_known_at_ex_date)
-        << "book_state_known_at_ex_date must default to false. A caller that does not populate "
-           "it would otherwise start skipping every event for a symbol it holds.";
+        << "... but the basis is pre-event, so the event MUST still apply. A position opened ON "
+           "the ex-date run is exactly this case: it is absent at ex_date-1 yet its fill was "
+           "priced at close(ex_date-1), which is pre-event.";
 }

--- a/tests/live/corp_actions/test_ex_date_eligibility.cpp
+++ b/tests/live/corp_actions/test_ex_date_eligibility.cpp
@@ -1,0 +1,170 @@
+// E2-F17 regression pins — a corporate action must not restate a position the book did not
+// hold on the ex-date.
+//
+// THE FAILURE, measured over an 82-day live replay (2026-04-10 .. 2026-06-30), the same run
+// that validated the E2-F15 horizon gate. FOUR of the six dividends applied were applied to
+// positions held on no part of their ex-date:
+//
+//   symbol  ex_date       applied on    held at ex-date?
+//   ABT     2026-04-15    2026-04-18    no  -- first held 04-17, two days AFTER
+//   AAPL    2026-05-11    2026-06-11    no  -- a month late
+//   DD      2026-05-15    2026-06-12    no
+//   TMUS    2026-05-29    2026-06-05    no
+//   GOOGL   2026-06-08    2026-06-09    YES -- legitimate
+//   META    2026-06-15    2026-06-16    YES -- legitimate
+//
+// The book was verifiably flat 2026-05-04..05-16 while runs were happening, so these are not
+// missing-history artefacts. ABT alone moved the basis 95.47 -> 94.881429 and put +$33.79 of
+// unrealized that does not exist onto the equity curve -- permanently, once the position sells,
+// because the sale's realized is then struck against a fabricated basis.
+//
+// WHY IT HAPPENED. The applier walks CURRENTLY-held symbols and applies any event inside the
+// fetch window [ex_date-14d, today]. A position opened after the ex-date was bought at a price
+// the market had ALREADY adjusted, so restating it is a second, unearned adjustment. For a
+// strategy that opens and closes names continuously this is ordinary, not exotic.
+//
+// The engine already detected it -- `qty_at_ex_date` was 0 and it logged a warning on exactly
+// those four and on neither of the other two -- but the fallback only substituted today's
+// quantity into the CASH figure. The old comment said so outright: "The basis adjustment is
+// unaffected." That sentence was the bug.
+//
+// WHY THE FIX IS GATED. `qty_at_ex_date == 0` alone is ambiguous: it means either "genuinely
+// flat" or "nothing is known about that date". Skipping on the second would DROP real
+// adjustments, which is the worse failure. `book_state_known_at_ex_date` is the positive
+// signal that the book state was actually observed.
+
+#include <gtest/gtest.h>
+
+#include <string>
+#include <unordered_map>
+
+#include "trade_ngin/core/types.hpp"
+#include "trade_ngin/live/corporate_actions_applier.hpp"
+
+using namespace trade_ngin;
+
+namespace {
+
+// Real ABT numbers from the failure.
+constexpr double kQtyNow = 57.412048;
+constexpr double kBasisPostEx = 95.47;        // close(2026-04-16), already ex-dividend
+constexpr double kDividend = 0.63;
+constexpr double kCloseAtEx = 101.56;         // close(2026-04-15)
+constexpr const char* kExDate = "2026-04-15";
+
+Position held(const std::string& sym, double qty, double avg) {
+    Position p;
+    p.symbol = sym;
+    p.quantity = Quantity(qty);
+    p.average_price = Decimal(avg);
+    return p;
+}
+
+CorpActionEvent dividend_event(double qty_at_ex, bool book_known) {
+    CorpActionEvent ev;
+    ev.symbol = "ABT";
+    ev.ex_date = kExDate;
+    ev.type = CorpActionType::DIVIDEND;
+    ev.value = kDividend;
+    ev.close_at_ex_date = kCloseAtEx;
+    ev.qty_at_ex_date = qty_at_ex;
+    ev.book_state_known_at_ex_date = book_known;
+    return ev;
+}
+
+CorpActionEvent split_event(double qty_at_ex, bool book_known) {
+    CorpActionEvent ev;
+    ev.symbol = "BKNG";
+    ev.ex_date = "2026-04-06";
+    ev.type = CorpActionType::SPLIT;
+    ev.value = 25.0;
+    ev.qty_at_ex_date = qty_at_ex;
+    ev.book_state_known_at_ex_date = book_known;
+    return ev;
+}
+
+}  // namespace
+
+// ---------------------------------------------------------------------------
+// THE FIX. Verifiably flat at the ex-date -> the event must not touch the basis.
+// ---------------------------------------------------------------------------
+
+TEST(CorpActionExDateEligibility, VerifiablyFlatAtExDateSkipsTheEvent) {
+    std::unordered_map<std::string, Position> positions{
+        {"ABT", held("ABT", kQtyNow, kBasisPostEx)}};
+
+    auto adjustments =
+        CorporateActionsApplier::apply(positions, {dividend_event(0.0, /*book_known=*/true)});
+
+    EXPECT_TRUE(adjustments.empty())
+        << "A dividend was applied to a position the book is on record as not holding at the "
+           "ex-date. This is the ABT case: bought 04-17 at a price already ex-dividend.";
+
+    EXPECT_DOUBLE_EQ(static_cast<double>(positions["ABT"].average_price), kBasisPostEx)
+        << "The basis was restated for a dividend never received. Pre-fix this moved "
+           "95.47 -> 94.881429, worth +$33.79 of unrealized that does not exist.";
+    EXPECT_DOUBLE_EQ(static_cast<double>(positions["ABT"].quantity), kQtyNow);
+}
+
+// The same rule must cover splits, where the magnitude is catastrophic rather than small.
+TEST(CorpActionExDateEligibility, TheRuleCoversSplitsNotJustDividends) {
+    std::unordered_map<std::string, Position> positions{
+        {"BKNG", held("BKNG", 30.0, 167.7724)}};   // bought AFTER the split, post-split price
+
+    auto adjustments =
+        CorporateActionsApplier::apply(positions, {split_event(0.0, /*book_known=*/true)});
+
+    EXPECT_TRUE(adjustments.empty());
+    EXPECT_DOUBLE_EQ(static_cast<double>(positions["BKNG"].quantity), 30.0)
+        << "A 25:1 split was applied to a position bought after the ex-date at post-split "
+           "prices. That multiplies a correct book by 25 -- the same class of error as F15, "
+           "reached from the other direction.";
+    EXPECT_DOUBLE_EQ(static_cast<double>(positions["BKNG"].average_price), 167.7724);
+}
+
+// ---------------------------------------------------------------------------
+// THE TWO WAYS THE FIX COULD BE WORSE THAN THE BUG.
+// ---------------------------------------------------------------------------
+
+// 1. A position genuinely held at the ex-date must still be adjusted. GOOGL and META in the
+//    replay are this case, and they were correct before the fix and must stay correct.
+TEST(CorpActionExDateEligibility, HeldAtExDateStillApplies) {
+    std::unordered_map<std::string, Position> positions{
+        {"ABT", held("ABT", kQtyNow, kBasisPostEx)}};
+
+    auto adjustments =
+        CorporateActionsApplier::apply(positions, {dividend_event(kQtyNow, /*book_known=*/true)});
+
+    ASSERT_EQ(adjustments.size(), 1u)
+        << "A dividend on a position genuinely held at the ex-date was skipped. The fix must "
+           "not drop real adjustments -- that is worse than the bug it replaces.";
+
+    // 1e-6 not 1e-9: the applier rounds the restated basis, so the two differ at the 9th
+    // decimal. That is a rounding artefact, not a basis error -- the defect this file exists
+    // for moves the basis by 0.59, six orders of magnitude above this tolerance.
+    const double ratio = 1.0 + kDividend / kCloseAtEx;
+    EXPECT_NEAR(static_cast<double>(positions["ABT"].average_price), kBasisPostEx / ratio, 1e-6);
+}
+
+// 2. UNKNOWN must not be read as flat. A thin or absent position history is exactly when a
+//    catch-up matters most, and silently skipping there would lose real adjustments with
+//    nothing to indicate it. Unknown keeps the historical behaviour: apply, and warn.
+TEST(CorpActionExDateEligibility, UnknownBookStateStillAppliesAndDoesNotSilentlyDrop) {
+    std::unordered_map<std::string, Position> positions{
+        {"ABT", held("ABT", kQtyNow, kBasisPostEx)}};
+
+    auto adjustments =
+        CorporateActionsApplier::apply(positions, {dividend_event(0.0, /*book_known=*/false)});
+
+    ASSERT_EQ(adjustments.size(), 1u)
+        << "An unknown ex-date book state was treated as 'flat' and the event was dropped. "
+           "Only a POSITIVE observation that the book held nothing may skip an event.";
+}
+
+// The default must be the safe one, so any caller that never sets the field keeps working.
+TEST(CorpActionExDateEligibility, DefaultIsUnknownSoLegacyCallersAreUnaffected) {
+    CorpActionEvent ev;
+    EXPECT_FALSE(ev.book_state_known_at_ex_date)
+        << "book_state_known_at_ex_date must default to false. A caller that does not populate "
+           "it would otherwise start skipping every event for a symbol it holds.";
+}

--- a/tests/live/corp_actions/test_frame_horizon.cpp
+++ b/tests/live/corp_actions/test_frame_horizon.cpp
@@ -1,0 +1,340 @@
+// E2-F15 regression pins — a corp-action restatement must not put the position and the price
+// series in different unit frames.
+//
+// THE FAILURE, from a real run (2026-09-01 10:09, R4 window, log r4d/2026-04-06.log):
+//
+//   Applied SPLIT for BKNG (ex_date 2026-04-06): qty 10 -> 250, avg_price 4194.31 -> 167.7724
+//   Generated execution: BKNG SELL 248.799399 at 4194.31        <-- PRE-split price
+//   Day T position for BKNG: qty=1.200601 realized_pnl=1001584.464342
+//
+// $1,001,800 gross realized P&L on a $100,000 book. `4194.31 / 25 = 167.7724` exactly: the
+// price was 25x too large because the position moved into post-split units and the price
+// series did not.
+//
+// WHY IT HAPPENED. Two windows, each individually correct:
+//   * the corp-action fetch reads split_factor from the ex-date bar ROW, so it spans day D --
+//     legitimate, split ratios are announced weeks ahead and using one is not lookahead;
+//   * the bar load ends at the last completed session on a replay (`end_date = now - 24h`),
+//     and build_equity_adjusted_query back-adjusts a bar by the steps of every LATER bar, so
+//     with the ex-date bar outside the window there is no step and the closes stay raw.
+// Nothing rescaled the prices to match the restated basis.
+//
+// THE FIX is a horizon gate, not a rescale: only apply an event the price series already
+// covers. Rescaling the price maps instead would corrupt finalize_previous_day, which marks
+// `previous_positions_pre_action` and MUST stay pre-event -- that would trade a $1M error for
+// a $40k one.
+//
+// WHY THESE TESTS EXIST AT ALL. Every invariant the E2 fix wave added PASSES on the bad
+// number at HEAD: L5 rows-sum-to-aggregate, `total_pnl = (realized - costs) + unrealized`,
+// `equity = initial + total_pnl`, and the daily-flow identity. They are all INTERNAL
+// consistency checks and the wrong number is consistently wrong everywhere. The first test
+// below is the missing statement -- the only one that compares a restatement against
+// something outside itself.
+
+#include <gtest/gtest.h>
+
+#include <cmath>
+#include <string>
+#include <unordered_map>
+
+#include "trade_ngin/core/types.hpp"
+#include "trade_ngin/live/corporate_actions_applier.hpp"
+
+using namespace trade_ngin;
+
+namespace {
+
+// Real numbers from the BKNG failure, so the fixture cannot drift from what production did.
+constexpr double kQtyBefore = 10.0;
+constexpr double kBasisBefore = 4194.31;     // 2026-04-02 close, pre-split
+constexpr double kSplitRatio = 25.0;         // ex-date 2026-04-06
+constexpr double kBasisAfter = 167.7724;     // 4194.31 / 25, exactly
+constexpr const char* kExDate = "2026-04-06";
+constexpr const char* kLastLoadedBar = "2026-04-02";   // the horizon on a replay for 04-06
+
+Position held(double qty, double avg) {
+    Position p;
+    p.symbol = "BKNG";
+    p.quantity = Quantity(qty);
+    p.average_price = Decimal(avg);
+    return p;
+}
+
+CorpActionEvent split_event(double ratio) {
+    CorpActionEvent ev;
+    ev.symbol = "BKNG";
+    ev.ex_date = kExDate;
+    ev.type = CorpActionType::SPLIT;
+    ev.value = ratio;
+    return ev;
+}
+
+// The runner's gate, in one line, so the test pins the RULE rather than the runner's plumbing:
+// an event may be applied only if the symbol's loaded price series already reaches its ex-date.
+bool horizon_allows(const std::string& ex_date, const std::string& last_bar_date) {
+    return !last_bar_date.empty() && ex_date <= last_bar_date;
+}
+
+// E2-F16's companion rule, likewise stated as the RULE rather than the plumbing. Day T-1 is
+// normally finalized from the PRE-corp-action snapshot (8a1a96ef), so a day is not restated
+// before its own ex-date. That holds only while the ex-date is still in the future relative to
+// T-1. Once the horizon gate defers an event, the event can arrive on a run whose T-1 is ALREADY
+// on or after the ex-date -- and then the T-1 close is post-event while the pre-action basis is
+// pre-event. Finalize from the restated book in exactly that case.
+bool finalize_from_restated_book(const std::string& applied_ex_date, const std::string& t1_date) {
+    return !applied_ex_date.empty() && applied_ex_date <= t1_date;
+}
+
+}  // namespace
+
+// ---------------------------------------------------------------------------
+// 1. THE MISSING INVARIANT. This is the check whose absence let $1M through.
+// ---------------------------------------------------------------------------
+
+TEST(CorpActionFrameHorizon, BasisToMarkRatioIsInvariantAcrossAClassOneApply) {
+    std::unordered_map<std::string, Position> positions{{"BKNG", held(kQtyBefore, kBasisBefore)}};
+
+    // The mark the runner would price against. On the failing run this stayed PRE-split
+    // because the ex-date bar was outside the loaded window.
+    const double mark_before = kBasisBefore;
+
+    auto adjustments = CorporateActionsApplier::apply(positions, {split_event(kSplitRatio)});
+    ASSERT_EQ(adjustments.size(), 1u);
+    const auto& adj = adjustments.front();
+
+    EXPECT_NEAR(adj.avg_price_after, kBasisAfter, 1e-9);
+    EXPECT_NEAR(static_cast<double>(positions["BKNG"].quantity), 250.0, 1e-9);
+
+    // If the price series is in the same frame as the basis, it has been rescaled by the SAME
+    // factor, so basis/mark is unchanged. Applying the event while the mark is still pre-event
+    // breaks exactly this.
+    const double mark_after_if_unrescaled = mark_before;
+    const double ratio_before = adj.avg_price_before / mark_before;
+    const double ratio_after = adj.avg_price_after / mark_after_if_unrescaled;
+
+    EXPECT_NEAR(ratio_after / ratio_before, 1.0 / kSplitRatio, 1e-9)
+        << "Sanity: leaving the mark pre-event must break the invariant by exactly the split "
+           "ratio. If this fails the fixture no longer reproduces the defect.";
+
+    // And with the mark in the same frame, the invariant holds — which is what the horizon
+    // gate guarantees by refusing to apply until the series covers the ex-date.
+    const double mark_after_correct = mark_before / kSplitRatio;
+    EXPECT_NEAR(adj.avg_price_after / mark_after_correct, ratio_before, 1e-9)
+        << "Basis and mark are in different unit frames after the restatement. This is the "
+           "condition that produced BKNG SELL 248.799399 at 4194.31 -- $1,001,800 of realized "
+           "P&L on a $100,000 book.";
+}
+
+// Same invariant, the other direction. A reverse split inverts the sign of the error: the
+// basis becomes LARGER than the mark, `pnl_pct = (price - basis)/basis` reads about -90%, and
+// the mean-reversion stop-loss fires and liquidates the position on the ex-date.
+// 69 reverse-split bars exist in equities_data.ohlcv_1d.
+TEST(CorpActionFrameHorizon, InvariantAlsoHoldsForAReverseSplit) {
+    const double ratio = 0.1;  // 1-for-10
+    std::unordered_map<std::string, Position> positions{{"BKNG", held(100.0, 20.0)}};
+    const double mark_before = 20.0;
+
+    auto adjustments = CorporateActionsApplier::apply(positions, {[&] {
+                                                          auto e = split_event(ratio);
+                                                          return e;
+                                                      }()});
+    ASSERT_EQ(adjustments.size(), 1u);
+    const auto& adj = adjustments.front();
+
+    EXPECT_NEAR(adj.avg_price_after, 200.0, 1e-9) << "1-for-10 must multiply the basis by 10.";
+    EXPECT_NEAR(static_cast<double>(positions["BKNG"].quantity), 10.0, 1e-9);
+
+    // Un-rescaled mark: basis 200 vs mark 20 -> pnl_pct = (20-200)/200 = -90%, tripping a 5%
+    // stop that should never have fired.
+    const double pnl_pct_unrescaled = (mark_before - adj.avg_price_after) / adj.avg_price_after;
+    EXPECT_LT(pnl_pct_unrescaled, -0.5)
+        << "Sanity: the un-rescaled frame must look like a catastrophic loss. If it does not, "
+           "this fixture no longer reproduces the reverse-split stop-loss inversion.";
+
+    // Same frame: no P&L at all, which is correct — a reverse split moves no value.
+    const double mark_after_correct = mark_before / ratio;
+    EXPECT_NEAR((mark_after_correct - adj.avg_price_after) / adj.avg_price_after, 0.0, 1e-9);
+}
+
+// Dividends restate the basis by `1 + d/close` rather than a share ratio. Smaller (0.06-0.71%
+// on the configured universe) but ~50,953 dividend bars exist against 771 split bars, so this
+// is the flavour that actually fires — roughly every 11 trading days per held name. And unlike
+// the mark, the realized error never self-heals: daily_realized_pnl is deliberately absent
+// from the Day T-1 UPDATE, so a mispriced ex-date fill welds into every cumulative figure.
+TEST(CorpActionFrameHorizon, InvariantAlsoHoldsForADividend) {
+    const double close_at_ex = 89.27;   // ABT, 2026-07-15
+    const double div = 0.63;
+    const double ratio = 1.0 + div / close_at_ex;
+
+    std::unordered_map<std::string, Position> positions{{"ABT", held(88.0, close_at_ex)}};
+    CorpActionEvent ev;
+    ev.symbol = "ABT";
+    ev.ex_date = "2026-07-15";
+    ev.type = CorpActionType::DIVIDEND;
+    ev.value = div;
+    ev.close_at_ex_date = close_at_ex;
+
+    auto adjustments = CorporateActionsApplier::apply(positions, {ev});
+    ASSERT_EQ(adjustments.size(), 1u);
+    const auto& adj = adjustments.front();
+
+    EXPECT_NEAR(adj.ratio_change, ratio, 1e-9);
+    EXPECT_NEAR(adj.avg_price_after, close_at_ex / ratio, 1e-9);
+
+    // Same shape as the split: with the mark left in the pre-event frame the reported gain is
+    // about the dividend cash, booked as a phantom price move.
+    const double phantom = 88.0 * (close_at_ex - adj.avg_price_after);
+    EXPECT_NEAR(phantom, 88.0 * div / ratio, 1e-6)
+        << "The un-rescaled frame should book roughly the dividend cash as a price gain.";
+}
+
+// ---------------------------------------------------------------------------
+// 2. THE GATE. Defer while the series is behind; apply unchanged once it catches up.
+// ---------------------------------------------------------------------------
+
+TEST(CorpActionFrameHorizon, EventPastTheNewestLoadedBarIsDeferred) {
+    EXPECT_FALSE(horizon_allows(kExDate, kLastLoadedBar))
+        << "An ex-date beyond the newest loaded bar must be deferred. This is the BKNG case: "
+           "the corp-action fetch spans 2026-04-06 but the bar load ends 2026-04-02.";
+
+    // A held symbol with no bars at all in the window is the same refusal, and also surfaces
+    // a symbol that is held but has been dropped from the configured universe.
+    EXPECT_FALSE(horizon_allows(kExDate, ""));
+}
+
+TEST(CorpActionFrameHorizon, EventCoveredByTheSeriesAppliesUnchanged) {
+    // True-live, or the next replay run: the ex-date bar is loaded, back-adjustment has run,
+    // and the whole series is post-event. The gate must be a no-op here.
+    EXPECT_TRUE(horizon_allows(kExDate, kExDate));
+    EXPECT_TRUE(horizon_allows(kExDate, "2026-04-07"));
+
+    std::unordered_map<std::string, Position> positions{{"BKNG", held(kQtyBefore, kBasisBefore)}};
+    auto adjustments = CorporateActionsApplier::apply(positions, {split_event(kSplitRatio)});
+
+    ASSERT_EQ(adjustments.size(), 1u)
+        << "With the horizon satisfied the event must still apply exactly as before -- the gate "
+           "must not change true-live behaviour.";
+    EXPECT_NEAR(static_cast<double>(positions["BKNG"].quantity), 250.0, 1e-9);
+    EXPECT_NEAR(static_cast<double>(positions["BKNG"].average_price), kBasisAfter, 1e-9);
+}
+
+// Deferral must be recoverable, not a silent drop. The runner writes no dedup row for a
+// deferred event, so the next run reconsiders it — the same recovery the dividend-denominator
+// skip already relies on.
+TEST(CorpActionFrameHorizon, DeferredEventAppliesOnTheNextRunAndTheInvariantThenHolds) {
+    std::unordered_map<std::string, Position> positions{{"BKNG", held(kQtyBefore, kBasisBefore)}};
+
+    // Run 1: horizon behind -> nothing applied, position untouched.
+    ASSERT_FALSE(horizon_allows(kExDate, kLastLoadedBar));
+    EXPECT_NEAR(static_cast<double>(positions["BKNG"].quantity), kQtyBefore, 1e-9);
+    EXPECT_NEAR(static_cast<double>(positions["BKNG"].average_price), kBasisBefore, 1e-9);
+
+    // Run 2: the ex-date bar is now loaded and the series is adjusted.
+    ASSERT_TRUE(horizon_allows(kExDate, "2026-04-07"));
+    auto adjustments = CorporateActionsApplier::apply(positions, {split_event(kSplitRatio)});
+    ASSERT_EQ(adjustments.size(), 1u);
+
+    const double mark_now = 176.19;  // real 2026-04-06 close, post-split
+    const double basis = static_cast<double>(positions["BKNG"].average_price);
+    EXPECT_NEAR(basis, kBasisAfter, 1e-9);
+
+    // Basis and mark are now in one frame, so the stop-loss input is sane instead of +2400%.
+    const double pnl_pct = (mark_now - basis) / basis;
+    EXPECT_GT(pnl_pct, 0.0);
+    EXPECT_LT(pnl_pct, 0.25)
+        << "Post-fix the mark and basis must be comparable. Pre-fix this read about +2400%, "
+           "which is why the stop-loss could never fire on a forward split.";
+}
+
+
+// ---------------------------------------------------------------------------
+// 4. E2-F16 -- the defect the horizon gate CREATED, and its fix.
+//
+// Deferral is correct, but it invents a state 8a1a96ef never had to consider: an event applying
+// on run D for an ex-date of D-1. The pre-action snapshot is then a frame behind the T-1 close,
+// and the finalizer marks a pre-split basis against a post-split price. Measured on a real run:
+// the 2026-04-06 row took -4824.16 of phantom unrealized and the equity curve dropped to
+// 95,080.29. It does NOT self-correct -- running 04-08 and 04-09 left the row untouched.
+// ---------------------------------------------------------------------------
+
+TEST(CorpActionFrameHorizon, DeferredEventCatchingUpFinalizesFromTheRestatedBook) {
+    // Run on 04-07: the split for ex-date 04-06 was deferred yesterday and applies now, so T-1
+    // (04-06) is already post-event.
+    EXPECT_TRUE(finalize_from_restated_book(kExDate, "2026-04-06"))
+        << "ex_date == T-1: the deferred event has caught up and the T-1 close is post-event.";
+    EXPECT_TRUE(finalize_from_restated_book(kExDate, "2026-04-07"))
+        << "ex_date behind T-1: a longer gap, same conclusion.";
+
+    // The ordinary case must be untouched: an event whose ex-date is still ahead of T-1 is
+    // exactly what 8a1a96ef's pre-action snapshot exists for.
+    EXPECT_FALSE(finalize_from_restated_book(kExDate, "2026-04-02"))
+        << "ex_date after T-1 must keep the PRE-action snapshot, or a day is restated before "
+           "its own ex-date -- the regression 8a1a96ef fixed.";
+
+    // No class-1 event applied at all: every symbol keeps the pre-action snapshot.
+    EXPECT_FALSE(finalize_from_restated_book("", "2026-04-06"))
+        << "With no applied event the predicate must be false for every symbol, so the futures "
+           "path and every ordinary equity day are byte-for-byte unchanged.";
+}
+
+TEST(CorpActionFrameHorizon, RestatedBookAndPreActionBookDisagreeByExactlyTheSplitRatio) {
+    // The real 2026-04-06 close, post-split, and the residual position after the 04-06 sell.
+    constexpr double kT1ClosePostSplit = 176.19;
+    constexpr double kQtyHeldPreSplit = 1.200601;
+    const double qty_held_post_split = kQtyHeldPreSplit * kSplitRatio;   // 30.015025
+
+    // WRONG -- pre-action book (pre-split basis) marked against the post-split T-1 close.
+    const double wrong = kQtyHeldPreSplit * (kT1ClosePostSplit - kBasisBefore);
+    EXPECT_NEAR(wrong, -4824.16, 0.01)
+        << "This is the number the 2026-04-06 row actually carried before the fix.";
+
+    // RIGHT -- restated book, both sides post-split.
+    const double right = qty_held_post_split * (kT1ClosePostSplit - kBasisAfter);
+    EXPECT_NEAR(right, 252.6545, 1e-3);
+
+    // ...and it must equal the same economics computed entirely in PRE-split units, which is
+    // the independent derivation: the engine never sees this expression.
+    const double pre_split_units =
+        kQtyHeldPreSplit * (kT1ClosePostSplit * kSplitRatio - kBasisBefore);
+    EXPECT_NEAR(right, pre_split_units, 1e-6)
+        << "Restating the book must be economically neutral. If these ever disagree, the "
+           "applier's rescale convention and the finalizer have drifted apart again.";
+
+    // The defect was not a rounding matter: it is the whole book, with the sign flipped.
+    EXPECT_GT(std::abs(wrong - right), 5000.0);
+    EXPECT_LT(wrong, 0.0);
+    EXPECT_GT(right, 0.0);
+}
+
+TEST(CorpActionFrameHorizon, RestatedFinalizationIsNeutralForAReverseSplitAndADividend) {
+    // Reverse split, real DD numbers: 1-for-3 on 2026-06-24, close 46.67 -> 137.82.
+    {
+        constexpr double kRatio = 1.0 / 3.0;      // split_factor 0.3333333333
+        constexpr double kQtyBeforeRs = 30.0;
+        constexpr double kBasisBeforeRs = 46.67;
+        constexpr double kT1Close = 137.82;
+        const double qty_after = kQtyBeforeRs * kRatio;
+        const double basis_after = kBasisBeforeRs / kRatio;
+
+        const double restated = qty_after * (kT1Close - basis_after);
+        const double pre_event_units = kQtyBeforeRs * (kT1Close * kRatio - kBasisBeforeRs);
+        EXPECT_NEAR(restated, pre_event_units, 1e-6);
+    }
+
+    // Dividend, real ABT numbers: 0.63 on 2026-04-15 against a 101.56 close.
+    {
+        constexpr double kDiv = 0.63;
+        constexpr double kCloseAtEx = 101.56;
+        const double ratio = 1.0 + kDiv / kCloseAtEx;
+        constexpr double kQty = 57.412048;
+        constexpr double kBasisBeforeDiv = 95.47;
+        constexpr double kT1Close = 96.81;
+        const double basis_after = kBasisBeforeDiv / ratio;
+
+        // Quantity is unchanged by a dividend, so neutrality is a statement about the basis
+        // and the mark moving together.
+        const double restated = kQty * (kT1Close - basis_after);
+        const double pre_event_units = kQty * (kT1Close * ratio - kBasisBeforeDiv) / ratio;
+        EXPECT_NEAR(restated, pre_event_units, 1e-6);
+    }
+}

--- a/tests/live/test_finalize_realized_policy.cpp
+++ b/tests/live/test_finalize_realized_policy.cpp
@@ -1,0 +1,311 @@
+// tests/live/test_finalize_realized_policy.cpp
+//
+// E2-F19 / E2-F20: what the Day T-1 finalization leaves in realized_pnl, per
+// settlement model.
+//
+// LivePnLManager::finalize_previous_day writes the settlement move
+// qty x (close(T-1) - close(T-2)) x point_value into every finalized row's
+// realized_pnl. Under SETTLED (futures) that IS the day's realized -- a position
+// entered at close(T-2) and settled at close(T-1) realizes its whole move daily.
+// Under MARK_TO_MARKET (equities) it is a mark, and writing it over the trade
+// realized the day's own run recorded is how a column named "daily_realized_pnl"
+// came to hold price moves.
+//
+// The equity runner puts the LOADED T-1 figure back (LiveDailyCycle::
+// restore_loaded_realized) rather than editing the shared finalizer, so the
+// futures path is untouched by construction. These tests pin both halves: the
+// futures value that must never move, and the equity restore that must.
+//
+// F20 measured the weekend consequence: Saturday's and Sunday's runs both
+// finalize Friday, so Monday loads Friday's row already holding a mark move and
+// seeds it (META 2026-07-31..08-04: Tue 120.590763 = 73.351951 Friday mark +
+// 31.311175 Mon trade + 15.927637 Tue trade). Restoring from the loaded row makes
+// the Friday row a fixed point across all three finalizations.
+
+#include <gtest/gtest.h>
+
+#include <chrono>
+#include <cmath>
+#include <memory>
+#include <string>
+#include <unordered_map>
+#include <vector>
+
+// Pre-load std headers before flipping private->public (same device as
+// test_finalize_unrealized_policy.cpp), or the macro leaks into libc++.
+#include <algorithm>
+#include <map>
+#include <mutex>
+#include <optional>
+#include <ranges>
+
+#include "trade_ngin/core/types.hpp"
+#include "trade_ngin/instruments/futures.hpp"
+#define private public
+#include "trade_ngin/instruments/instrument_registry.hpp"
+#include "trade_ngin/live/live_pnl_manager.hpp"
+#undef private
+#include "trade_ngin/live/live_daily_cycle.hpp"
+
+using namespace trade_ngin;
+
+namespace {
+
+using Book = std::unordered_map<std::string, Position>;
+using Closes = std::unordered_map<std::string, double>;
+
+// Real MNQ.v.0 numbers from 2025-10-10, the E2-F3 fixture.
+constexpr double kFutQty = 3.0;
+constexpr double kFutT2 = 25335.0;
+constexpr double kFutT1 = 24188.0;
+constexpr double kFutPv = 2.0;
+constexpr double kFutMove = kFutQty * (kFutT1 - kFutT2) * kFutPv;  // -6882.00
+
+// Real TMUS numbers from 2026-04-14/15: the basis and the exit realized.
+// The symbol is chosen because its name matches no futures root in the
+// point-value fallback (AAPL matches "PL", MSFT matches "MSF").
+constexpr const char* kEq = "TMUS";
+constexpr double kEqQty = 37.515436;
+constexpr double kEqBasis = 200.733033;
+constexpr double kEqRealized = -402.654413;
+constexpr double kEqT2 = 195.0;
+constexpr double kEqT1 = 190.0;
+constexpr double kEqMove = kEqQty * (kEqT1 - kEqT2);  // -187.577180, != kEqRealized
+
+std::shared_ptr<FuturesInstrument> make_mnq_futures() {
+    FuturesSpec spec;
+    spec.root_symbol = "MNQ";
+    spec.exchange = "CME";
+    spec.currency = "USD";
+    spec.multiplier = kFutPv;
+    spec.tick_size = 0.25;
+    spec.commission_per_contract = 0.5;
+    spec.initial_margin = 2000.0;
+    spec.maintenance_margin = 1800.0;
+    spec.weight = 1.0;
+    return std::make_shared<FuturesInstrument>("MNQ.v.0", spec);
+}
+
+Position make_row(const std::string& symbol, double qty, double basis, double realized) {
+    Position p;
+    p.symbol = symbol;
+    p.quantity = Quantity(qty);
+    p.average_price = Decimal(basis);
+    p.realized_pnl = Decimal(realized);
+    p.unrealized_pnl = Decimal(0.0);
+    p.last_update = std::chrono::system_clock::now();
+    return p;
+}
+
+class FinalizeRealizedPolicyTest : public ::testing::Test {
+protected:
+    void SetUp() override {
+        InstrumentRegistry::instance().instruments_["MNQ.v.0"] = make_mnq_futures();
+    }
+    void TearDown() override {
+        InstrumentRegistry::instance().instruments_.erase("MNQ.v.0");
+    }
+
+    LivePnLManager::FinalizationResult finalize(const Book& loaded, const Closes& t1,
+                                                const Closes& t2,
+                                                LivePnLManager::UnrealizedPolicy policy) {
+        LivePnLManager mgr(100000.0, InstrumentRegistry::instance());
+        std::vector<Position> prev;
+        for (const auto& [_, p] : loaded) prev.push_back(p);
+        auto res = mgr.finalize_previous_day(prev, t1, t2, 100000.0, 0.0, policy);
+        EXPECT_TRUE(res.is_ok());
+        return res.value();
+    }
+
+    // The equity runner's T-1 path: finalize, then put the loaded realized back.
+    LivePnLManager::FinalizationResult finalize_and_restore(const Book& loaded, const Closes& t1,
+                                                            const Closes& t2) {
+        auto r = finalize(loaded, t1, t2, LivePnLManager::UnrealizedPolicy::MARK_TO_MARKET);
+        LiveDailyCycle::restore_loaded_realized(r.finalized_positions, loaded);
+        return r;
+    }
+
+    static const Position& only(const LivePnLManager::FinalizationResult& r) {
+        EXPECT_EQ(r.finalized_positions.size(), 1u);
+        return r.finalized_positions.front();
+    }
+
+    static const Position* find(const LivePnLManager::FinalizationResult& r,
+                                const std::string& symbol) {
+        for (const auto& p : r.finalized_positions) {
+            if (p.symbol == symbol) return &p;
+        }
+        return nullptr;
+    }
+};
+
+}  // namespace
+
+// ---------------------------------------------------------------------------
+// T-1: the futures pin. Must pass before and after; fails loudly if anyone makes
+// the equity behaviour unconditional or routes futures through the restore.
+// ---------------------------------------------------------------------------
+
+TEST_F(FinalizeRealizedPolicyTest, SettledFinalizationWritesTheSettlementMoveAsRealized) {
+    Book loaded{{"MNQ.v.0", make_row("MNQ.v.0", kFutQty, kFutT2, /*realized*/ 123.45)}};
+    auto r = finalize(loaded, {{"MNQ.v.0", kFutT1}}, {{"MNQ.v.0", kFutT2}},
+                      LivePnLManager::UnrealizedPolicy::SETTLED);
+
+    EXPECT_DOUBLE_EQ(only(r).realized_pnl.as_double(), kFutMove)
+        << "Under SETTLED the settlement move IS the day's realized. An incoming "
+           "realized on the input row is discarded, exactly as today.";
+    EXPECT_DOUBLE_EQ(r.finalized_daily_pnl, kFutMove);
+    EXPECT_DOUBLE_EQ(r.position_realized_pnl.at("MNQ.v.0"), kFutMove);
+    EXPECT_DOUBLE_EQ(only(r).unrealized_pnl.as_double(), 0.0);
+}
+
+// The default policy is SETTLED, so a five-argument caller (both futures runners)
+// gets the same row.
+TEST_F(FinalizeRealizedPolicyTest, DefaultPolicyMatchesSettled) {
+    LivePnLManager mgr(100000.0, InstrumentRegistry::instance());
+    std::vector<Position> prev{make_row("MNQ.v.0", kFutQty, kFutT2, 123.45)};
+    auto res = mgr.finalize_previous_day(prev, {{"MNQ.v.0", kFutT1}}, {{"MNQ.v.0", kFutT2}},
+                                         100000.0, 0.0);
+    ASSERT_TRUE(res.is_ok());
+    EXPECT_DOUBLE_EQ(res.value().finalized_positions.front().realized_pnl.as_double(), kFutMove);
+}
+
+// ---------------------------------------------------------------------------
+// T-2: the equity restore. The row keeps the trade realized the day's own run
+// wrote; the mark goes to unrealized; the aggregate still reports the move.
+// ---------------------------------------------------------------------------
+
+TEST_F(FinalizeRealizedPolicyTest, EquityRowKeepsTheLoadedTradeRealized) {
+    Book loaded{{kEq, make_row(kEq, kEqQty, kEqBasis, kEqRealized)}};
+    auto r = finalize_and_restore(loaded, {{kEq, kEqT1}}, {{kEq, kEqT2}});
+
+    ASSERT_NE(std::abs(kEqMove - kEqRealized), 0.0)
+        << "fixture precondition: the mark move must differ from the trade realized "
+           "or the restore is indistinguishable from the finalizer";
+    EXPECT_NEAR(only(r).realized_pnl.as_double(), kEqRealized, 1e-6)
+        << "the T-1 row must carry the day's trade realized, not the mark move "
+           "(E2-F19 route 2 / E2-F20)";
+    EXPECT_NEAR(only(r).unrealized_pnl.as_double(), kEqQty * (kEqT1 - kEqBasis), 1e-6)
+        << "the mark belongs in daily_unrealized_pnl, measured against the cost basis";
+}
+
+// The restore is a row-only change: the aggregate the equity curve is built from
+// still reports the settlement move. This is what keeps yesterday_total_pnl and
+// total_unrealized_pnl byte-identical, and it is also the proof that the fix did
+// not go into the finalizer.
+TEST_F(FinalizeRealizedPolicyTest, RestoreDoesNotTouchTheAggregate) {
+    Book loaded{{kEq, make_row(kEq, kEqQty, kEqBasis, kEqRealized)}};
+    auto r = finalize_and_restore(loaded, {{kEq, kEqT1}}, {{kEq, kEqT2}});
+
+    EXPECT_NEAR(r.finalized_daily_pnl, kEqMove, 1e-6)
+        << "finalized_daily_pnl must still be the mark move (also guards against a "
+           "stray point-value multiplier for the equity symbol)";
+    EXPECT_NEAR(r.position_realized_pnl.at(kEq), kEqMove, 1e-6);
+    EXPECT_NEAR(r.finalized_unrealized_pnl, kEqQty * (kEqT1 - kEqBasis), 1e-6);
+}
+
+// ---------------------------------------------------------------------------
+// T-4: the degenerate branches -- no T-1 close, then no T-2 close. A single thin
+// name reaches these at 852 symbols, and a naive fix would silently zero a real
+// figure here.
+// ---------------------------------------------------------------------------
+
+TEST_F(FinalizeRealizedPolicyTest, MissingT1CloseStillRestoresRealized) {
+    Book loaded{{kEq, make_row(kEq, kEqQty, kEqBasis, kEqRealized)}};
+    auto r = finalize_and_restore(loaded, /*t1*/ {}, {{kEq, kEqT2}});
+
+    EXPECT_NEAR(only(r).realized_pnl.as_double(), kEqRealized, 1e-6)
+        << "a missing T-1 close must not erase the day's trade realized";
+    // Residual R-2, pinned as ACCEPTED for now: the row's unrealized level is
+    // written as 0 on this branch. Row and aggregate agree (the accumulation is
+    // skipped too), so L5 holds; the level is wrong. Tracked separately.
+    EXPECT_DOUBLE_EQ(only(r).unrealized_pnl.as_double(), 0.0);
+}
+
+TEST_F(FinalizeRealizedPolicyTest, MissingT2CloseStillRestoresRealized) {
+    Book loaded{{kEq, make_row(kEq, kEqQty, kEqBasis, kEqRealized)}};
+    auto r = finalize_and_restore(loaded, {{kEq, kEqT1}}, /*t2*/ {{"OTHER", 1.0}});
+
+    EXPECT_NEAR(only(r).realized_pnl.as_double(), kEqRealized, 1e-6);
+    EXPECT_DOUBLE_EQ(only(r).unrealized_pnl.as_double(), 0.0);
+}
+
+// Under SETTLED the degenerate branches keep writing 0 -- the futures pin for T-4.
+TEST_F(FinalizeRealizedPolicyTest, SettledDegenerateBranchesWriteZero) {
+    Book loaded{{"MNQ.v.0", make_row("MNQ.v.0", kFutQty, kFutT2, 123.45)}};
+    auto r = finalize(loaded, {}, {{"MNQ.v.0", kFutT2}},
+                      LivePnLManager::UnrealizedPolicy::SETTLED);
+    EXPECT_DOUBLE_EQ(only(r).realized_pnl.as_double(), 0.0);
+    EXPECT_DOUBLE_EQ(r.finalized_daily_pnl, 0.0);
+}
+
+// ---------------------------------------------------------------------------
+// T-5 / T-5b: a closed row (qty 0, realized != 0) carried into the T-1 write set
+// keeps its realized, contributes nothing to any aggregate, and is not dead.
+// ---------------------------------------------------------------------------
+
+TEST_F(FinalizeRealizedPolicyTest, ClosedRowSurvivesFinalizationWithItsRealized) {
+    const double kExit = -327.342;
+    Book open_only{{"META", make_row("META", 4.148866, 539.03, 0.0)}};
+    Book with_closed = open_only;
+    with_closed["AAPLX"] = make_row("AAPLX", 0.0, 0.0, kExit);  // closed yesterday
+
+    Closes t1{{"META", 556.71}, {"AAPLX", 275.15}};
+    Closes t2{{"META", 539.03}, {"AAPLX", 293.08}};
+
+    auto base = finalize_and_restore(open_only, t1, t2);
+    auto r = finalize_and_restore(with_closed, t1, t2);
+
+    const Position* closed = find(r, "AAPLX");
+    ASSERT_NE(closed, nullptr) << "the closed row must come back out of finalization";
+    EXPECT_NEAR(closed->realized_pnl.as_double(), kExit, 1e-6)
+        << "the exit's realized must survive the T-1 rewrite";
+    EXPECT_DOUBLE_EQ(closed->unrealized_pnl.as_double(), 0.0);
+    EXPECT_FALSE(LiveDailyCycle::is_dead_row(*closed))
+        << "the T-1 write site must keep this row (route 3 leaked through this site)";
+
+    EXPECT_DOUBLE_EQ(r.finalized_daily_pnl, base.finalized_daily_pnl)
+        << "a zero-quantity row must not move the finalized aggregate";
+    EXPECT_DOUBLE_EQ(r.finalized_unrealized_pnl, base.finalized_unrealized_pnl)
+        << "total_unrealized_pnl is summed from these rows; a closed row adds 0";
+}
+
+// ---------------------------------------------------------------------------
+// T-13: the Sat/Sun/Mon triple. Each finalization of the same loaded rows must
+// leave the row equal to what was LOADED -- not merely equal to the previous
+// pass, which the finalizer already guarantees because it is a fixed point of
+// quantity and closes (F20 §5). The claim under test is stability against the
+// day's own written value.
+// ---------------------------------------------------------------------------
+
+TEST_F(FinalizeRealizedPolicyTest, RepeatedFinalizationIsAFixedPointOfTheLoadedRow) {
+    Book loaded{
+        {kEq, make_row(kEq, kEqQty, kEqBasis, kEqRealized)},
+        {"META", make_row("META", 4.148866, 539.03, 31.311175)},
+    };
+    Closes t1{{kEq, kEqT1}, {"META", 556.71}};
+    Closes t2{{kEq, kEqT2}, {"META", 539.03}};
+
+    for (int pass = 1; pass <= 3; ++pass) {
+        auto r = finalize_and_restore(loaded, t1, t2);
+        for (const auto& [symbol, original] : loaded) {
+            const Position* fp = find(r, symbol);
+            ASSERT_NE(fp, nullptr);
+            EXPECT_DOUBLE_EQ(fp->realized_pnl.as_double(), original.realized_pnl.as_double())
+                << "pass " << pass << ": " << symbol
+                << " realized drifted from the loaded value (F20 weekend contamination)";
+            EXPECT_DOUBLE_EQ(fp->quantity.as_double(), original.quantity.as_double());
+            EXPECT_DOUBLE_EQ(fp->average_price.as_double(),
+                             original.average_price.as_double());
+        }
+    }
+}
+
+// A finalized row with no loaded counterpart cannot carry a loaded realized; it
+// gets 0 rather than the mark move.
+TEST_F(FinalizeRealizedPolicyTest, RowWithoutALoadedCounterpartGetsZeroRealized) {
+    std::vector<Position> finalized{make_row("META", 4.148866, 539.03, /*mark*/ 73.351951)};
+    Book loaded;  // nothing loaded for META
+    LiveDailyCycle::restore_loaded_realized(finalized, loaded);
+    EXPECT_DOUBLE_EQ(finalized.front().realized_pnl.as_double(), 0.0);
+}

--- a/tests/live/test_finalize_realized_policy.cpp
+++ b/tests/live/test_finalize_realized_policy.cpp
@@ -212,14 +212,16 @@ TEST_F(FinalizeRealizedPolicyTest, RestoreDoesNotTouchTheAggregate) {
 
 TEST_F(FinalizeRealizedPolicyTest, MissingT1CloseStillRestoresRealized) {
     Book loaded{{kEq, make_row(kEq, kEqQty, kEqBasis, kEqRealized)}};
+    loaded[kEq].unrealized_pnl = Decimal(146.98);  // the last known mark
     auto r = finalize_and_restore(loaded, /*t1*/ {}, {{kEq, kEqT2}});
 
     EXPECT_NEAR(only(r).realized_pnl.as_double(), kEqRealized, 1e-6)
         << "a missing T-1 close must not erase the day's trade realized";
-    // Residual R-2, pinned as ACCEPTED for now: the row's unrealized level is
-    // written as 0 on this branch. Row and aggregate agree (the accumulation is
-    // skipped too), so L5 holds; the level is wrong. Tracked separately.
-    EXPECT_DOUBLE_EQ(only(r).unrealized_pnl.as_double(), 0.0);
+    // R-2: the last known mark is carried, on the row AND in the aggregate. A halted or
+    // unprinted name is still worth its last price; zero made the level vanish for a day
+    // and reappear as a phantom jump.
+    EXPECT_NEAR(only(r).unrealized_pnl.as_double(), 146.98, 1e-6);
+    EXPECT_NEAR(r.finalized_unrealized_pnl, 146.98, 1e-6);
 }
 
 TEST_F(FinalizeRealizedPolicyTest, MissingT2CloseStillRestoresRealized) {
@@ -227,7 +229,11 @@ TEST_F(FinalizeRealizedPolicyTest, MissingT2CloseStillRestoresRealized) {
     auto r = finalize_and_restore(loaded, {{kEq, kEqT1}}, /*t2*/ {{"OTHER", 1.0}});
 
     EXPECT_NEAR(only(r).realized_pnl.as_double(), kEqRealized, 1e-6);
-    EXPECT_DOUBLE_EQ(only(r).unrealized_pnl.as_double(), 0.0);
+    // R-2: a T-1 close exists, so the mark against the cost basis is computable; no
+    // settlement move is reported (T-2 missing), but the level is not zeroed.
+    EXPECT_NEAR(only(r).unrealized_pnl.as_double(), kEqQty * (kEqT1 - kEqBasis), 1e-6);
+    EXPECT_NEAR(r.finalized_unrealized_pnl, kEqQty * (kEqT1 - kEqBasis), 1e-6);
+    EXPECT_DOUBLE_EQ(r.finalized_daily_pnl, 0.0);
 }
 
 // Under SETTLED the degenerate branches keep writing 0 -- the futures pin for T-4.
@@ -308,4 +314,19 @@ TEST_F(FinalizeRealizedPolicyTest, RowWithoutALoadedCounterpartGetsZeroRealized)
     Book loaded;  // nothing loaded for META
     LiveDailyCycle::restore_loaded_realized(finalized, loaded);
     EXPECT_DOUBLE_EQ(finalized.front().realized_pnl.as_double(), 0.0);
+}
+
+// ---------------------------------------------------------------------------
+// R-1: the finalizer itself no longer writes the mark move into realized under
+// MARK_TO_MARKET -- without the runner's restore step. A new caller cannot fall
+// into the trap. The aggregate still carries the move.
+// ---------------------------------------------------------------------------
+TEST_F(FinalizeRealizedPolicyTest, FinalizerAloneKeepsTradeRealizedUnderMarkToMarket) {
+    Book loaded{{kEq, make_row(kEq, kEqQty, kEqBasis, kEqRealized)}};
+    auto r = finalize(loaded, {{kEq, kEqT1}}, {{kEq, kEqT2}},
+                      LivePnLManager::UnrealizedPolicy::MARK_TO_MARKET);
+    EXPECT_NEAR(only(r).realized_pnl.as_double(), kEqRealized, 1e-6)
+        << "no restore was applied: the finalizer must not write the mark move as realized "
+           "on a cash book";
+    EXPECT_NEAR(r.finalized_daily_pnl, kEqMove, 1e-6) << "the aggregate still carries the move";
 }

--- a/tests/live/test_finalize_unrealized_policy.cpp
+++ b/tests/live/test_finalize_unrealized_policy.cpp
@@ -1,0 +1,171 @@
+// E2-F3 regression pins.
+//
+// LivePnLManager::finalize_previous_day writes the Day T-1 row. Commit 4d5ea48f replaced
+// futures' unconditional `unrealized_pnl = 0` with a mark-to-market expression, justified
+// by the comment "average_price resets to close after daily settlement, so this is ~0".
+//
+// That premise is false, and off by exactly one day. Under the futures T-1 lag model the
+// runner enters a position at close(T-1) (live_portfolio_conservative.cpp STEP 2 sets
+// average_price = yesterday_close) and the NEXT day's run settles it at close(T). So on a
+// futures row average_price IS the prior settlement close -- precisely the day_t2_close the
+// finalizer already uses to compute realized. The injected expression therefore reduces to
+//
+//     qty * (t1_close - average_price) * pt  ==  qty * (t1_close - t2_close) * pt  ==  realized
+//
+// i.e. it records the same settlement move in a second column.
+//
+// Measured on the first ever 10-day futures replay (2025-10-06..15): 65 of 77 rows non-zero
+// where main writes 0, on 2025-10-10 six of nine rows had daily_unrealized_pnl EXACTLY equal
+// to daily_realized_pnl (-315.00, -2295.00, -3558.75, -6882.00, -590.00, +718.75), and the
+// per-row sum reached -12,586.69 while live_results correctly reported 0.00 -- a violation
+// of the row-sums-to-aggregate invariant (protocol section 12, L5).
+//
+// Both directions are pinned. The SETTLED case is the futures invariant that must not move;
+// the MARK_TO_MARKET case is the equity behaviour 4d5ea48f actually wanted and must keep.
+
+#include <gtest/gtest.h>
+#include <chrono>
+#include <cmath>
+#include <memory>
+#include <string>
+#include <unordered_map>
+#include <vector>
+
+// Pre-load std headers before flipping private->public, or the macro leaks into libc++.
+#include <algorithm>
+#include <map>
+#include <mutex>
+#include <optional>
+#include <ranges>
+
+#include "trade_ngin/instruments/futures.hpp"
+#define private public
+#include "trade_ngin/instruments/instrument_registry.hpp"
+#include "trade_ngin/live/live_pnl_manager.hpp"
+#undef private
+
+using namespace trade_ngin;
+
+namespace {
+
+// Real numbers from the MNQ.v.0 row on 2025-10-10, so the fixture cannot drift from what
+// production actually produced.
+constexpr double kQty        = 3.0;
+constexpr double kT2Close    = 25335.0;   // close 2025-10-09 -- what average_price holds
+constexpr double kT1Close    = 24188.0;   // close 2025-10-10
+constexpr double kPointValue = 2.0;       // MNQ contract size
+// (24188 - 25335) * 3 * 2
+constexpr double kOneDayMove = (kT1Close - kT2Close) * kQty * kPointValue;  // -6882.00
+
+// Registered so get_point_value("MNQ.v.0") resolves deterministically rather than
+// falling back to a default, which would make the exact-value assertions meaningless.
+std::shared_ptr<FuturesInstrument> make_mnq_futures() {
+    FuturesSpec spec;
+    spec.root_symbol = "MNQ";
+    spec.exchange = "CME";
+    spec.currency = "USD";
+    spec.multiplier = kPointValue;
+    spec.tick_size = 0.25;
+    spec.commission_per_contract = 0.5;
+    spec.initial_margin = 2000.0;
+    spec.maintenance_margin = 1800.0;
+    spec.weight = 1.0;
+    return std::make_shared<FuturesInstrument>("MNQ.v.0", spec);
+}
+
+Position futures_position() {
+    Position p;
+    p.symbol = "MNQ.v.0";
+    p.quantity = Decimal(kQty);
+    // The T-1 lag model: the run on day T-1 wrote the prior settlement close here.
+    p.average_price = Decimal(kT2Close);
+    p.realized_pnl = Decimal(0.0);
+    p.unrealized_pnl = Decimal(0.0);
+    p.last_update = std::chrono::system_clock::now();
+    return p;
+}
+
+class FinalizeUnrealizedPolicyTest : public ::testing::Test {
+protected:
+    void SetUp() override {
+        InstrumentRegistry::instance().instruments_["MNQ.v.0"] = make_mnq_futures();
+    }
+    void TearDown() override {
+        InstrumentRegistry::instance().instruments_.erase("MNQ.v.0");
+    }
+
+    // Returns the unrealized value the finalizer wrote onto the Day T-1 row.
+    double finalized_unrealized(LivePnLManager::UnrealizedPolicy policy, bool pass_policy) {
+        auto& registry = InstrumentRegistry::instance();
+        LivePnLManager mgr(500000.0, registry);
+
+        std::vector<Position> prev{futures_position()};
+        std::unordered_map<std::string, double> t1{{"MNQ.v.0", kT1Close}};
+        std::unordered_map<std::string, double> t2{{"MNQ.v.0", kT2Close}};
+
+        auto res = pass_policy
+                       ? mgr.finalize_previous_day(prev, t1, t2, 500000.0, 0.0, policy)
+                       : mgr.finalize_previous_day(prev, t1, t2, 500000.0, 0.0);
+        EXPECT_TRUE(res.is_ok());
+        if (!res.is_ok() || res.value().finalized_positions.empty()) return NAN;
+        return res.value().finalized_positions.front().unrealized_pnl.as_double();
+    }
+};
+
+}  // namespace
+
+// THE FUTURES INVARIANT. A position whose average_price is the prior settlement close --
+// which under the T-1 lag model is every futures position -- must finalize with zero
+// unrealized, because that move is already booked as realized.
+TEST_F(FinalizeUnrealizedPolicyTest, SettledPolicyWritesZeroEvenWhenPriceMoved) {
+    const double u = finalized_unrealized(LivePnLManager::UnrealizedPolicy::SETTLED, true);
+
+    EXPECT_DOUBLE_EQ(u, 0.0)
+        << "Futures finalization wrote a non-zero unrealized P&L. average_price is the "
+           "prior settlement close, so this value is the settlement move already recorded "
+           "in realized_pnl -- the same day counted twice (E2-F3).";
+}
+
+// The default must BE the futures behaviour, so a caller that says nothing is safe.
+// Both futures runners call finalize_previous_day with no policy argument.
+TEST_F(FinalizeUnrealizedPolicyTest, DefaultPolicyIsSettledSoFuturesCallersNeedNoArgument) {
+    const double u = finalized_unrealized(LivePnLManager::UnrealizedPolicy::SETTLED, false);
+
+    EXPECT_DOUBLE_EQ(u, 0.0)
+        << "Omitting the policy argument did not yield the futures behaviour. The two "
+           "futures runners pass no policy, so the default must be SETTLED.";
+}
+
+// The equity behaviour 4d5ea48f wanted, and which the fix must preserve.
+TEST_F(FinalizeUnrealizedPolicyTest, MarkToMarketPolicyMeasuresAgainstTheCostBasis) {
+    const double u =
+        finalized_unrealized(LivePnLManager::UnrealizedPolicy::MARK_TO_MARKET, true);
+
+    EXPECT_DOUBLE_EQ(u, kOneDayMove)
+        << "Mark-to-market finalization did not measure the position against its "
+           "average_price. Equities depend on this: there average_price is a true "
+           "weighted cost basis.";
+}
+
+// The double-count made concrete: under SETTLED the unrealized must NOT equal the realized
+// move, which is exactly the equality observed in production on 6 of 9 rows.
+TEST_F(FinalizeUnrealizedPolicyTest, SettledUnrealizedDoesNotDuplicateTheRealizedMove) {
+    const double settled = finalized_unrealized(LivePnLManager::UnrealizedPolicy::SETTLED, true);
+
+    EXPECT_NE(settled, kOneDayMove)
+        << "Futures unrealized equals the one-day settlement move (" << kOneDayMove
+        << "), which is what realized_pnl already holds. This is the exact E2-F3 signature: "
+           "on 2025-10-10 six of nine rows had unrealized == realized to the cent.";
+}
+
+// Guards against the policy being accepted but ignored -- both assertions above could pass
+// for reasons unrelated to the flag if the branch were never taken.
+TEST_F(FinalizeUnrealizedPolicyTest, ThePolicyIsWhatDecidesTheOutcome) {
+    const double settled = finalized_unrealized(LivePnLManager::UnrealizedPolicy::SETTLED, true);
+    const double marked =
+        finalized_unrealized(LivePnLManager::UnrealizedPolicy::MARK_TO_MARKET, true);
+
+    EXPECT_NE(settled, marked)
+        << "UnrealizedPolicy changed nothing. If both paths agree the parameter is not "
+           "wired into the finalizer, and this suite would not catch a regression of E2-F3.";
+}

--- a/tests/live/test_finalize_unrealized_policy.cpp
+++ b/tests/live/test_finalize_unrealized_policy.cpp
@@ -169,3 +169,86 @@ TEST_F(FinalizeUnrealizedPolicyTest, ThePolicyIsWhatDecidesTheOutcome) {
         << "UnrealizedPolicy changed nothing. If both paths agree the parameter is not "
            "wired into the finalizer, and this suite would not catch a regression of E2-F3.";
 }
+
+// ===========================================================================
+// E2-F1: FinalizationResult::finalized_unrealized_pnl -- the aggregate counterpart of the
+// per-row unrealized written above.
+//
+// live_results.total_unrealized_pnl used to be a DAY-T snapshot: the book priced at
+// close(T-2), computed at insert and never revisited by the T-1 finalization. The finalized
+// position rows were priced at close(T-1). So the aggregate and the rows it is supposed to
+// summarise differed by exactly that day's P&L -- E2-F13, residual 0.0000 against
+// `tu + daily_realized` on every finalized row, which is far too tight to be coincidence.
+//
+// The aggregate is now summed from the same finalized rows that get persisted, so the
+// row-sums-to-aggregate invariant (protocol L5) holds by construction rather than by two
+// code paths happening to agree. Verified on the 2026-07-24..08-04 replay: L5 residual
+// 0.0000 on all 12 days, weekends included.
+//
+// Futures safety is structural: the accumulation lives INSIDE the MARK_TO_MARKET branch, so
+// SETTLED cannot reach it. Both futures runners pass no policy argument and therefore get
+// SETTLED and an aggregate of exactly 0.0.
+// ===========================================================================
+
+// THE FUTURES PIN. Must be exactly 0.0 with no policy argument at all -- that is how both
+// futures runners call it.
+TEST_F(FinalizeUnrealizedPolicyTest, FinalizedUnrealizedAggregateIsZeroForFuturesByDefault) {
+    auto& registry = InstrumentRegistry::instance();
+    LivePnLManager mgr(500000.0, registry);
+
+    std::vector<Position> prev{futures_position()};
+    std::unordered_map<std::string, double> t1{{"MNQ.v.0", kT1Close}};
+    std::unordered_map<std::string, double> t2{{"MNQ.v.0", kT2Close}};
+
+    auto res = mgr.finalize_previous_day(prev, t1, t2, 500000.0, 0.0);
+    ASSERT_TRUE(res.is_ok());
+
+    EXPECT_DOUBLE_EQ(res.value().finalized_unrealized_pnl, 0.0)
+        << "The default (futures) path accumulated a non-zero unrealized aggregate. Under "
+           "SETTLED every finalized row's unrealized is 0 by the settlement identity, so the "
+           "sum must be 0 too -- by construction, not by measurement. A non-zero value here "
+           "means the accumulation escaped the MARK_TO_MARKET branch.";
+}
+
+// And explicitly under SETTLED, for a caller that names the policy.
+TEST_F(FinalizeUnrealizedPolicyTest, FinalizedUnrealizedAggregateIsZeroUnderSettled) {
+    auto& registry = InstrumentRegistry::instance();
+    LivePnLManager mgr(500000.0, registry);
+
+    std::vector<Position> prev{futures_position()};
+    std::unordered_map<std::string, double> t1{{"MNQ.v.0", kT1Close}};
+    std::unordered_map<std::string, double> t2{{"MNQ.v.0", kT2Close}};
+
+    auto res = mgr.finalize_previous_day(prev, t1, t2, 500000.0, 0.0,
+                                         LivePnLManager::UnrealizedPolicy::SETTLED);
+    ASSERT_TRUE(res.is_ok());
+    EXPECT_DOUBLE_EQ(res.value().finalized_unrealized_pnl, 0.0);
+}
+
+// Equities: the aggregate must equal the sum of the rows it summarises. This is L5.
+TEST_F(FinalizeUnrealizedPolicyTest, FinalizedUnrealizedAggregateEqualsSumOfFinalizedRows) {
+    auto& registry = InstrumentRegistry::instance();
+    LivePnLManager mgr(500000.0, registry);
+
+    std::vector<Position> prev{futures_position()};
+    std::unordered_map<std::string, double> t1{{"MNQ.v.0", kT1Close}};
+    std::unordered_map<std::string, double> t2{{"MNQ.v.0", kT2Close}};
+
+    auto res = mgr.finalize_previous_day(prev, t1, t2, 500000.0, 0.0,
+                                         LivePnLManager::UnrealizedPolicy::MARK_TO_MARKET);
+    ASSERT_TRUE(res.is_ok());
+
+    double row_sum = 0.0;
+    for (const auto& p : res.value().finalized_positions) {
+        row_sum += p.unrealized_pnl.as_double();
+    }
+
+    EXPECT_DOUBLE_EQ(res.value().finalized_unrealized_pnl, row_sum)
+        << "The aggregate diverged from the rows. live_results.total_unrealized_pnl is "
+           "written from this figure and trading.positions.daily_unrealized_pnl from those "
+           "rows, so any gap here reappears as an L5 violation in the database -- which is "
+           "exactly what E2-F13 was.";
+    EXPECT_DOUBLE_EQ(res.value().finalized_unrealized_pnl, kOneDayMove)
+        << "The mark-to-market aggregate should equal the one-day move for this fixture, "
+           "whose average_price is the T-2 close.";
+}

--- a/tests/live/test_live_price_manager.cpp
+++ b/tests/live/test_live_price_manager.cpp
@@ -109,6 +109,128 @@ TEST_F(LivePriceManagerTest, UpdateFromBarsLastBarNotFromYesterdaySkipsT1) {
     EXPECT_TRUE(mgr.get_latest_price("ZC").is_ok());
 }
 
+// ===== E2-F14: caller-resolved T-1 date =====
+//
+// Omitted, T-1 is `reference_date - 24h` matched against the LAST bar only. That suits
+// FUTURES, whose runners resolve the book they are finalizing with the same arithmetic
+// (live_portfolio.cpp:1047, live_portfolio_conservative.cpp:1061) -- book and prices name
+// the same day by construction.
+//
+// EQUITIES resolve the book with find_previous_trading_day(), which is calendar-aware. On a
+// Sunday or Monday run that returns FRIDAY while `now - 24h` asks for Sat/Sun, and
+// equities_data.ohlcv_1d has no weekend rows. The already-finalized Friday was then
+// re-finalized against an empty price map and its position rows overwritten with 0/0 by a
+// store_positions that runs outside the gate protecting live_results.
+//
+// Measured on the 2026-07-24..08-04 weekend-inclusive replay: Sat 08-01 finalized Friday at
+// $864.759444; Sun 08-02 and Mon 08-03 each re-zeroed it. L5 residual -864.7594 on 07-31,
+// -14.6574 on 07-24, 0.0000 on every other finalized day.
+
+namespace {
+// Exact UTC midnights, so floor<days> boundaries are unambiguous.
+constexpr int64_t kDay = 86400;
+constexpr int64_t kThu = 20665 * kDay;  // an arbitrary but fixed Thursday
+constexpr int64_t kFri = kThu + kDay;
+constexpr int64_t kSat = kThu + 2 * kDay;
+constexpr int64_t kSun = kThu + 3 * kDay;
+constexpr int64_t kMon = kThu + 4 * kDay;
+}  // namespace
+
+// The futures invariant: passing no t1_date must behave exactly as before.
+TEST_F(LivePriceManagerTest, OmittingT1DateKeepsTheMinus24hRuleForFuturesCallers) {
+    LivePriceManager mgr(nullptr);
+    std::vector<Bar> bars{make_bar("ZC", ts_seconds(kThu), 600.0),
+                          make_bar("ZC", ts_seconds(kFri), 610.0)};
+
+    // Reference Saturday -> expects Friday -> found.
+    ASSERT_TRUE(mgr.update_from_bars(bars, ts_seconds(kSat)).is_ok());
+    auto t1 = mgr.get_previous_day_price("ZC");
+    ASSERT_TRUE(t1.is_ok());
+    EXPECT_DOUBLE_EQ(t1.value(), 610.0);
+
+    // Reference Monday -> expects Sunday -> ag future has no Sunday bar -> skipped.
+    // This is CORRECT for futures and must not become a fallback: falling back to Friday
+    // here would book (Fri-Thu) onto the Sunday row, a move the Saturday run already
+    // booked onto Friday's row.
+    LivePriceManager mgr2(nullptr);
+    ASSERT_TRUE(mgr2.update_from_bars(bars, ts_seconds(kMon)).is_ok());
+    EXPECT_TRUE(mgr2.get_previous_day_price("ZC").is_error())
+        << "The default path gained a T-1 fallback. Futures relies on the skip: with a "
+           "fallback an ag symbol would have the same move settled twice.";
+}
+
+// The equity fix: a Monday run resolving Friday must find Friday's bar.
+TEST_F(LivePriceManagerTest, CallerResolvedT1FindsFridayOnAMondayRun) {
+    LivePriceManager mgr(nullptr);
+    std::vector<Bar> bars{make_bar("AAPL", ts_seconds(kThu), 100.0),
+                          make_bar("AAPL", ts_seconds(kFri), 105.0)};
+
+    // now = Monday, but the book was resolved to Friday by find_previous_trading_day().
+    ASSERT_TRUE(mgr.update_from_bars(bars, ts_seconds(kMon), ts_seconds(kFri)).is_ok());
+
+    auto t1 = mgr.get_previous_day_price("AAPL");
+    ASSERT_TRUE(t1.is_ok())
+        << "The resolved trading day produced no T-1 price. This is the defect: the book "
+           "says Friday, the price lookup asked for Sunday, and Friday's finalized rows "
+           "were overwritten with zeros.";
+    EXPECT_DOUBLE_EQ(t1.value(), 105.0);
+
+    auto t2 = mgr.get_two_days_ago_price("AAPL");
+    ASSERT_TRUE(t2.is_ok());
+    EXPECT_DOUBLE_EQ(t2.value(), 100.0)
+        << "T-2 must be the bar immediately preceding the resolved T-1 bar.";
+}
+
+// The reason the lookup SEARCHES rather than testing back(): on a live run the vendor may
+// already have posted today's bar. A back()-only test would then reject a good Friday.
+TEST_F(LivePriceManagerTest, CallerResolvedT1FindsTheBarEvenWhenALaterBarExists) {
+    LivePriceManager mgr(nullptr);
+    std::vector<Bar> bars{make_bar("MSFT", ts_seconds(kThu), 200.0),
+                          make_bar("MSFT", ts_seconds(kFri), 205.0),
+                          make_bar("MSFT", ts_seconds(kMon), 210.0)};  // today, already posted
+
+    ASSERT_TRUE(mgr.update_from_bars(bars, ts_seconds(kMon), ts_seconds(kFri)).is_ok());
+
+    auto t1 = mgr.get_previous_day_price("MSFT");
+    ASSERT_TRUE(t1.is_ok())
+        << "A back()-only match was reinstated: today's bar is last, so Friday was missed.";
+    EXPECT_DOUBLE_EQ(t1.value(), 205.0);
+    EXPECT_DOUBLE_EQ(mgr.get_two_days_ago_price("MSFT").value(), 200.0);
+}
+
+// A genuine data gap on a real trading day must still be skipped, not papered over.
+TEST_F(LivePriceManagerTest, CallerResolvedT1StillSkipsWhenThatDayHasNoBar) {
+    LivePriceManager mgr(nullptr);
+    std::vector<Bar> bars{make_bar("ABEV", ts_seconds(kThu), 5.0)};  // nothing on Friday
+
+    ASSERT_TRUE(mgr.update_from_bars(bars, ts_seconds(kMon), ts_seconds(kFri)).is_ok());
+
+    EXPECT_TRUE(mgr.get_previous_day_price("ABEV").is_error())
+        << "Supplying t1_date must not become a licence to substitute an older bar. A real "
+           "gap on a real trading day is still a skip.";
+    EXPECT_TRUE(mgr.get_latest_price("ABEV").is_ok())
+        << "latest_prices_ is still populated as a fallback for other consumers.";
+}
+
+// Re-finalizing the same day must be idempotent -- that is what makes the Sun/Mon repeat
+// runs harmless once the date is shared.
+TEST_F(LivePriceManagerTest, CallerResolvedT1IsIdempotentAcrossRepeatedRuns) {
+    std::vector<Bar> bars{make_bar("GOOGL", ts_seconds(kThu), 300.0),
+                          make_bar("GOOGL", ts_seconds(kFri), 310.0)};
+
+    double first = 0.0;
+    for (int64_t ref : {kSat, kSun, kMon}) {
+        LivePriceManager mgr(nullptr);
+        ASSERT_TRUE(mgr.update_from_bars(bars, ts_seconds(ref), ts_seconds(kFri)).is_ok());
+        auto t1 = mgr.get_previous_day_price("GOOGL");
+        ASSERT_TRUE(t1.is_ok()) << "Run with reference day " << ref << " lost the T-1 price.";
+        if (first == 0.0) first = t1.value();
+        EXPECT_DOUBLE_EQ(t1.value(), first)
+            << "Sat/Sun/Mon runs finalizing the same Friday produced different T-1 prices.";
+        EXPECT_DOUBLE_EQ(t1.value(), 310.0);
+    }
+}
+
 // ===== get_*_price miss paths =====
 
 TEST_F(LivePriceManagerTest, GetPreviousDayPriceMissingSymbolReturnsError) {

--- a/tests/live/test_realized_row_retention.cpp
+++ b/tests/live/test_realized_row_retention.cpp
@@ -1,0 +1,166 @@
+// tests/live/test_realized_row_retention.cpp
+//
+// E2-F19 route 3 and gap G1: which trading.positions rows survive a write.
+//
+// A position closed to zero used to write NO row, so the realized P&L of the exit --
+// the largest single figure of an equity position's life -- had nowhere to live at
+// row level. The rule was copied from futures, where an exit realizes exactly zero
+// (average_price is reset to close(T-1) daily and fills strike at close(T-1)), so
+// dropping the row there discards a row that is genuinely empty. Equities carry a
+// true cost basis and the exit realizes the whole accumulated gain.
+//
+// Measured 2026-04-15: TMUS sold out for -402.654413; live_results carried it, the
+// positions table did not, residual 436.64 for the day. Eleven such close events in
+// the 2026-04-01..08-04 series.
+//
+// These tests pin the pure rules the runner applies at both write sites, plus the
+// load-time partition that keeps closed rows out of every other consumer.
+
+#include <gtest/gtest.h>
+
+#include <chrono>
+#include <string>
+#include <unordered_map>
+#include <vector>
+
+#include "trade_ngin/core/types.hpp"
+#include "trade_ngin/live/live_daily_cycle.hpp"
+
+using namespace trade_ngin;
+
+namespace {
+
+Position row(const std::string& symbol, double qty, double realized, double basis = 100.0) {
+    Position p;
+    p.symbol = symbol;
+    p.quantity = Quantity(qty);
+    p.average_price = Decimal(basis);
+    p.unrealized_pnl = Decimal(0.0);
+    p.realized_pnl = Decimal(realized);
+    p.last_update = std::chrono::system_clock::now();
+    return p;
+}
+
+}  // namespace
+
+// ---------------------------------------------------------------------------
+// is_dead_row: drop a row only when it carries neither quantity nor realized.
+// ---------------------------------------------------------------------------
+
+// The futures exit and the persistent-flat case: identical to today.
+TEST(RealizedRowRetention, FlatRowWithNoRealizedIsDead) {
+    EXPECT_TRUE(LiveDailyCycle::is_dead_row(row("MNQ.v.0", 0.0, 0.0)));
+}
+
+// The AAPL/TMUS close-day case: the row that used to be dropped.
+TEST(RealizedRowRetention, ClosedRowCarryingRealizedIsKept) {
+    EXPECT_FALSE(LiveDailyCycle::is_dead_row(row("TMUS", 0.0, -402.654413)))
+        << "an equity exit realizes its whole accumulated gain; the row that carries "
+           "it must survive the write (E2-F19 route 3)";
+}
+
+// A held position that did not trade today: kept, as today.
+TEST(RealizedRowRetention, HeldRowWithNoRealizedIsKept) {
+    EXPECT_FALSE(LiveDailyCycle::is_dead_row(row("TMUS", 20.844513, 0.0)));
+}
+
+// Tolerance is per field, not on the sum. Decimal is fixed-point at 1e-8, so a
+// value below that rounds to exactly zero before the predicate ever sees it; the
+// smallest representable non-zero figure must keep the row on its own.
+TEST(RealizedRowRetention, ToleranceIsPerField) {
+    EXPECT_TRUE(LiveDailyCycle::is_dead_row(row("X", 1e-11, 1e-11)))
+        << "below Decimal resolution both fields are exactly zero";
+    EXPECT_FALSE(LiveDailyCycle::is_dead_row(row("X", 0.0, 1e-7)))
+        << "a realized figure above tolerance keeps the row even at zero quantity";
+    EXPECT_FALSE(LiveDailyCycle::is_dead_row(row("X", 1e-7, 0.0)));
+}
+
+// ---------------------------------------------------------------------------
+// split_open_and_closed: the load-time partition.
+// ---------------------------------------------------------------------------
+
+TEST(RealizedRowRetention, PartitionSeparatesClosedRowsFromTheHeldBook) {
+    std::unordered_map<std::string, Position> loaded{
+        {"DD", row("DD", 7.5738, -15.4473)},
+        {"AAPL", row("AAPL", 0.0, -327.342)},
+        {"META", row("META", 4.148866, 0.0)},
+    };
+    std::unordered_map<std::string, Position> open, closed;
+    LiveDailyCycle::split_open_and_closed(loaded, open, closed);
+
+    ASSERT_EQ(open.size(), 2u);
+    ASSERT_EQ(closed.size(), 1u);
+    EXPECT_TRUE(open.count("DD"));
+    EXPECT_TRUE(open.count("META"));
+    ASSERT_TRUE(closed.count("AAPL"));
+    EXPECT_DOUBLE_EQ(closed.at("AAPL").realized_pnl.as_double(), -327.342)
+        << "a closed row is carried verbatim";
+}
+
+// A book with no closed rows -- today's data, every day -- is returned unchanged.
+TEST(RealizedRowRetention, PartitionIsIdentityOnAnOpenOnlyBook) {
+    std::unordered_map<std::string, Position> loaded{
+        {"DD", row("DD", 7.5738, -15.4473)},
+        {"META", row("META", 4.148866, 73.351951)},
+    };
+    std::unordered_map<std::string, Position> open, closed;
+    LiveDailyCycle::split_open_and_closed(loaded, open, closed);
+    EXPECT_EQ(open.size(), 2u);
+    EXPECT_TRUE(closed.empty());
+}
+
+// ---------------------------------------------------------------------------
+// add_rowless_exits (G1): a symbol the strategy closed out that has no entry in
+// the day-T target map. Reachable when a held name leaves the configured universe
+// (contra-merge, rename, de-configuration): generate_daily_executions emits the
+// close-out, on_execution books the realized, and nothing iterates it into a row.
+// ---------------------------------------------------------------------------
+
+TEST(RealizedRowRetention, StrategyExitWithoutATargetEntryGetsAClosedRow) {
+    const Timestamp now = std::chrono::system_clock::now();
+    std::unordered_map<std::string, Position> positions{{"DD", row("DD", 7.5738, 0.0)}};
+    std::unordered_map<std::string, Position> strategy{
+        {"DD", row("DD", 7.5738, 0.0)},
+        {"MSFT", row("MSFT", 0.0, 100.0)},  // closed out today, absent from targets
+    };
+
+    auto added = LiveDailyCycle::add_rowless_exits(positions, strategy, now);
+
+    ASSERT_EQ(added.size(), 1u) << "exactly one rowless exit must be reported";
+    EXPECT_EQ(added.front(), "MSFT");
+    ASSERT_TRUE(positions.count("MSFT")) << "the exit must now have a row to live on";
+    const auto& synthesized = positions.at("MSFT");
+    EXPECT_DOUBLE_EQ(synthesized.quantity.as_double(), 0.0);
+    EXPECT_DOUBLE_EQ(synthesized.average_price.as_double(), 0.0)
+        << "a closed row records no basis: average_price is a cost basis for a "
+           "position that no longer exists (AVERAGE_PRICE_LIFECYCLE.md)";
+    EXPECT_DOUBLE_EQ(synthesized.unrealized_pnl.as_double(), 0.0);
+    EXPECT_DOUBLE_EQ(synthesized.realized_pnl.as_double(), 100.0);
+    EXPECT_EQ(synthesized.last_update, now);
+    EXPECT_FALSE(LiveDailyCycle::is_dead_row(synthesized));
+}
+
+// A symbol already in the target map is the runner's business, not this helper's.
+TEST(RealizedRowRetention, TargetEntryIsNeverOverwritten) {
+    const Timestamp now = std::chrono::system_clock::now();
+    std::unordered_map<std::string, Position> positions{{"DD", row("DD", 0.0, -15.0)}};
+    std::unordered_map<std::string, Position> strategy{{"DD", row("DD", 0.0, -15.0)}};
+
+    auto added = LiveDailyCycle::add_rowless_exits(positions, strategy, now);
+
+    EXPECT_TRUE(added.empty());
+    EXPECT_DOUBLE_EQ(positions.at("DD").realized_pnl.as_double(), -15.0);
+}
+
+// A strategy symbol with nothing realized and no target entry adds nothing:
+// the configured universe carries flat symbols the strategy also knows about.
+TEST(RealizedRowRetention, FlatStrategySymbolAddsNoRow) {
+    const Timestamp now = std::chrono::system_clock::now();
+    std::unordered_map<std::string, Position> positions;
+    std::unordered_map<std::string, Position> strategy{{"MSFT", row("MSFT", 0.0, 0.0)}};
+
+    auto added = LiveDailyCycle::add_rowless_exits(positions, strategy, now);
+
+    EXPECT_TRUE(added.empty());
+    EXPECT_TRUE(positions.empty());
+}

--- a/tests/portfolio/test_fractional_position_convergence.cpp
+++ b/tests/portfolio/test_fractional_position_convergence.cpp
@@ -1,0 +1,190 @@
+// E2-F1 regression pins.
+//
+// The optimizer/risk loop in PortfolioManager::process_market_data iterates until
+// target positions are integral, applying the risk scale IN PLACE on every lap
+// (portfolio_manager.cpp: `pos.quantity *= risk_result.recommended_scale`).
+//
+// Futures trade whole contracts, so the loop converges on lap 1 and the scale is
+// applied exactly once -- the single application the design comment at that site
+// reasons about. Equities with fractional shares can never satisfy an
+// integrality test, so pre-fix the loop ran all 5 laps, compounded the scale
+// (the gate is scale-invariant, so shrinking never satisfies it -- see E2-F2),
+// and then force-rounded the decayed remainder to an integer, i.e. to zero.
+//
+// Observed in the first ever bt_equity_mr run: META target 2.42425398 decayed
+// 2.424 -> 0.767 -> 0.243 -> 0.077 -> 0.024 -> rounded to 0. Across that run 220
+// days hit max iterations and 107 of 448 forced roundings drove a nonzero target
+// to exactly zero.
+//
+// These tests pin BOTH directions, because pinning only one is what let this
+// survive: the false case is the futures invariant (must keep rounding), the
+// true case is the equities fix (must keep the fraction).
+
+#include <gtest/gtest.h>
+#include <chrono>
+#include <cmath>
+#include <memory>
+#include <thread>
+#include "../core/test_base.hpp"
+#include "../data/test_db_utils.hpp"
+
+#define private public
+#include "trade_ngin/portfolio/portfolio_manager.hpp"
+#undef private
+
+#include "trade_ngin/strategy/base_strategy.hpp"
+
+using namespace trade_ngin;
+using namespace trade_ngin::testing;
+
+namespace {
+
+// Deterministic strategy that always targets the same fractional quantity.
+// Deliberately NOT MockStrategy: that one calls rand(), so it cannot support an
+// exact assertion about a quantity.
+class FixedFractionalStrategy : public BaseStrategy {
+public:
+    FixedFractionalStrategy(std::string id, StrategyConfig config,
+                            std::shared_ptr<DatabaseInterface> db, double qty)
+        : BaseStrategy(std::move(id), std::move(config),
+                       std::static_pointer_cast<trade_ngin::PostgresDatabase>(db)),
+          qty_(qty) {
+        metadata_.name = "Fixed Fractional Strategy";
+    }
+
+    Result<void> on_data(const std::vector<Bar>& data) override {
+        auto base = BaseStrategy::on_data(data);
+        if (base.is_error()) return base;
+        for (const auto& bar : data) {
+            Position pos;
+            pos.symbol = bar.symbol;
+            pos.quantity = Decimal(qty_);
+            pos.average_price = bar.close;
+            pos.last_update = bar.timestamp;
+            positions_[bar.symbol] = pos;
+            last_signals_[bar.symbol] = 1.0;
+        }
+        return Result<void>();
+    }
+
+    std::unordered_map<std::string, Position> get_target_positions() const override {
+        return positions_;
+    }
+
+private:
+    double qty_;
+};
+
+constexpr double kFractionalQty = 2.42425398;  // the observed META target
+
+std::vector<Bar> flat_bars(const std::string& symbol, int n,
+                           std::chrono::system_clock::time_point t0) {
+    std::vector<Bar> v;
+    for (int i = 0; i < n; ++i) {
+        Bar b;
+        b.symbol = symbol;
+        b.timestamp = t0 + std::chrono::hours(24 * i);
+        b.open = b.close = Decimal(100.0);
+        b.high = Decimal(101.0);
+        b.low = Decimal(99.0);
+        b.volume = 100000.0;
+        v.push_back(b);
+    }
+    return v;
+}
+
+PortfolioConfig config_with(bool allow_fractional) {
+    PortfolioConfig c{1'000'000.0, 100'000.0, 1.0, 0.0, /*optimization=*/false,
+                      /*risk=*/false};
+    c.allow_fractional_positions = allow_fractional;
+    c.risk_config.capital = 1'000'000.0;
+    return c;
+}
+
+class FractionalConvergenceTest : public TestBase {
+protected:
+    void SetUp() override {
+        TestBase::SetUp();
+        StateManager::reset_instance();
+        std::this_thread::sleep_for(std::chrono::milliseconds(50));
+        db_ = std::make_shared<MockPostgresDatabase>("mock://testdb");
+        ASSERT_TRUE(db_->connect().is_ok());
+    }
+
+    void TearDown() override {
+        db_.reset();
+        StateManager::reset_instance();
+        std::this_thread::sleep_for(std::chrono::milliseconds(50));
+        TestBase::TearDown();
+    }
+
+    // Runs one process cycle and returns the quantity the loop settled on.
+    double settled_quantity(bool allow_fractional) {
+        static int n = 0;
+        const std::string uid = "FRAC_S_" + std::to_string(++n);
+        auto manager = std::make_unique<PortfolioManager>(config_with(allow_fractional),
+                                                          "PM_FRAC_" + std::to_string(n));
+
+        StrategyConfig sc;
+        sc.capital_allocation = 1'000'000.0;
+        sc.max_leverage = 2.0;
+        sc.asset_classes = {AssetClass::EQUITIES};
+        sc.frequencies = {DataFrequency::DAILY};
+        sc.trading_params["AAPL"] = 1.0;
+        sc.position_limits["AAPL"] = 10000.0;
+
+        auto strat = std::make_shared<FixedFractionalStrategy>(uid, sc, db_, kFractionalQty);
+        EXPECT_TRUE(strat->initialize().is_ok());
+        EXPECT_TRUE(strat->start().is_ok());
+        EXPECT_TRUE(manager->add_strategy(strat, 1.0, false, false).is_ok());
+
+        auto t0 = std::chrono::system_clock::now() - std::chrono::hours(24 * 30);
+        EXPECT_TRUE(manager->process_market_data(flat_bars("AAPL", 25, t0)).is_ok());
+
+        const auto& info = manager->strategies_.at(uid);
+        auto it = info.target_positions.find("AAPL");
+        if (it == info.target_positions.end()) return 0.0;
+        return static_cast<double>(it->second.quantity);
+    }
+
+    std::shared_ptr<MockPostgresDatabase> db_;
+};
+
+}  // namespace
+
+// The equities fix: a fractional target is a legitimate end state and must
+// survive the loop intact. Pre-fix this position was force-rounded away.
+TEST_F(FractionalConvergenceTest, FractionalTargetSurvivesWhenPortfolioPermitsIt) {
+    const double q = settled_quantity(/*allow_fractional=*/true);
+
+    EXPECT_NEAR(q, kFractionalQty, 1e-9)
+        << "A permitted fractional target was altered by the optimizer/risk loop. "
+           "If it came back integral the terminal force-rounding block ran, which "
+           "means the loop did not treat the fraction as converged.";
+
+    // State the property directly, not just the value: the fraction must remain.
+    EXPECT_GT(std::abs(q - std::round(q)), 1e-6)
+        << "Target came back integral; allow_fractional_positions was not honoured.";
+}
+
+// The futures invariant. This is the half that must NOT change: whole-contract
+// portfolios leave the flag false and must still be driven to integers.
+TEST_F(FractionalConvergenceTest, IntegralityStillEnforcedWhenFractionsAreNotPermitted) {
+    const double q = settled_quantity(/*allow_fractional=*/false);
+
+    EXPECT_LT(std::abs(q - std::round(q)), 1e-6)
+        << "A portfolio that does NOT permit fractional positions returned a "
+           "fractional quantity. The futures integrality guarantee has been broken.";
+}
+
+// The two paths must genuinely differ, or both assertions above could be passing
+// for a reason unrelated to the flag (e.g. the loop never ran at all).
+TEST_F(FractionalConvergenceTest, TheFlagIsWhatDecidesTheOutcome) {
+    const double permitted = settled_quantity(true);
+    const double forbidden = settled_quantity(false);
+
+    EXPECT_NE(permitted, forbidden)
+        << "allow_fractional_positions changed nothing. Both paths agreeing means "
+           "the flag is not wired into the convergence test, so this suite would "
+           "not catch a regression of E2-F1.";
+}

--- a/tests/portfolio/test_portfolio_manager.cpp
+++ b/tests/portfolio/test_portfolio_manager.cpp
@@ -787,3 +787,31 @@ TEST_F(PortfolioManagerExtendedTest, ProcessWithOptimizationAndRiskBothEnabled) 
 }
 
 }  // namespace portfolio_manager_extended_detail
+
+// E2-C9: PortfolioManager owns a SECOND TransactionCostManager, independent of the one
+// BacktestCoordinator holds. The PM's prices the executions that reach backtest.executions
+// and the equity curve; the coordinator's prices the copies that feed the reported metrics.
+// Only the coordinator's was ever registered, so one backtest run carried two different cost
+// bases -- stored executions from the static hardcoded configs, metrics from ADV-tiered ones.
+//
+// This pins that the accessor actually reaches the PM's own manager. It cannot pin the app
+// wiring (bt_equity_mean_reversion.cpp must call it alongside the coordinator registration);
+// what it catches is the accessor being a no-op or forwarding to the wrong object.
+TEST_F(PortfolioManagerTest, RegisterEquityCostConfigsReachesTheManagersOwnCostModel) {
+    std::unordered_map<std::string, std::vector<Bar>> bars_by_symbol;
+    for (int i = 0; i < 25; ++i) {
+        Bar b;
+        b.symbol = "AAPL";
+        b.timestamp = std::chrono::system_clock::now() - std::chrono::hours(24 * (25 - i));
+        b.open = b.high = b.low = b.close = Decimal(190.0);
+        b.volume = 40'000'000.0;
+        bars_by_symbol["AAPL"].push_back(b);
+    }
+
+    const int registered = manager_->register_equity_cost_configs({"AAPL"}, bars_by_symbol);
+
+    EXPECT_EQ(registered, 1)
+        << "PortfolioManager::register_equity_cost_configs did not register anything. Its own "
+           "cost manager then keeps whatever initialize_default_configs() gave it, while the "
+           "coordinator's uses ADV-tiered configs -- two cost bases in one backtest run.";
+}

--- a/tests/storage/test_live_results_key_roundtrip_db.cpp
+++ b/tests/storage/test_live_results_key_roundtrip_db.cpp
@@ -181,3 +181,35 @@ TEST_F(LiveResultsKeyRoundTripTest, ThePreFixKeyFindsNothing) {
     EXPECT_TRUE(wrong_portfolio.value().empty())
         << "the row landed on the futures book instead of the configured portfolio";
 }
+
+// E2-F22: what is loaded must equal what was stored, and re-storing the loaded book must be
+// a fixed point -- no +5 h per pass, no migration onto the next date after four passes.
+TEST_F(LiveResultsKeyRoundTripTest, LoadedTimestampEqualsStoredAndRewritesDoNotMigrate) {
+    Position p = make_position("AAPL", 10.0, 100.0);
+    // 18:00 UTC on the 16th (date_at is UTC noon); a drifted parse (+5 h per
+    // pass) would walk it across midnight within the five passes below.
+    p.last_update = date_at(2026, 3, 16) + std::chrono::hours(6);  // 18:00 UTC
+    ASSERT_FALSE(db_->store_positions({p}, kScratchStrategyId, kScratchStrategyName,
+                                      kScratchPortfolio, "trading.positions").is_error());
+
+    for (int pass = 0; pass < 5; ++pass) {
+        auto loaded = db_->load_positions_by_date(kScratchStrategyId, kScratchStrategyName,
+                                                  kScratchPortfolio, date_at(2026, 3, 16),
+                                                  "trading.positions");
+        ASSERT_TRUE(loaded.is_ok()) << loaded.error()->what();
+        ASSERT_EQ(loaded.value().count("AAPL"), 1u) << "pass " << pass << ": row lost";
+        const auto& row = loaded.value().at("AAPL");
+        EXPECT_EQ(row.last_update, p.last_update)
+            << "pass " << pass << ": loaded timestamp drifted from the stored instant";
+        std::vector<Position> again{row};
+        ASSERT_FALSE(db_->store_positions(again, kScratchStrategyId, kScratchStrategyName,
+                                          kScratchPortfolio, "trading.positions").is_error());
+    }
+
+    auto next_day = db_->load_positions_by_date(kScratchStrategyId, kScratchStrategyName,
+                                                kScratchPortfolio, date_at(2026, 3, 17),
+                                                "trading.positions");
+    ASSERT_TRUE(next_day.is_ok());
+    EXPECT_TRUE(next_day.value().empty())
+        << "five rewrites must never put a 2026-03-16 row onto 2026-03-17";
+}

--- a/tests/strategy/test_equity_pnl_accounting.cpp
+++ b/tests/strategy/test_equity_pnl_accounting.cpp
@@ -192,3 +192,96 @@ TEST_F(EquityPnLAccountingTest, TieredEquityConfig) {
     EXPECT_NEAR(penny.tick_size, 0.0001, 1e-8);  // Sub-dollar tick size
     EXPECT_NEAR(penny.baseline_spread_ticks, 10.0, 1e-6);
 }
+
+// ===========================================================================
+// E2-F8: the target position carries a MARK, positions_ carries the BASIS.
+//
+// The backtest coordinator's unrealized calculation reads average_price off the
+// positions returned by get_strategy_positions(), which are the strategy's TARGET
+// positions -- and MeanReversionStrategy::get_target_positions() sets
+// `pos.average_price = inst_data.current_price` (mean_reversion.cpp:214), the day's
+// close. Measured against the live DB, the mark implied by day D's stored unrealized
+// equalled day D+1's stored average_price on ~87% of consecutive rows: the column was
+// a one-day mark change, not a position-lifetime unrealized.
+//
+// BaseStrategy::on_execution() is the sole legitimate writer of a volume-weighted cost
+// basis and keeps it in positions_, which get_target_positions() deliberately does not
+// read. The coordinator must therefore prefer positions_ when measuring unrealized.
+//
+// These pin the divergence itself. If someone later "fixes" get_target_positions() to
+// return the basis, the first test fails and points them at the coordinator so the two
+// fixes cannot silently double up. See docs/AVERAGE_PRICE_LIFECYCLE.md for the three
+// meanings of this field and which is in force where.
+// ===========================================================================
+
+TEST_F(EquityPnLAccountingTest, TargetPositionsCarryTheMarkWhileHeldPositionsCarryTheBasis) {
+    strategy_ = std::make_unique<MeanReversionStrategy>("test_basis_vs_mark", strategy_config_,
+                                                        mr_config_, db_);
+    ASSERT_TRUE(strategy_->initialize().is_ok());
+    strategy_->start();
+
+    ExecutionReport fill;
+    fill.symbol = "AAPL";
+    fill.side = Side::BUY;
+    fill.fill_price = 150.0;
+    fill.filled_quantity = 100;
+    fill.fill_time = std::chrono::system_clock::now();
+    fill.total_transaction_costs = 0.0;
+    ASSERT_TRUE(strategy_->on_execution(fill).is_ok());
+
+    // A later bar at a different price.
+    std::vector<Bar> bars = {make_bar("AAPL", 160.0)};
+    ASSERT_TRUE(strategy_->on_data(bars).is_ok());
+
+    // The fill-maintained record holds what the position COST.
+    const auto& held = strategy_->get_positions();
+    auto h = held.find("AAPL");
+    ASSERT_NE(h, held.end());
+    EXPECT_NEAR(static_cast<double>(h->second.average_price), 150.0, 1e-6)
+        << "positions_ must hold the fill-weighted cost basis -- on_execution is its sole "
+           "writer.";
+
+    // The target position holds what it is WORTH. These are different quantities and the
+    // coordinator must not confuse them.
+    auto targets = strategy_->get_target_positions();
+    auto t = targets.find("AAPL");
+    ASSERT_NE(t, targets.end());
+    EXPECT_NEAR(static_cast<double>(t->second.average_price), 160.0, 1e-6)
+        << "get_target_positions() no longer reports the mark. If this was deliberate, the "
+           "basis resolution in BacktestCoordinator (E2-F8) is now redundant and must be "
+           "removed in the same change -- otherwise the two corrections stack.";
+
+    EXPECT_NE(static_cast<double>(h->second.average_price),
+              static_cast<double>(t->second.average_price))
+        << "The mark and the basis have converged, so this fixture no longer exercises the "
+           "divergence it exists to pin.";
+}
+
+TEST_F(EquityPnLAccountingTest, OnExecutionMaintainsVolumeWeightedBasisAcrossFills) {
+    strategy_ = std::make_unique<MeanReversionStrategy>("test_vwap_basis", strategy_config_,
+                                                        mr_config_, db_);
+    ASSERT_TRUE(strategy_->initialize().is_ok());
+    strategy_->start();
+
+    ExecutionReport first;
+    first.symbol = "AAPL";
+    first.side = Side::BUY;
+    first.fill_price = 150.0;
+    first.filled_quantity = 100;
+    first.fill_time = std::chrono::system_clock::now();
+    first.total_transaction_costs = 0.0;
+    ASSERT_TRUE(strategy_->on_execution(first).is_ok());
+
+    ExecutionReport second = first;
+    second.fill_price = 170.0;
+    second.filled_quantity = 100;
+    ASSERT_TRUE(strategy_->on_execution(second).is_ok());
+
+    const auto& held = strategy_->get_positions();
+    auto h = held.find("AAPL");
+    ASSERT_NE(h, held.end());
+    EXPECT_NEAR(static_cast<double>(h->second.quantity), 200.0, 1e-6);
+    EXPECT_NEAR(static_cast<double>(h->second.average_price), 160.0, 1e-6)
+        << "Two 100-share buys at 150 and 170 must give a 160.00 weighted basis. This is "
+           "the value the backtest coordinator now measures unrealized against.";
+}

--- a/tests/strategy/test_equity_pnl_accounting.cpp
+++ b/tests/strategy/test_equity_pnl_accounting.cpp
@@ -157,7 +157,9 @@ TEST_F(EquityPnLAccountingTest, UnknownEquityGetsCorrectDefaults) {
     auto equity_config = registry.get_config("RANDOM_STOCK", AssetType::EQUITY);
     EXPECT_NEAR(equity_config.point_value, 1.0, 1e-6);        // NOT 100.0
     EXPECT_NEAR(equity_config.commission_per_unit, 0.005, 1e-6); // NOT -1.0
-    EXPECT_TRUE(equity_config.apply_regulatory_fees);
+    // E2-C3: IBKR Pro Fixed is all-inclusive of exchange, clearing and regulatory fees, so
+    // SEC/FINRA must NOT be charged separately. True would be correct under Tiered.
+    EXPECT_FALSE(equity_config.apply_regulatory_fees);
 
     // Unknown futures should still get futures defaults
     auto futures_config = registry.get_config("UNKNOWN_FUTURE");
@@ -172,8 +174,13 @@ TEST_F(EquityPnLAccountingTest, KnownEquityGetsExplicitConfig) {
     auto aapl_config = registry.get_config("AAPL");
     EXPECT_NEAR(aapl_config.point_value, 1.0, 1e-6);
     EXPECT_NEAR(aapl_config.commission_per_unit, 0.005, 1e-6);
-    EXPECT_TRUE(aapl_config.apply_regulatory_fees);
-    EXPECT_NEAR(aapl_config.max_commission_pct, 0.005, 1e-6);  // 0.5% cap
+    // E2-C3 / E2-C1: the equity schedule is IBKR Pro FIXED throughout -- $0.005/share,
+    // $1.00 minimum, 1% maximum, fees included. It previously carried Tiered's 0.5% cap on
+    // top of Fixed's rate and minimum, taking the worse half of each tier. Switching to
+    // Tiered is a three-field change (rate -> 0.0005-0.0035, minimum -> 0.35,
+    // apply_regulatory_fees -> true), not a one-field one.
+    EXPECT_FALSE(aapl_config.apply_regulatory_fees);
+    EXPECT_NEAR(aapl_config.max_commission_pct, 0.01, 1e-6);  // 1% cap (Fixed)
 }
 
 TEST_F(EquityPnLAccountingTest, TieredEquityConfig) {

--- a/tests/strategy/test_live_daily_cycle_seeding.cpp
+++ b/tests/strategy/test_live_daily_cycle_seeding.cpp
@@ -8,6 +8,8 @@
 
 #include "../core/test_base.hpp"
 #include "../data/test_db_utils.hpp"
+#include "trade_ngin/instruments/instrument_registry.hpp"
+#include "trade_ngin/live/execution_manager.hpp"
 #include "trade_ngin/live/live_daily_cycle.hpp"
 #include "trade_ngin/live/live_pnl_manager.hpp"
 #include "trade_ngin/strategy/mean_reversion.hpp"
@@ -381,4 +383,279 @@ TEST_F(LiveDailyCycleSeedingTest, BacktestAccumulationPathIsUnchanged) {
     ASSERT_TRUE(strategy->on_data(bars).is_ok());
     EXPECT_GT(strategy->get_position("AAPL"), 0.0)
         << "the accumulated holding is held inside the hold band";
+}
+
+// ---------------------------------------------------------------------------
+// E2-F19 / E2-F20: the seeded book must not carry yesterday's realized P&L into
+// today's row.
+//
+// seed_positions() is a wholesale copy, so positions_[sym].realized_pnl started
+// each session at whatever the loaded T-1 row held, and on_execution() added
+// today's fills on top. The persisted day-T row was therefore yesterday's value
+// plus today's trades -- and on a Monday, yesterday's value was Friday's MARK MOVE,
+// because the Saturday and Sunday runs had each finalized Friday (E2-F20).
+//
+// metrics_.realized_pnl is a separate accumulator that seeding never touches; it
+// feeds live_results.daily_realized_pnl and has always been correct. These tests
+// pin that asymmetry: the per-position figure becomes today's flow, the aggregate
+// does not move.
+// ---------------------------------------------------------------------------
+
+namespace {
+
+Position held_with_pnl(const std::string& symbol, double quantity, double average_price,
+                       double realized, double unrealized) {
+    Position pos;
+    pos.symbol = symbol;
+    pos.quantity = Quantity(quantity);
+    pos.average_price = Decimal(average_price);
+    pos.realized_pnl = Decimal(realized);
+    pos.unrealized_pnl = Decimal(unrealized);
+    pos.last_update = std::chrono::system_clock::now();
+    return pos;
+}
+
+ExecutionReport fill(const std::string& symbol, Side side, double qty, double price) {
+    ExecutionReport f;
+    f.order_id = "T_" + symbol;
+    f.exec_id = "T_" + symbol + "_X";
+    f.symbol = symbol;
+    f.side = side;
+    f.filled_quantity = Quantity(qty);
+    f.fill_price = Price(price);
+    f.fill_time = std::chrono::system_clock::now();
+    return f;
+}
+
+}  // namespace
+
+// T-6. Seeding hands the strategy quantity, basis and mark; it does NOT hand it a
+// realized figure. unrealized is asserted at the value on_data re-marks it to --
+// (close - basis) x qty -- which is the stronger claim: the seeded basis reached
+// the mark, so the seed did not zero the basis along with realized.
+TEST_F(LiveDailyCycleSeedingTest, SeedZeroesRealizedAndKeepsBasisAndMark) {
+    auto bars = hold_band_series("AAPL");  // closes at 98.5
+    auto seeded = create_strategy();
+    std::unordered_map<std::string, Position> previous{
+        {"AAPL", held_with_pnl("AAPL", 100.0, 98.0, /*realized*/ -466.969196,
+                               /*unrealized*/ 12.34)}};
+    ASSERT_TRUE(
+        LiveDailyCycle::prepare_strategy_for_signals(*seeded, previous, bars).is_ok());
+
+    const auto& positions = seeded->get_positions();
+    auto it = positions.find("AAPL");
+    ASSERT_NE(it, positions.end());
+    EXPECT_DOUBLE_EQ(it->second.quantity.as_double(), 100.0);
+    EXPECT_DOUBLE_EQ(it->second.average_price.as_double(), 98.0)
+        << "the seeded cost basis must survive: the stop-loss measures from it";
+    EXPECT_NEAR(it->second.unrealized_pnl.as_double(), (98.5 - 98.0) * 100.0, 1e-6)
+        << "unrealized is re-marked from the seeded basis; update_metrics() sums it "
+           "into the drawdown gate, so it must be seeded, not zeroed";
+    EXPECT_DOUBLE_EQ(it->second.realized_pnl.as_double(), 0.0)
+        << "yesterday's realized must not be seeded: the row is a per-day flow "
+           "(E2-F19 route 1)";
+}
+
+// T-7. The day's row is the day's trade, not the day's trade plus the chain.
+// Real TMUS 2026-04-15 numbers: closing SELL 37.515436 @ 190 against a 200.733033
+// basis realizes -402.654413. The map had -466.969196 seeded from the prior row,
+// and stored -869.62 for the day; live_results stored -402.6544. This is the test
+// that would have caught the second reverted attempt.
+TEST_F(LiveDailyCycleSeedingTest, SeededRealizedDoesNotLeakIntoTheDaysFill) {
+    mr_config_.use_stop_loss = false;  // basis 200.73 vs 98.5 closes would fire it
+    strategy_config_.trading_params["TMUS"] = 1.0;
+    strategy_config_.position_limits["TMUS"] = 100000.0;
+
+    const double qty = 37.515436;
+    const double basis = 200.733033;
+    const double exit = 190.0;
+    const double expected = (exit - basis) * qty;  // -402.654413
+
+    auto bars = hold_band_series("TMUS");
+    auto seeded = create_strategy();
+    std::unordered_map<std::string, Position> previous{
+        {"TMUS", held_with_pnl("TMUS", qty, basis, /*realized*/ -466.969196, 0.0)}};
+    ASSERT_TRUE(
+        LiveDailyCycle::prepare_strategy_for_signals(*seeded, previous, bars).is_ok());
+
+    ASSERT_TRUE(seeded->on_execution(fill("TMUS", Side::SELL, qty, exit)).is_ok());
+
+    const auto& positions = seeded->get_positions();
+    auto it = positions.find("TMUS");
+    ASSERT_NE(it, positions.end());
+    EXPECT_NEAR(it->second.realized_pnl.as_double(), expected, 1e-6)
+        << "the per-position realized must be today's fill alone, not the seeded "
+           "chain plus today's fill";
+    EXPECT_DOUBLE_EQ(it->second.quantity.as_double(), 0.0);
+
+    // The control: the aggregate accumulator was never seeded and is unchanged
+    // by this fix. It must equal the same figure in both the old and new world.
+    EXPECT_NEAR(seeded->get_metrics().realized_pnl, expected, 1e-6)
+        << "metrics_.realized_pnl feeds live_results and must not move";
+}
+
+// ---------------------------------------------------------------------------
+// T-12. Three sessions -- open, hold, close -- with the T-1 finalization
+// interposed between them the way the runner does it. Without the interposed
+// finalize the old code also passes, because a day-1 row seeded with realized 0
+// stays 0; the contamination needs the finalizer to have rewritten the row
+// first (F20 Fact B). Every day: sum of per-position realized == the aggregate
+// accumulator + the day's costs, and day 2's row is 0 while day 3's carries the
+// exit.
+// ---------------------------------------------------------------------------
+TEST_F(LiveDailyCycleSeedingTest, ThreeDayFlowWithInterposedFinalization) {
+    mr_config_.use_stop_loss = false;
+    strategy_config_.trading_params["TMUS"] = 1.0;
+    strategy_config_.position_limits["TMUS"] = 100000.0;
+
+    ExecutionManager em;
+    LivePnLManager pnl(100000.0, InstrumentRegistry::instance());
+    const Timestamp now = std::chrono::system_clock::now();
+    auto bars = hold_band_series("TMUS");
+
+    // The "database": what each session loads is what the previous session's
+    // T-1 finalization left behind, not what the previous session wrote.
+    auto finalize_like_a_weekend = [&](const std::unordered_map<std::string, Position>& book,
+                                       double t2, double t1) {
+        std::vector<Position> prev;
+        for (const auto& [_, p] : book) prev.push_back(p);
+        auto r = pnl.finalize_previous_day(prev, {{"TMUS", t1}}, {{"TMUS", t2}}, 100000.0,
+                                           0.0, LivePnLManager::UnrealizedPolicy::MARK_TO_MARKET);
+        EXPECT_TRUE(r.is_ok());
+        auto finalized = r.value().finalized_positions;
+        LiveDailyCycle::restore_loaded_realized(finalized, book);
+        std::unordered_map<std::string, Position> out;
+        for (const auto& p : finalized) out[p.symbol] = p;
+        return out;
+    };
+
+    auto run_day = [&](const std::unordered_map<std::string, Position>& loaded,
+                       double target_qty, double t1_close) {
+        auto strat = create_strategy();
+        EXPECT_TRUE(
+            LiveDailyCycle::prepare_strategy_for_signals(*strat, loaded, bars).is_ok());
+
+        std::unordered_map<std::string, Position> positions;
+        Position target;
+        target.symbol = "TMUS";
+        target.quantity = Quantity(target_qty);
+        target.average_price = Decimal(t1_close);
+        target.last_update = now;
+        positions["TMUS"] = target;
+
+        auto outcome = LiveDailyCycle::execute_day_t(em, positions, loaded,
+                                                     {{"TMUS", t1_close}}, bars, now);
+        EXPECT_TRUE(outcome.is_ok());
+        double costs = 0.0;
+        for (const auto& e : outcome.value().executions) {
+            EXPECT_TRUE(strat->on_execution(e).is_ok());
+            costs += e.total_transaction_costs.as_double();
+        }
+        LiveDailyCycle::resolve_and_apply_basis(positions, strat->get_positions(), loaded,
+                                                outcome.value().execution_prices);
+
+        double row_sum = 0.0;
+        for (const auto& [_, p] : positions) row_sum += p.realized_pnl.as_double();
+        EXPECT_NEAR(row_sum, strat->get_metrics().realized_pnl + costs, 1e-6)
+            << "rows must sum to the aggregate on every day (protocol L5)";
+        return positions;
+    };
+
+    // Day 1: open 10 @ 100.
+    auto day1 = run_day({}, 10.0, 100.0);
+    ASSERT_TRUE(day1.count("TMUS"));
+    EXPECT_DOUBLE_EQ(day1.at("TMUS").realized_pnl.as_double(), 0.0);
+
+    // Weekend: day 1's row is finalized (twice would be the same) before day 2 reads it.
+    auto day1_as_loaded = finalize_like_a_weekend(day1, 100.0, 105.0);
+
+    // Day 2: hold. Nothing traded, so the row must be 0 -- not the 50.0 mark move
+    // the finalizer wrote onto day 1's row.
+    auto day2 = run_day(day1_as_loaded, 10.0, 105.0);
+    ASSERT_TRUE(day2.count("TMUS"));
+    EXPECT_DOUBLE_EQ(day2.at("TMUS").realized_pnl.as_double(), 0.0)
+        << "a held, untraded position realizes nothing today; a mark move leaked "
+           "in through the seed (E2-F20)";
+
+    auto day2_as_loaded = finalize_like_a_weekend(day2, 105.0, 110.0);
+
+    // Day 3: close at 110. The exit realizes 10 x (110 - 100) = 100 -- and it must
+    // be on a row, i.e. the qty-0 entry is not dead.
+    auto day3 = run_day(day2_as_loaded, 0.0, 110.0);
+    ASSERT_TRUE(day3.count("TMUS"));
+    EXPECT_DOUBLE_EQ(day3.at("TMUS").quantity.as_double(), 0.0);
+    EXPECT_NEAR(day3.at("TMUS").realized_pnl.as_double(), 100.0, 1e-6)
+        << "the close-day row carries the exit's realized";
+    EXPECT_FALSE(LiveDailyCycle::is_dead_row(day3.at("TMUS")))
+        << "the day-T write must keep the close-day row (E2-F19 route 3)";
+}
+
+// ---------------------------------------------------------------------------
+// G1 in both shapes. The runner's day-T book comes from the strategy's target
+// map, which covers the configured universe. A held symbol IN the universe gets a
+// qty-0 target and the close-out flows through the ordinary delta path (route 3:
+// the row exists and must not be dropped). A held symbol NOT in the universe --
+// contra-merged, renamed, or de-configured -- gets a close-out from
+// generate_daily_executions' second loop and no row at all (G1: a row must be
+// synthesized).
+// ---------------------------------------------------------------------------
+TEST_F(LiveDailyCycleSeedingTest, CloseOutOfAConfiguredSymbolKeepsItsRow) {
+    ExecutionManager em;
+    const Timestamp now = std::chrono::system_clock::now();
+    auto bars = hold_band_series("MSFT");
+    auto strat = create_strategy();
+    std::unordered_map<std::string, Position> previous{
+        {"MSFT", held_with_pnl("MSFT", 10.0, 100.0, 0.0, 0.0)}};
+    ASSERT_TRUE(LiveDailyCycle::prepare_strategy_for_signals(*strat, previous, bars).is_ok());
+
+    std::unordered_map<std::string, Position> positions;
+    Position target;
+    target.symbol = "MSFT";
+    target.quantity = Quantity(0.0);
+    target.last_update = now;
+    positions["MSFT"] = target;
+
+    auto outcome = LiveDailyCycle::execute_day_t(em, positions, previous, {{"MSFT", 110.0}},
+                                                 bars, now);
+    ASSERT_TRUE(outcome.is_ok());
+    ASSERT_EQ(outcome.value().executions.size(), 1u);
+    ASSERT_TRUE(strat->on_execution(outcome.value().executions.front()).is_ok());
+    LiveDailyCycle::resolve_and_apply_basis(positions, strat->get_positions(), previous,
+                                            outcome.value().execution_prices);
+
+    ASSERT_TRUE(positions.count("MSFT"));
+    EXPECT_NEAR(positions.at("MSFT").realized_pnl.as_double(), 100.0, 1e-6);
+    EXPECT_FALSE(LiveDailyCycle::is_dead_row(positions.at("MSFT")));
+}
+
+TEST_F(LiveDailyCycleSeedingTest, CloseOutOfAnUnconfiguredSymbolGetsARow) {
+    ExecutionManager em;
+    const Timestamp now = std::chrono::system_clock::now();
+    auto bars = hold_band_series("MSFT");
+    auto strat = create_strategy();
+    std::unordered_map<std::string, Position> previous{
+        {"MSFT", held_with_pnl("MSFT", 10.0, 100.0, 0.0, 0.0)}};
+    ASSERT_TRUE(LiveDailyCycle::prepare_strategy_for_signals(*strat, previous, bars).is_ok());
+
+    // MSFT has left the universe: no target entry at all.
+    std::unordered_map<std::string, Position> positions;
+
+    auto outcome = LiveDailyCycle::execute_day_t(em, positions, previous, {{"MSFT", 110.0}},
+                                                 bars, now);
+    ASSERT_TRUE(outcome.is_ok());
+    ASSERT_EQ(outcome.value().executions.size(), 1u)
+        << "generate_daily_executions must close out a held symbol absent from targets";
+    EXPECT_EQ(outcome.value().executions.front().side, Side::SELL);
+    ASSERT_TRUE(strat->on_execution(outcome.value().executions.front()).is_ok());
+    LiveDailyCycle::resolve_and_apply_basis(positions, strat->get_positions(), previous,
+                                            outcome.value().execution_prices);
+    EXPECT_FALSE(positions.count("MSFT")) << "precondition: no row exists yet for the exit";
+
+    auto added = LiveDailyCycle::add_rowless_exits(positions, strat->get_positions(), now);
+
+    ASSERT_EQ(added.size(), 1u);
+    ASSERT_TRUE(positions.count("MSFT")) << "the exit's realized needs a row (G1)";
+    EXPECT_NEAR(positions.at("MSFT").realized_pnl.as_double(), 100.0, 1e-6);
+    EXPECT_DOUBLE_EQ(positions.at("MSFT").quantity.as_double(), 0.0);
+    EXPECT_FALSE(LiveDailyCycle::is_dead_row(positions.at("MSFT")));
 }

--- a/tests/transaction_cost/test_transaction_cost_manager.cpp
+++ b/tests/transaction_cost/test_transaction_cost_manager.cpp
@@ -83,14 +83,25 @@ TEST(ADVClassifierWireupTest, MegaCapSymbolGetsTier1Config) {
     EXPECT_EQ(cfg.asset_type, AssetType::EQUITY);
     EXPECT_DOUBLE_EQ(cfg.point_value, 1.0);
     EXPECT_DOUBLE_EQ(cfg.commission_per_unit, 0.005);
-    EXPECT_TRUE(cfg.apply_regulatory_fees);
+    // E2-C3: false under IBKR Pro Fixed, whose $0.005/share is all-inclusive of exchange,
+    // clearing and regulatory fees. Charging SEC/FINRA on top double-charges. It would be
+    // true under Tiered, where fees are passed through.
+    EXPECT_FALSE(cfg.apply_regulatory_fees);
     EXPECT_LE(cfg.baseline_spread_ticks, 2.0)
         << "Mega-cap should have tight spread (≤2 ticks); got "
         << cfg.baseline_spread_ticks;
 }
 
-// Symbol with no bars gets skipped (warning logged); not registered.
-TEST(ADVClassifierWireupTest, SymbolWithNoBarsIsSkipped) {
+// E2-F14: a symbol with no bars is registered with the UNTIERED EQUITY DEFAULT, not
+// skipped. Skipping left it absent from configs_, and an absent symbol does not fall back
+// to the equity default -- get_config() only reaches that when the caller passes
+// AssetType::EQUITY, which none of the nine production call sites does. So a skipped equity
+// resolved to the FUTURES default: $1.50/share instead of $0.005 and point_value 100
+// instead of 1. Worse, configs_ is one flat map shared across asset classes and real tickers
+// collide with futures roots (CL = Colgate-Palmolive AND Crude Oil; ES = Eversource AND the
+// E-mini S&P). Registering the default makes the futures fallthrough unreachable for a
+// configured equity regardless of what any call site passes.
+TEST(ADVClassifierWireupTest, SymbolWithNoBarsGetsEquityDefaultNotFuturesPricing) {
     TransactionCostManager::Config tcm_config;
     TransactionCostManager tcm(tcm_config);
 
@@ -98,11 +109,18 @@ TEST(ADVClassifierWireupTest, SymbolWithNoBarsIsSkipped) {
     // No entry for "MSFT".
 
     int registered = tcm.register_equity_costs_from_bars({"MSFT"}, bars_by_symbol);
-    EXPECT_EQ(registered, 0);
+    EXPECT_EQ(registered, 1) << "A configured equity with no bars must still be registered.";
+
+    AssetCostConfig cfg = tcm.get_asset_config("MSFT");
+    EXPECT_DOUBLE_EQ(cfg.point_value, 1.0)
+        << "Unregistered equity inherited a futures point_value -- 100x the slippage.";
+    EXPECT_DOUBLE_EQ(cfg.commission_per_unit, 0.005)
+        << "Unregistered equity inherited the futures per-contract fee, i.e. $1.50/SHARE.";
 }
 
-// Symbol with bars but zero volume is skipped (degenerate ADV).
-TEST(ADVClassifierWireupTest, ZeroVolumeIsSkipped) {
+// E2-F14: same reasoning as the no-bars case -- a degenerate ADV must not leave a
+// configured equity resolving as a future.
+TEST(ADVClassifierWireupTest, ZeroVolumeGetsEquityDefaultNotFuturesPricing) {
     TransactionCostManager::Config tcm_config;
     TransactionCostManager tcm(tcm_config);
 
@@ -110,7 +128,11 @@ TEST(ADVClassifierWireupTest, ZeroVolumeIsSkipped) {
     bars_by_symbol["GOOG"] = synthetic_equity_bars("GOOG", 20, 150.0, /*volume=*/0.0);
 
     int registered = tcm.register_equity_costs_from_bars({"GOOG"}, bars_by_symbol);
-    EXPECT_EQ(registered, 0);
+    EXPECT_EQ(registered, 1) << "A zero-ADV equity must still be registered.";
+
+    AssetCostConfig cfg = tcm.get_asset_config("GOOG");
+    EXPECT_DOUBLE_EQ(cfg.point_value, 1.0);
+    EXPECT_DOUBLE_EQ(cfg.commission_per_unit, 0.005);
 }
 
 // Smaller bar history than the lookback window still computes ADV from what
@@ -421,4 +443,91 @@ TEST(UnknownEquityCostsDispatchTest, WithoutHintFallsThroughToFuturesDefault) {
     EXPECT_GT(result.commissions_fees, 1.50)
         << "Without an equity hint, fallback should still be futures-shaped. "
            "If this asserts because the result is ~$1, dispatch defaults changed.";
+}
+
+// ===========================================================================
+// E2-C1 / E2-C2 / E2-C3 -- the equity commission schedule is IBKR Pro FIXED:
+//   $0.005/share, minimum $1.00 per order, maximum 1% of trade value,
+//   all-inclusive of exchange, clearing and regulatory fees.
+//
+// The floor and the cap do different jobs and only collide on very small orders --
+// exactly what a fractional-share book trades. The floor protects the broker on
+// small-but-normal orders; the cap protects the client on tiny ones. IBKR publishes the
+// cap as "Maximum per order", so it is a ceiling and must be applied LAST.
+//
+// The code computed max(floor, min(cap, raw)), which let the floor override the cap and
+// made max_commission_pct provably dead for any stock above $0.50/share: the inner
+// min(cap, raw) picks the cap only when pct*price < commission_per_unit, so above that the
+// expression collapsed to max(floor, raw) and the configured cap could not change a single
+// output value.
+//
+// Real numbers from EQUITY_MR_PORTFOLIO, 2026-07-24..08-03, so the fixture cannot drift
+// from what production produced: the cap should have bound on 5 of 15 executions and did
+// not, a 21% over-charge ($15.00 vs $12.35) concentrated on the smallest clips.
+// ===========================================================================
+
+namespace {
+// AAPL et al. are pre-registered by initialize_default_configs(), so these exercise the
+// real production config rather than a synthetic one.
+TransactionCostManager make_equity_tcm() {
+    TransactionCostManager::Config cfg;
+    return TransactionCostManager(cfg);
+}
+}  // namespace
+
+TEST(EquityCommissionSchedule, CapSupersedesFloorOnATinyOrder) {
+    auto tcm = make_equity_tcm();
+
+    // The worst observed case: AMZN 2026-07-29, 0.081001 shares at $230.86 = $18.70 notional.
+    //   raw  = 0.081001 * 0.005 = $0.000405
+    //   cap  = 1% * 18.70       = $0.187
+    //   floor                   = $1.00
+    const double qty = 0.081001, px = 230.86;
+    auto r = tcm.calculate_costs("AMZN", qty, px);
+
+    EXPECT_NEAR(r.commissions_fees, 0.01 * qty * px, 1e-9)
+        << "The 1% cap did not bind. Production charged $1.00 on an $18.70 trade -- 535 bps "
+           "where the schedule caps at 100 bps. A maximum a minimum can exceed is not a "
+           "maximum; the cap must be applied after the floor.";
+    EXPECT_LT(r.commissions_fees, 1.0)
+        << "Commission is still pinned at the $1.00 floor, i.e. the old clamp order.";
+}
+
+TEST(EquityCommissionSchedule, FloorAppliesWhenTheCapSitsAboveIt) {
+    auto tcm = make_equity_tcm();
+
+    // GOOGL 2026-07-24: 7.149959 shares at $317.69 = $2,271.47 notional.
+    //   raw = $0.0357, cap = 1% * 2271.47 = $22.71, floor = $1.00  -> floor wins.
+    auto r = tcm.calculate_costs("GOOGL", 7.149959, 317.69);
+
+    EXPECT_NEAR(r.commissions_fees, 1.00, 1e-9)
+        << "The $1.00 per-order minimum stopped applying on a normal-sized order. The cap "
+           "must not be allowed to pull the charge below the floor when it sits above it.";
+}
+
+TEST(EquityCommissionSchedule, LargeOrderPaysThePerShareRate) {
+    auto tcm = make_equity_tcm();
+
+    // 10,000 shares at $300: raw = $50, floor $1.00, cap 1% * 3,000,000 = $30,000.
+    // Neither bound applies -- the per-share rate is what is charged.
+    auto r = tcm.calculate_costs("AAPL", 10000.0, 300.0);
+
+    EXPECT_NEAR(r.commissions_fees, 50.0, 1e-9)
+        << "A large order should pay the per-share rate, with neither bound binding.";
+}
+
+TEST(EquityCommissionSchedule, RegulatoryFeesAreNotChargedOnTopOfFixed) {
+    auto tcm = make_equity_tcm();
+
+    // AMZN 2026-08-03 sell: 16.590374 shares at $271.58 = $4,505.61.
+    // Under Fixed the $0.005/share already includes exchange, clearing and regulatory fees,
+    // so SEC ($0.0928 here) and FINRA TAF ($0.0032) must NOT be added.
+    const double qty = 16.590374, px = 271.58;
+    auto sell = tcm.calculate_costs("AMZN", -qty, px);
+    auto buy = tcm.calculate_costs("AMZN", qty, px);
+
+    EXPECT_NEAR(sell.commissions_fees, buy.commissions_fees, 1e-9)
+        << "A sell was charged more than the identical buy, i.e. regulatory fees were added "
+           "on top of an all-inclusive Fixed schedule. That is a double-charge. It would be "
+           "correct under Tiered, where fees are passed through.";
 }

--- a/tests/transaction_cost/test_transaction_cost_manager.cpp
+++ b/tests/transaction_cost/test_transaction_cost_manager.cpp
@@ -531,3 +531,73 @@ TEST(EquityCommissionSchedule, RegulatoryFeesAreNotChargedOnTopOfFixed) {
            "on top of an all-inclusive Fixed schedule. That is a double-charge. It would be "
            "correct under Tiered, where fees are passed through.";
 }
+
+// ===========================================================================
+// E2-F3: a missing prior close must omit the RETURN, not the VOLUME.
+//
+// BacktestCoordinator used to `continue` when a symbol had no bar on the previous processed
+// day, skipping update_market_data entirely -- which dropped the volume observation along
+// with the log return. Volume is a valid, correct observation regardless of whether a prior
+// bar exists, and ADV is what sizes market impact.
+//
+// The futures universe has mixed calendars: the eight grain/livestock roots have ZERO Sunday
+// bars while the rest of the book has ~95 over two years, so every Monday those symbols hit
+// the missing-prior-bar path. That excluded Mondays from a 20-day ADV window for ten symbols
+// -- 6.7% of all symbol-days, ~21% of trading days for those ten. KE.v.0 sits on the 20,000
+// ADV bucket boundary (20,092 with Mondays, 19,948 without), flipping its impact coefficient
+// 60 -> 80 bps purely on which days were counted.
+//
+// The coordinator now passes prev_close = 0.0 instead of skipping, relying on the gate below.
+// Do NOT "fix" this by passing prev_close = close (what main does): that injects a
+// log(close/close) = 0 return, a false observation that biases volatility downward.
+// ===========================================================================
+
+TEST(MarketDataUpdate, ZeroPrevCloseStillRecordsVolume) {
+    TransactionCostManager::Config cfg;
+    TransactionCostManager tcm(cfg);
+
+    // No prior close available -- the coordinator's missing-T-1-bar case.
+    tcm.update_market_data("ZC", /*volume=*/12345.0, /*close=*/600.0, /*prev_close=*/0.0);
+
+    EXPECT_DOUBLE_EQ(tcm.get_adv("ZC"), 12345.0)
+        << "Volume was not recorded when the prior close was unavailable. ADV must still "
+           "advance -- dropping it is what excluded Mondays from the ag symbols' ADV window "
+           "and flipped KE.v.0 across the 20,000 impact bucket boundary.";
+}
+
+TEST(MarketDataUpdate, ZeroPrevCloseAddsNoReturnObservation) {
+    TransactionCostManager::Config cfg;
+    TransactionCostManager tcm(cfg);
+
+    // A symbol that has only ever been seen without a prior close carries no return
+    // observations at all, so volatility falls back to the model default rather than being
+    // pulled toward zero by fabricated log(close/close) = 0 entries.
+    const double untouched = tcm.get_annual_volatility("NEVER_SEEN");
+
+    for (int i = 0; i < 5; ++i) {
+        tcm.update_market_data("ZW", 1000.0, 600.0 + i, /*prev_close=*/0.0);
+    }
+
+    EXPECT_DOUBLE_EQ(tcm.get_annual_volatility("ZW"), untouched)
+        << "A return was recorded from an absent prior close. Passing prev_close = close "
+           "instead (what main does) injects a zero return, which biases the volatility "
+           "estimate downward on 1 day in 5 for symbols with no Sunday session.";
+    EXPECT_DOUBLE_EQ(tcm.get_adv("ZW"), 1000.0)
+        << "Volume must still have been recorded on every one of those bars.";
+}
+
+TEST(MarketDataUpdate, ValidPrevCloseRecordsBothVolumeAndReturn) {
+    TransactionCostManager::Config cfg;
+    TransactionCostManager tcm(cfg);
+
+    // Varying returns, so the series has real dispersion -- a constant return has zero
+    // stddev and would prove nothing.
+    const double closes[] = {600.0, 612.0, 605.0, 621.0, 610.0, 628.0};
+    for (int i = 1; i < 6; ++i) {
+        tcm.update_market_data("ZS", 1000.0, closes[i], closes[i - 1]);
+    }
+
+    EXPECT_DOUBLE_EQ(tcm.get_adv("ZS"), 1000.0);
+    EXPECT_GT(tcm.get_annual_volatility("ZS"), 0.0)
+        << "A genuine prior close must still produce a return observation.";
+}


### PR DESCRIPTION
Fixes from the E2 verification: the per-day realized column on positions (seed zero, close-day row, restore on finalize), the phantom re-sell after a close, the loader timestamp frame (timegm), the replay-sees-the-future detector, carry-last-mark on an unprinted symbol, backtest realized-flow alignment, migrations 004/005.