### PR TITLE
equities: finishing, batches 1 to 3

### DIFF
--- a/apps/strategies/live_equity_mean_reversion.cpp
+++ b/apps/strategies/live_equity_mean_reversion.cpp
@@ -88,12 +88,13 @@ int main(int argc, char* argv[]) {
                 continue;
             }
 
-            // Try to parse as date
-            std::tm tm = {};
-            std::istringstream ss(arg);
-            ss >> std::get_time(&tm, "%Y-%m-%d");
-            if (!ss.fail()) {
-                target_date = std::chrono::system_clock::from_time_t(std::mktime(&tm));
+            // Try to parse as date. UTC midnight, not local midnight: every
+            // consumer of target_date formats it back through gmtime, so a
+            // std::mktime parse moves the entire run to the previous day on any
+            // host at a positive UTC offset (E3 mktime sites).
+            std::chrono::system_clock::time_point parsed_date;
+            if (core::parse_utc_date(arg, parsed_date)) {
+                target_date = parsed_date;
                 use_override_date = true;
                 std::cout << "Running for historical date: " << arg << std::endl;
             } else if (arg != "--send-email") {
@@ -1330,11 +1331,14 @@ int main(int argc, char* argv[]) {
                                           const std::string& ex_date) -> double {
                     auto cached = positions_at_date_cache.find(ex_date);
                     if (cached == positions_at_date_cache.end()) {
-                        std::tm tm{};
-                        std::istringstream ss(ex_date);
-                        ss >> std::get_time(&tm, "%Y-%m-%d");
-                        if (ss.fail()) return 0.0;
-                        auto tt = std::mktime(&tm) - 24 * 60 * 60;  // ex_date - 1 day
+                        // UTC midnight, then minus one day. Parsed with
+                        // parse_utc_date, NOT std::mktime: mktime reads the
+                        // ex-date as LOCAL midnight, so on a host at a positive
+                        // UTC offset this asked for the book two days before the
+                        // ex-date instead of one (E3 mktime sites).
+                        std::chrono::system_clock::time_point ex_tp;
+                        if (!core::parse_utc_date(ex_date, ex_tp)) return 0.0;
+                        auto tt = std::chrono::system_clock::to_time_t(ex_tp) - 24 * 60 * 60;
                         auto tp = std::chrono::system_clock::from_time_t(tt);
                         auto r = db->load_positions_by_date(
                             kEquityStrategyId, kEquityStrategyName,
@@ -1356,17 +1360,14 @@ int main(int argc, char* argv[]) {
                 // ON the ex-date run has a clean basis and MUST still be restated. Measuring at
                 // E-1 would call it "flat at the ex-date" and skip a real adjustment.
                 //
-                // Parsed with timegm, NOT mktime. The ex_date-1 lambda above uses
-                // `std::mktime`, which reads the tm as LOCAL time and then formats UTC -- on a
-                // host at a positive UTC offset that lands a day early. That is pre-existing
-                // and out of scope here, but new code must not propagate it.
+                // Parsed as UTC midnight, NOT with `std::mktime`, which reads the tm as LOCAL
+                // time and then formats UTC -- on a host at a positive UTC offset that lands
+                // a day early. The ex_date-1 lambda above now goes through the same helper.
                 auto parse_ex_date = [](const std::string& d)
                     -> std::optional<std::chrono::system_clock::time_point> {
-                    std::tm tm{};
-                    std::istringstream ss(d);
-                    ss >> std::get_time(&tm, "%Y-%m-%d");
-                    if (ss.fail()) return std::nullopt;
-                    return std::chrono::system_clock::from_time_t(timegm(&tm));
+                    std::chrono::system_clock::time_point tp;
+                    if (!core::parse_utc_date(d, tp)) return std::nullopt;
+                    return tp;
                 };
 
                 std::unordered_map<std::string, std::unordered_map<std::string, Position>>

--- a/apps/strategies/live_equity_mean_reversion.cpp
+++ b/apps/strategies/live_equity_mean_reversion.cpp
@@ -24,6 +24,7 @@
 #include "trade_ngin/live/corporate_actions_lifecycle.hpp"
 #include "trade_ngin/live/corp_action_window.hpp"
 #include "trade_ngin/live/data_freshness.hpp"
+#include "trade_ngin/live/corp_action_feed_status.hpp"
 #include "trade_ngin/live/corporate_actions_audit_log.hpp"
 #include "trade_ngin/live/live_daily_cycle.hpp"
 #include "trade_ngin/portfolio/portfolio_manager.hpp"
@@ -609,6 +610,36 @@ int main(int argc, char* argv[]) {
         // feed current however far behind the other 851 were -- a guard that cannot
         // fail is not a guard. It also skipped entirely on an empty load and measured
         // in instants rather than calendar days.
+        // Deal-terms feed freshness -- the OTHER feed, and a different question.
+        // equities_data.corporate_action supplies class-3 deal terms and class-2
+        // renames, and it stopped receiving events in 2025. That fact used to be a
+        // constant compiled into the binary and quoted in every termination WARN, so
+        // a restarted subscription would have gone unannounced and the WARNs would
+        // have kept naming a date that was no longer true (E4 item 3). Measure it,
+        // say it out loud once per run, and hand it to the handler that quotes it.
+        std::string corp_action_feed_last_date;
+        {
+            const std::string as_of_ymd =
+                format_ymd_utc(std::chrono::system_clock::to_time_t(end_date));
+            auto feed_max = db->get_corp_action_feed_last_date(as_of_ymd);
+            if (feed_max.is_error()) {
+                WARN("Could not measure the corporate-action deal-terms feed: " +
+                     std::string(feed_max.error()->what()) +
+                     " -- termination WARNs will quote the compiled-in date instead.");
+            } else {
+                corp_action_feed_last_date = feed_max.value();
+            }
+            const auto feed = assess_corp_action_feed(corp_action_feed_last_date, as_of_ymd);
+            INFO(describe_corp_action_feed(feed));
+            if (feed.revived_since_build) {
+                WARN("The corporate-action deal-terms feed has rows after " +
+                     std::string(kCorpActionTableFrozenAfter) +
+                     ", the date this binary was built against. Deal-terms rollover and "
+                     "survivor-keyed TERMINATION rows are now reachable; confirm E4 "
+                     "NEW-5(A) has landed before running this book at universe scale.");
+            }
+        }
+
         {
             const int tolerance_days = app_config.live.data_staleness_tolerance_days;
             const std::string as_of_ymd =
@@ -2045,7 +2076,8 @@ int main(int argc, char* argv[]) {
                 }
 
                 auto exits = CorporateActionsLifecycle::apply_terminations(
-                    previous_positions, terminations, final_closes);
+                    previous_positions, terminations, final_closes,
+                    corp_action_feed_last_date);
                 lifecycle_log.insert(lifecycle_log.end(), exits.begin(), exits.end());
             }
 

--- a/apps/strategies/live_equity_mean_reversion.cpp
+++ b/apps/strategies/live_equity_mean_reversion.cpp
@@ -157,6 +157,18 @@ int main(int argc, char* argv[]) {
         // dev/deploy/system-wide chain).
         auto holiday_checker_ptr = std::make_shared<HolidayChecker>(
             HolidayChecker::resolve_holidays_path());
+        // BA-1: a calendar that did not load fully is fatal, not an ERROR log.
+        // Every downstream use -- the non-trading-day skip, the previous-trading-
+        // day walk, EquityInstrument::is_market_open -- reads "not a holiday"
+        // and "never loaded" as the same value, so proceeding books a day that
+        // did not exist against a T-1 book that was never there.
+        if (!holiday_checker_ptr->loaded()) {
+            std::cerr << "FATAL: market holiday calendar failed to load from "
+                      << HolidayChecker::resolve_holidays_path()
+                      << " - refusing to run. Every date would report as a trading day."
+                      << std::endl;
+            return 1;
+        }
         EquityInstrument::set_holiday_checker(holiday_checker_ptr);
 
         // Setup database connection pool

--- a/apps/strategies/live_equity_mean_reversion.cpp
+++ b/apps/strategies/live_equity_mean_reversion.cpp
@@ -25,6 +25,7 @@
 #include "trade_ngin/live/corp_action_window.hpp"
 #include "trade_ngin/live/data_freshness.hpp"
 #include "trade_ngin/live/corp_action_feed_status.hpp"
+#include "trade_ngin/live/trading_days_anchor.hpp"
 #include "trade_ngin/live/corporate_actions_audit_log.hpp"
 #include "trade_ngin/live/live_daily_cycle.hpp"
 #include "trade_ngin/portfolio/portfolio_manager.hpp"
@@ -610,6 +611,64 @@ int main(int argc, char* argv[]) {
         // feed current however far behind the other 851 were -- a guard that cannot
         // fail is not a guard. It also skipped entirely on an empty load and measured
         // in instants rather than calendar days.
+        // Annualization anchor (E2-F32). trading.get_trading_days() takes its start
+        // date from strategy_trading_days_metadata and only falls back to MIN(date)
+        // over live_results when NO row exists -- so a metadata row dated after the
+        // book's own first day is worse than no row at all, and the function cannot
+        // notice because it stops looking the moment it finds one. Measured on this
+        // book: anchor 2026-07-24 against a book starting 2026-04-01 gave 1 trading
+        // day for 115 of 126 rows and annualized -3.5 % into -1674 % on 07-27. The
+        // run exited 0 and stored it.
+        //
+        // The check is one comparison the function cannot make. On a mismatch the
+        // correct anchor is the book's own first day, and the count below is computed
+        // from it rather than taken from the function.
+        std::string trading_days_anchor_override;
+        {
+            auto anchor_q = db->execute_query(
+                "SELECT COALESCE(MIN(live_start_date)::text, '') "
+                "FROM trading.strategy_trading_days_metadata "
+                "WHERE strategy_id = '" + std::string(kEquityStrategyId) + "'"
+                " AND portfolio_id = '" + portfolio_id + "'");
+            auto first_q = db->execute_query(
+                "SELECT COALESCE(MIN(date)::text, '') FROM trading.live_results "
+                "WHERE strategy_id = '" + std::string(kEquityStrategyId) + "'"
+                " AND portfolio_id = '" + portfolio_id + "'");
+
+            auto first_cell = [](const Result<std::shared_ptr<arrow::Table>>& r) -> std::string {
+                if (r.is_error() || !r.value() || r.value()->num_rows() == 0) return {};
+                auto col = std::static_pointer_cast<arrow::StringArray>(
+                    r.value()->column(0)->chunk(0));
+                if (!col || col->length() == 0 || col->IsNull(0)) return {};
+                return std::string(col->GetView(0));
+            };
+
+            if (anchor_q.is_error() || first_q.is_error()) {
+                WARN("Could not check the annualization anchor for " + portfolio_id +
+                     "; total_annualized_return is reported as the DB function computes it.");
+            } else {
+                const auto anchor = assess_trading_days_anchor(first_cell(anchor_q),
+                                                               first_cell(first_q));
+                if (anchor.anchor_is_late) {
+                    trading_days_anchor_override = anchor.effective_anchor;
+                    WARN("Annualization anchor is LATER than the book it annualizes: "
+                         "strategy_trading_days_metadata.live_start_date = " +
+                         anchor.metadata_anchor + " but live_results for " + portfolio_id +
+                         " start " + anchor.earliest_result +
+                         ". trading.get_trading_days would return 1 for every date before "
+                         "the anchor and explode total_annualized_return just after it "
+                         "(E2-F32). Using " + anchor.effective_anchor +
+                         " for this run; seed the metadata row to that date, or delete it "
+                         "so the MIN(date) fallback applies.");
+                } else {
+                    INFO("Annualization anchor " +
+                         (anchor.effective_anchor.empty() ? std::string("(none yet)")
+                                                          : anchor.effective_anchor) +
+                         " is consistent with the book for " + portfolio_id);
+                }
+            }
+        }
+
         // Deal-terms feed freshness -- the OTHER feed, and a different question.
         // equities_data.corporate_action supplies class-3 deal terms and class-2
         // renames, and it stopped receiving events in 2025. That fact used to be a
@@ -3444,6 +3503,18 @@ int main(int argc, char* argv[]) {
                             INFO("Trading days for yesterday (" + yesterday_date_str + "): " + std::to_string(trading_days_count));
                         }
                     }
+                    // E2-F32: the function anchored to a metadata row that post-dates
+                    // the book, so recompute from the book's own first day. Same
+                    // formula the function uses, different start date.
+                    if (!trading_days_anchor_override.empty()) {
+                        const int corrected = trading_days_from_anchor(
+                            trading_days_anchor_override, yesterday_date_str);
+                        WARN("Trading days for yesterday (" + yesterday_date_str +
+                             ") corrected from " + std::to_string(trading_days_count) +
+                             " to " + std::to_string(corrected) + " (anchor " +
+                             trading_days_anchor_override + ", E2-F32)");
+                        trading_days_count = corrected;
+                    }
                 } else {
                     WARN("Could not call get_trading_days function: " + std::string(trading_days_result.error()->what()));
                 }
@@ -3956,6 +4027,16 @@ int main(int argc, char* argv[]) {
                         trading_days_count = std::max<int>(1, std::stoi(arr->GetString(0)));
                         INFO("Trading days for today (" + now_date_str + "): " + std::to_string(trading_days_count));
                     }
+                }
+                // E2-F32, as above: correct the ANCHOR, not the formula.
+                if (!trading_days_anchor_override.empty()) {
+                    const int corrected =
+                        trading_days_from_anchor(trading_days_anchor_override, now_date_str);
+                    WARN("Trading days for today (" + now_date_str + ") corrected from " +
+                         std::to_string(trading_days_count) + " to " +
+                         std::to_string(corrected) + " (anchor " +
+                         trading_days_anchor_override + ", E2-F32)");
+                    trading_days_count = corrected;
                 }
             } else {
                 WARN("Could not call get_trading_days function: " + std::string(trading_days_result.error()->what()));

--- a/apps/strategies/live_equity_mean_reversion.cpp
+++ b/apps/strategies/live_equity_mean_reversion.cpp
@@ -1041,18 +1041,39 @@ int main(int argc, char* argv[]) {
             auto inception_result = db->get_position_inception_dates(
                 kEquityStrategyId, kEquityStrategyName,
                 portfolio_id, held_symbols);
+            //
+            // BA-9: "the read failed" and "the read succeeded but cannot account for
+            // this holding" are the SAME epistemic state for class 1, and both must
+            // fail wide. Only is_error() used to widen, so a successful read that
+            // returned no row for a held symbol contributed nothing to the derivation
+            // and left the window at its 14-day floor -- the same silent narrowing
+            // this derivation replaced, reached by a different route.
+            const std::string bulk_start_ymd = format_ymd_utc(bulk_start_t);
             if (inception_result.is_error()) {
                 WARN("Could not read position inception dates (" +
                      std::string(inception_result.error()->what()) +
                      ") -- falling back to the full " +
                      std::to_string(max_lookback_days) + "-day price window");
-                for (const auto& sym : held_symbols) {
-                    inception_dates[sym] = format_ymd_utc(bulk_start_t);
-                }
+                inception_dates =
+                    inception_with_unknowns_widened(held_symbols, {}, bulk_start_ymd);
             } else {
-                inception_dates = inception_result.value();
+                inception_dates = inception_with_unknowns_widened(
+                    held_symbols, inception_result.value(), bulk_start_ymd);
                 inception_raw = inception_result.value();
                 inception_read_ok = true;
+
+                // Class 2 (renames) deliberately keeps the RAW map: it fails NARROW,
+                // and a bulk-start sentinel would satisfy `inception <= effective_until`
+                // for any recent alias, which is the era test's own failure mode.
+                const auto unexplained =
+                    held_symbols_without_inception(held_symbols, inception_result.value());
+                for (const auto& sym : unexplained) {
+                    WARN("No inception row for held symbol " + sym +
+                         " -- widening its class-1 price window to the bulk edge " +
+                         bulk_start_ymd +
+                         " rather than letting it sit at the floor. Class-2 renames "
+                         "still skip it, which is the correct direction for them.");
+                }
             }
 
             const auto window = derive_corp_action_window(

--- a/apps/strategies/live_equity_mean_reversion.cpp
+++ b/apps/strategies/live_equity_mean_reversion.cpp
@@ -541,6 +541,14 @@ int main(int argc, char* argv[]) {
         auto* results_manager = coordinator->get_results_manager();
         auto* price_manager = coordinator->get_price_manager();
         auto* pnl_manager = coordinator->get_pnl_manager();
+        // E2-F38 / BA-7: this is an equity book. Tell the PnL manager so, because a
+        // symbol that misses the InstrumentRegistry otherwise falls through to a
+        // SUBSTRING match over futures contract codes -- AAPL matches "PL" (platinum,
+        // 50), LEN matches "LE" (live cattle, 40000). The futures runners pass nothing
+        // and keep the fallback table.
+        if (pnl_manager) {
+            pnl_manager->set_asset_type(AssetType::EQUITY);
+        }
 
         // Create Phase 3 managers
         INFO("Creating ExecutionManager and MarginManager for Phase 3");

--- a/apps/strategies/live_equity_mean_reversion.cpp
+++ b/apps/strategies/live_equity_mean_reversion.cpp
@@ -945,12 +945,13 @@ int main(int argc, char* argv[]) {
         }
 
         // Check if today itself is a non-trading day
-        int today_dow = now_tm->tm_wday;
         std::ostringstream today_oss;
         today_oss << std::put_time(now_tm, "%Y-%m-%d");
         std::string today_date_str = today_oss.str();
-        bool today_is_non_trading = (today_dow == 0 || today_dow == 6 ||
-                                     holiday_checker.is_holiday(today_date_str));
+        // T-OR.3: one predicate, in a testable place. This was five inline copies of the
+        // weekend/holiday test and nothing covered any of them.
+        const bool today_is_non_trading =
+            LiveDailyCycle::is_non_trading_day(*now_tm, holiday_checker);
 
         // A closed market does NOT mean "do nothing". You still hold the book over a
         // weekend or holiday even though no new bar exists to signal from, so the day is
@@ -2435,7 +2436,7 @@ int main(int argc, char* argv[]) {
             // Carry the book forward untouched. No bar closed today, so there is nothing
             // to signal from and nothing legitimate to trade against; re-deriving targets
             // from a stale bar would manufacture a weekend trade.
-            positions = previous_positions;
+            positions = LiveDailyCycle::carry_forward(previous_positions);
             INFO("Non-trading day: carried " + std::to_string(positions.size()) +
                  " position(s) forward without generating signals.");
         } else {

--- a/apps/strategies/live_equity_mean_reversion.cpp
+++ b/apps/strategies/live_equity_mean_reversion.cpp
@@ -294,6 +294,147 @@ int main(int argc, char* argv[]) {
             return 1;
         }
 
+        // Moved above instrument registration for E2-F34: the effective universe below
+        // needs the previous trading day so it can read the book before the universe is
+        // fixed. Nothing between here and the price-manager update consumes
+        // `previous_date`, so the move is order-preserving for every other consumer.
+        // ========================================
+        // NON-TRADING DAY DETECTION
+        // Find the actual previous trading day (skip weekends and holidays)
+        // Mirrors the logic in live_portfolio.cpp for futures
+        // ========================================
+        const HolidayChecker& holiday_checker = *holiday_checker_ptr;
+
+        // The calendar covers a finite range of years. Outside it every date
+        // reports as a non-holiday because the answer is unknown, which would
+        // silently make find_previous_trading_day land on a closed day and
+        // return an empty previous-day book -- skipping corp actions and
+        // mis-stating PnL with no visible symptom. Fail closed instead.
+        {
+            char cov_buf[11];
+            std::tm cov_tm{};
+            auto cov_t = std::chrono::system_clock::to_time_t(now);
+            gmtime_r(&cov_t, &cov_tm);
+            std::strftime(cov_buf, sizeof(cov_buf), "%Y-%m-%d", &cov_tm);
+            if (!holiday_checker.covers_date(cov_buf)) {
+                ERROR("Holiday calendar does not cover " + std::string(cov_buf) +
+                      " (loaded: " + holiday_checker.coverage_description() +
+                      "). Trading-day arithmetic would treat market closures as "
+                      "open days. Extend the calendar via "
+                      "scripts/generate_market_holidays.py before running this date.");
+                return 1;
+            }
+        }
+
+        // Find the most recent trading day strictly before `now`. Walks back
+        // up to 14 days to cover worst-case US closure stacks (Christmas-week
+        // holidays + weekends, or 9/11-style multi-day exchange closures).
+        // Fails closed if exhausted rather than silently using a stale date.
+        auto prev_day_opt = holiday_checker.find_previous_trading_day(now);
+        if (!prev_day_opt.has_value()) {
+            ERROR("Failed to find a previous trading day within lookback bound. "
+                  "Holiday calendar may be misconfigured or stale. Aborting.");
+            return 1;
+        }
+        auto previous_date = *prev_day_opt;
+
+        // ========================================
+        // EFFECTIVE UNIVERSE (E2-F34 / F-4) -- finalized AFTER the book is known
+        // ========================================
+        // The universe used to be config and nothing else, fixed here, while
+        // apply_renames ran ~1,500 lines below. A held position whose successor is not
+        // in config therefore got no instrument, no bars, no cost config and no target:
+        // the day-T pass logged "Missing T-1 price for symbol with a non-zero position",
+        // execute_day_t rule 3 rolled its target back to the carried quantity, and the
+        // same thing happened again the next session -- an unpriceable zombie carried
+        // forever under a key nothing can price. So the book has to be read first.
+        //
+        // This read is deliberately separate from (and earlier than) the authoritative
+        // load below: it exists only to answer "what else must this run be able to
+        // price". Everything it produces -- the alias table and the current-holding
+        // start dates -- is reused by the class-2 block later in the run, so the
+        // universe and the re-keying cannot disagree about which renames apply.
+        std::vector<TickerAlias> ticker_aliases;
+        bool ticker_aliases_ok = false;
+        std::unordered_map<std::string, std::string> holding_start_dates;
+        bool holding_start_read_ok = false;
+        {
+            const std::string as_of_ymd_universe =
+                format_ymd_utc(std::chrono::system_clock::to_time_t(now));
+
+            std::unordered_map<std::string, Position> seed_held;
+            auto seed_book = db->load_positions_by_date(kEquityStrategyId, kEquityStrategyName,
+                                                       portfolio_id, previous_date,
+                                                       "trading.positions");
+            if (seed_book.is_ok()) {
+                std::unordered_map<std::string, Position> seed_closed;
+                LiveDailyCycle::split_open_and_closed(seed_book.value(), seed_held, seed_closed);
+            } else {
+                INFO("No previous-day book for the universe check (first run or no data): " +
+                     std::string(seed_book.error()->what()));
+            }
+
+            auto alias_result = db->get_ticker_aliases();
+            if (alias_result.is_error()) {
+                WARN("Failed to fetch ticker aliases: " +
+                     std::string(alias_result.error()->what()) +
+                     " -- the universe stays as configured and SERIES_CONTINUITY handling "
+                     "is skipped this run");
+            } else {
+                ticker_aliases.reserve(alias_result.value().size());
+                for (const auto& row : alias_result.value()) {
+                    ticker_aliases.push_back(TickerAlias{row.historical_ticker,
+                                                         row.current_symbol,
+                                                         row.effective_until, row.note});
+                }
+                ticker_aliases_ok = true;
+            }
+
+            if (!seed_held.empty()) {
+                std::vector<std::string> held_syms;
+                held_syms.reserve(seed_held.size());
+                for (const auto& [sym, pos] : seed_held) held_syms.push_back(sym);
+
+                // BA-2 / C-3 D1: the class-2 era test needs the start of the CURRENT
+                // holding, not the lifetime min(date) class 1 uses. A ticker closed years
+                // ago and re-bought last month otherwise satisfies the era test for an
+                // alias from the previous issuer's lifetime and gets re-keyed onto a
+                // symbol with no bars. Measured on this book on 2026-09-03: META's
+                // lifetime inception is 2026-06-11, its current holding began 2026-07-31.
+                auto holding_start = db->get_current_holding_start_dates(
+                    kEquityStrategyId, kEquityStrategyName, portfolio_id, held_syms);
+                if (holding_start.is_error()) {
+                    WARN("Could not read current-holding start dates (" +
+                         std::string(holding_start.error()->what()) +
+                         ") -- SERIES_CONTINUITY handling is skipped this run "
+                         "(fail-narrow) and the universe stays as configured");
+                } else {
+                    holding_start_dates = holding_start.value();
+                    holding_start_read_ok = true;
+                }
+            }
+
+            if (ticker_aliases_ok && holding_start_read_ok && !seed_held.empty()) {
+                const auto extended = LiveDailyCycle::effective_universe(
+                    symbols, seed_held, ticker_aliases, as_of_ymd_universe,
+                    holding_start_dates);
+                if (extended.size() != symbols.size()) {
+                    std::string added;
+                    for (size_t i = symbols.size(); i < extended.size(); ++i) {
+                        added += (added.empty() ? "" : ", ") + extended[i];
+                    }
+                    WARN("Effective universe extended beyond config for held positions "
+                         "whose ticker has been renamed: " + added +
+                         ". Without this the renamed holding would have no bars, no "
+                         "instrument and no target, and would be carried unpriceable "
+                         "forever (E2-F34).");
+                    symbols = extended;
+                }
+            }
+            INFO("Effective universe: " + std::to_string(symbols.size()) +
+                 " symbol(s) (config plus successors of held positions)");
+        }
+
         // Register equity instruments. Pass the exchange JSON path so per-symbol
         // exchanges populate correctly instead of defaulting to NYSE. Audit §1.2.
         auto equity_reg_result = registry.load_equity_instruments(
@@ -771,45 +912,6 @@ int main(int argc, char* argv[]) {
                 .register_equity_costs_from_bars(symbols, bars_by_symbol);
         }
 
-        // ========================================
-        // NON-TRADING DAY DETECTION
-        // Find the actual previous trading day (skip weekends and holidays)
-        // Mirrors the logic in live_portfolio.cpp for futures
-        // ========================================
-        const HolidayChecker& holiday_checker = *holiday_checker_ptr;
-
-        // The calendar covers a finite range of years. Outside it every date
-        // reports as a non-holiday because the answer is unknown, which would
-        // silently make find_previous_trading_day land on a closed day and
-        // return an empty previous-day book -- skipping corp actions and
-        // mis-stating PnL with no visible symptom. Fail closed instead.
-        {
-            char cov_buf[11];
-            std::tm cov_tm{};
-            auto cov_t = std::chrono::system_clock::to_time_t(now);
-            gmtime_r(&cov_t, &cov_tm);
-            std::strftime(cov_buf, sizeof(cov_buf), "%Y-%m-%d", &cov_tm);
-            if (!holiday_checker.covers_date(cov_buf)) {
-                ERROR("Holiday calendar does not cover " + std::string(cov_buf) +
-                      " (loaded: " + holiday_checker.coverage_description() +
-                      "). Trading-day arithmetic would treat market closures as "
-                      "open days. Extend the calendar via "
-                      "scripts/generate_market_holidays.py before running this date.");
-                return 1;
-            }
-        }
-
-        // Find the most recent trading day strictly before `now`. Walks back
-        // up to 14 days to cover worst-case US closure stacks (Christmas-week
-        // holidays + weekends, or 9/11-style multi-day exchange closures).
-        // Fails closed if exhausted rather than silently using a stale date.
-        auto prev_day_opt = holiday_checker.find_previous_trading_day(now);
-        if (!prev_day_opt.has_value()) {
-            ERROR("Failed to find a previous trading day within lookback bound. "
-                  "Holiday calendar may be misconfigured or stale. Aborting.");
-            return 1;
-        }
-        auto previous_date = *prev_day_opt;
 
         // E2-F14: extract T-1/T-2 prices keyed on the trading day we just resolved, NOT on
         // `now - 24h`.
@@ -1090,12 +1192,10 @@ int main(int argc, char* argv[]) {
         // Adjustments land BEFORE the strategy generates today's targets.
         // See docs/CORP_ACTIONS_DATA_BOUNDARY.md. Closes audit §1.12, §1.15.
         // ========================================
-        // Position inception, read once in the class-1 block below and consumed by
-        // BOTH corp-action blocks -- which need OPPOSITE failure semantics, so the raw
-        // result is carried out here rather than the class-1 fallback map.
-        // See the read site for why class 2 must never see that fallback.
-        std::unordered_map<std::string, std::string> inception_raw;
-        bool inception_read_ok = false;
+        // Position inception is read in the class-1 block below and is CLASS 1's alone:
+        // it is min(date) over all history and fails wide, which is right for a price
+        // window and wrong for an era test. Class 2 reads its own dates -- the start of
+        // the CURRENT holding, up with the effective universe (BA-2).
 
         if (!previous_positions.empty()) {
             // Lookback is DERIVED FROM POSITION HISTORY, never a fixed
@@ -1176,12 +1276,11 @@ int main(int argc, char* argv[]) {
             } else {
                 inception_dates = inception_with_unknowns_widened(
                     held_symbols, inception_result.value(), bulk_start_ymd);
-                inception_raw = inception_result.value();
-                inception_read_ok = true;
 
-                // Class 2 (renames) deliberately keeps the RAW map: it fails NARROW,
-                // and a bulk-start sentinel would satisfy `inception <= effective_until`
-                // for any recent alias, which is the era test's own failure mode.
+                // This map is class 1's only. Class 2 never sees it: a bulk-start
+                // sentinel would satisfy `inception <= effective_until` for any recent
+                // alias, and even the un-widened min(date) is a previous holding's date
+                // for a reused ticker (BA-2).
                 const auto unexplained =
                     held_symbols_without_inception(held_symbols, inception_result.value());
                 for (const auto& sym : unexplained) {
@@ -1964,29 +2063,29 @@ int main(int argc, char* argv[]) {
             // executions below so they reach live_results and the equity curve (E2-F11).
 
             // Class 2: re-key positions still held under a superseded ticker.
-            auto alias_result = db->get_ticker_aliases();
-            if (alias_result.is_error()) {
-                WARN("Failed to fetch ticker aliases: " +
-                     std::string(alias_result.error()->what()) +
-                     " -- skipping SERIES_CONTINUITY handling");
+            //
+            // The alias table and the era dates were read once, up with the effective
+            // universe (E2-F34), and are reused here on purpose: the universe this run
+            // loaded bars for was computed from exactly these inputs, so a rename this
+            // block performs is one the run can price.
+            //
+            // BA-2 / C-3 D1: the era input is the start of the CURRENT holding, NOT the
+            // lifetime min(date) the class-1 window uses. Feeding class 1's answer in
+            // here re-applies a rename from a previous issuer's lifetime to a position
+            // re-opened under the reused ticker, moving a live holding onto a symbol
+            // with no bars -- the precise failure the era test exists to prevent.
+            if (!ticker_aliases_ok) {
+                WARN("Ticker aliases unavailable -- skipping SERIES_CONTINUITY handling");
+            } else if (!holding_start_read_ok) {
+                // Fail narrow. A skipped rename is retried next run; a rename
+                // applied against a guessed era re-keys a live holding onto a
+                // symbol that may have no prices at all.
+                WARN("Current-holding start dates unavailable -- skipping SERIES_CONTINUITY "
+                     "handling this run rather than applying renames unbounded");
             } else {
-                std::vector<TickerAlias> aliases;
-                aliases.reserve(alias_result.value().size());
-                for (const auto& row : alias_result.value()) {
-                    aliases.push_back(TickerAlias{row.historical_ticker, row.current_symbol,
-                                                  row.effective_until, row.note});
-                }
-                if (!inception_read_ok) {
-                    // Fail narrow. A skipped rename is retried next run; a rename
-                    // applied against a guessed era re-keys a live holding onto a
-                    // symbol that may have no prices at all.
-                    WARN("Position inception dates unavailable -- skipping SERIES_CONTINUITY "
-                         "handling this run rather than applying renames unbounded");
-                } else {
-                    auto renames = CorporateActionsLifecycle::apply_renames(
-                        previous_positions, aliases, as_of_date, inception_raw);
-                    lifecycle_log.insert(lifecycle_log.end(), renames.begin(), renames.end());
-                }
+                auto renames = CorporateActionsLifecycle::apply_renames(
+                    previous_positions, ticker_aliases, as_of_date, holding_start_dates);
+                lifecycle_log.insert(lifecycle_log.end(), renames.begin(), renames.end());
             }
 
             // Class 3: build termination events from the two available
@@ -2964,6 +3063,7 @@ int main(int argc, char* argv[]) {
 
         // Save positions to database with daily PnL values
         INFO("Saving positions to database with daily PnL...");
+
         std::vector<trade_ngin::Position> positions_to_save;
         positions_to_save.reserve(positions.size());
 

--- a/apps/strategies/live_equity_mean_reversion.cpp
+++ b/apps/strategies/live_equity_mean_reversion.cpp
@@ -3064,6 +3064,35 @@ int main(int argc, char* argv[]) {
         // Save positions to database with daily PnL values
         INFO("Saving positions to database with daily PnL...");
 
+        // E2-F35 / BA-4: the row and the aggregate must be marked from the SAME map.
+        //
+        // resolve_and_apply_basis marks positions[*] from exec_outcome.execution_prices --
+        // the T-1 closes PLUS any widened substitute -- and live_results sums those marks.
+        // The loop below recomputed each row's unrealized from previous_day_close_prices
+        // alone, which by definition has NO entry for a widened symbol: that symbol's row
+        // came out 0 while the aggregate did not. The in-run L5 assert reconciles realized
+        // only, so the split was silent, and it fires precisely on the thin/halted names
+        // the widening exists for. Rule 6 in AVERAGE_PRICE_LIFECYCLE.md says marks and
+        // fills come from one map; this is that map.
+        //
+        // On a non-trading day execute_day_t never runs and execution_prices is empty, so
+        // this is exactly previous_day_close_prices and the carry-forward path is byte for
+        // byte what it was.
+        const auto day_t_marks = LiveDailyCycle::day_t_mark_prices(
+            previous_day_close_prices, exec_outcome.execution_prices);
+        {
+            size_t substituted = 0;
+            for (const auto& [sym, price] : day_t_marks) {
+                auto t1 = previous_day_close_prices.find(sym);
+                if (t1 == previous_day_close_prices.end() || t1->second != price) ++substituted;
+            }
+            if (substituted > 0) {
+                INFO("BASIS TRACE | row marks | " + std::to_string(substituted) +
+                     " symbol(s) marked from the execution price map rather than the T-1 "
+                     "close map, matching what the aggregate was marked at (E2-F35)");
+            }
+        }
+
         std::vector<trade_ngin::Position> positions_to_save;
         positions_to_save.reserve(positions.size());
 
@@ -3114,14 +3143,15 @@ int main(int argc, char* argv[]) {
             // guard; that case persists 0, as before.
             if (position.quantity.as_double() != 0.0) {
                 double current_price = 0.0;
-                auto price_it = previous_day_close_prices.find(symbol);
-                if (price_it != previous_day_close_prices.end()) {
+                auto price_it = day_t_marks.find(symbol);
+                if (price_it != day_t_marks.end()) {
                     current_price = price_it->second;
                 }
-                // Same rule the live_results aggregate uses, so the row and the total
-                // cannot disagree. Equities are point_value 1. The mark check stays here
-                // because current_price is 0.0 when the symbol has no T-1 close, and
-                // measuring against 0 would book the whole notional as a gain.
+                // Same rule AND the same price map the live_results aggregate uses, so the
+                // row and the total cannot disagree (E2-F35). Equities are point_value 1.
+                // The mark check stays here because current_price is 0.0 when the symbol
+                // has no close at all, and measuring against 0 would book the whole
+                // notional as a gain.
                 validated_position.unrealized_pnl =
                     current_price > 0.0
                         ? Decimal(LivePnLManager::unrealized_from_cost_basis(
@@ -4052,6 +4082,67 @@ int main(int argc, char* argv[]) {
                  std::to_string(previous_total_unrealized_pnl) +
                  ") rather than recomputing it from an unmarked book");
             total_unrealized_pnl = previous_total_unrealized_pnl;
+        }
+
+        // BA-4: protocol L5's UNREALIZED clause, asserted inside the run.
+        //
+        // The realized clause above has been checked since E2-F19 (R5); unrealized had
+        // nothing, which is how E2-F35 survived -- a widened symbol's row was 0 while the
+        // aggregate was not, and no assertion in the run could see it. Both sides are now
+        // computed from one basis and one mark map (`day_t_marks`), so on a trading day
+        // this is an identity and a violation means a row was dropped, double-counted or
+        // marked from somewhere else.
+        //
+        // A non-trading day is NOT an identity and is not treated as one. The aggregate
+        // there is the PREVIOUS row's stored figure, read back from a numeric column that
+        // rounds to 4 decimals, while the rows are recomputed against the T-1 close. The
+        // two agree because nothing moved (measured over the whole book on 2026-09-03:
+        // 74 days, 0 residuals above 1e-4, max 4.9e-5), but they agree by circumstance
+        // rather than by construction, so the closed-day check WARNs at a tolerance that
+        // covers the stored rounding instead of killing a run over it.
+        {
+            double row_unrealized_sum = 0.0;
+            std::string breakdown;
+            for (const auto& p : positions_to_save) {
+                const double u = static_cast<double>(p.unrealized_pnl);
+                row_unrealized_sum += u;
+                if (std::abs(u) > LiveDailyCycle::kRowTolerance) {
+                    breakdown += " " + p.symbol + "=" + std::to_string(u);
+                }
+            }
+            const double residual = row_unrealized_sum - total_unrealized_pnl;
+            if (today_is_non_trading) {
+                if (std::abs(residual) > 1e-2) {
+                    WARN("L5 unrealized identity: carried aggregate (" +
+                         std::to_string(total_unrealized_pnl) + ") differs from the sum of "
+                         "the rows written today (" + std::to_string(row_unrealized_sum) +
+                         "), residual " + std::to_string(residual) +
+                         ". On a closed day the aggregate is the previous row's stored "
+                         "figure and the rows are re-marked at the same close, so a "
+                         "difference beyond stored rounding means the book moved on a day "
+                         "the market was shut. Per-symbol rows:" +
+                         (breakdown.empty() ? std::string(" <none>") : breakdown));
+                } else {
+                    INFO("L5 unrealized identity holds on a closed day: rows " +
+                         std::to_string(row_unrealized_sum) + " ~= carried aggregate " +
+                         std::to_string(total_unrealized_pnl) + " (residual " +
+                         std::to_string(residual) + ")");
+                }
+            } else if (std::abs(residual) > 1e-4) {
+                ERROR("L5 unrealized identity VIOLATED: sum of "
+                      "positions.daily_unrealized_pnl (" + std::to_string(row_unrealized_sum) +
+                      ") != live_results.total_unrealized_pnl (" +
+                      std::to_string(total_unrealized_pnl) + "), residual " +
+                      std::to_string(residual) + ". Per-symbol rows:" +
+                      (breakdown.empty() ? std::string(" <none>") : breakdown) +
+                      ". Refusing to persist a day whose rows do not sum to its aggregate.");
+                return 1;
+            } else {
+                INFO("L5 unrealized identity holds: rows " +
+                     std::to_string(row_unrealized_sum) + " == aggregate " +
+                     std::to_string(total_unrealized_pnl) + " (residual " +
+                     std::to_string(residual) + ")");
+            }
         }
 
         // E2-F1: cumulative TRADE-realized, gross. Read from the previous row and extended by

--- a/apps/strategies/live_equity_mean_reversion.cpp
+++ b/apps/strategies/live_equity_mean_reversion.cpp
@@ -2340,17 +2340,22 @@ int main(int argc, char* argv[]) {
             INFO("Non-trading day: carried " + std::to_string(positions.size()) +
                  " position(s) forward without generating signals.");
         } else {
-            INFO("Seeding strategy with previous-day book and generating signals...");
+            INFO("Seeding strategy with previous-day book...");
             auto strat_prewarm = LiveDailyCycle::prepare_strategy_for_signals(
-                *mr_strategy, previous_positions, all_bars);
+                *mr_strategy, previous_positions);
             if (strat_prewarm.is_error()) {
-                std::cerr << "Failed to preprocess data in strategy: "
+                std::cerr << "Failed to seed strategy positions: "
                           << strat_prewarm.error()->what() << std::endl;
                 return 1;
             }
 
-            // Process data through portfolio pipeline (risk; optimization is off for MR)
-            INFO("Processing data through portfolio manager (risk)...");
+            // Process data through portfolio pipeline (risk; optimization is off for MR).
+            //
+            // E2-F28: this is the ONE place the strategy is fed. process_market_data
+            // calls strategy->on_data(all_bars) itself; seeding above deliberately does
+            // not, because MeanReversion appends every bar it is given and a second pass
+            // over the same vector doubled the price history and the ADV EMA.
+            INFO("Processing data through portfolio manager (feeds the strategy once; risk)...");
             auto port_process_result = portfolio->process_market_data(all_bars);
             if (port_process_result.is_error()) {
                 std::cerr << "Failed to process data in portfolio manager: "

--- a/apps/strategies/live_equity_mean_reversion.cpp
+++ b/apps/strategies/live_equity_mean_reversion.cpp
@@ -23,6 +23,7 @@
 #include "trade_ngin/live/corporate_actions_classification.hpp"
 #include "trade_ngin/live/corporate_actions_lifecycle.hpp"
 #include "trade_ngin/live/corp_action_window.hpp"
+#include "trade_ngin/live/data_freshness.hpp"
 #include "trade_ngin/live/corporate_actions_audit_log.hpp"
 #include "trade_ngin/live/live_daily_cycle.hpp"
 #include "trade_ngin/portfolio/portfolio_manager.hpp"
@@ -601,20 +602,39 @@ int main(int argc, char* argv[]) {
         // the configured tolerance, the run is on stale data -- WARN in historical-
         // replay mode, ERROR (refuse) in true-live mode. (Computed from the loaded
         // bars rather than a separate query: symbol-scoped and no extra round-trip.)
-        if (!all_bars.empty()) {
-            auto latest_bar = all_bars.front().timestamp;
-            for (const auto& bar : all_bars) {
-                if (bar.timestamp > latest_bar) latest_bar = bar.timestamp;
-            }
-            int tolerance_days = app_config.live.data_staleness_tolerance_days;
-            auto staleness = end_date - latest_bar;
-            long staleness_days =
-                std::chrono::duration_cast<std::chrono::hours>(staleness).count() / 24;
-            if (staleness > std::chrono::hours(24 * tolerance_days)) {
-                std::string msg =
-                    "Equity data is stale: newest loaded bar is " + std::to_string(staleness_days) +
-                    " days older than end_date (tolerance " + std::to_string(tolerance_days) +
-                    " days).";
+        //
+        // BA-12: measured from the STALEST symbol, not the freshest. This used to take
+        // the global max bar timestamp, so one symbol printing today reported the whole
+        // feed current however far behind the other 851 were -- a guard that cannot
+        // fail is not a guard. It also skipped entirely on an empty load and measured
+        // in instants rather than calendar days.
+        {
+            const int tolerance_days = app_config.live.data_staleness_tolerance_days;
+            const std::string as_of_ymd =
+                format_ymd_utc(std::chrono::system_clock::to_time_t(end_date));
+            const auto freshness = assess_feed_freshness(last_bar_date, as_of_ymd);
+
+            if (!freshness.any_data) {
+                // No symbol has a usable bar date. Maximally stale, never neutral.
+                const std::string msg =
+                    "Equity data freshness cannot be established: none of the " +
+                    std::to_string(freshness.symbols) +
+                    " loaded symbols carries a usable bar date as of " + as_of_ymd + ".";
+                if (use_override_date) {
+                    WARN(msg + " Proceeding in historical-replay mode.");
+                } else {
+                    ERROR(msg + " Refusing to run live without a feed. Refresh the OHLCV "
+                                "feed.");
+                    return 1;
+                }
+            } else if (freshness.days_behind > tolerance_days) {
+                const std::string msg =
+                    "Equity data is stale: the stalest of " +
+                    std::to_string(freshness.symbols) + " symbols (" +
+                    freshness.stalest_symbol + ") last printed " + freshness.stalest_date +
+                    ", " + std::to_string(freshness.days_behind) +
+                    " calendar days before " + as_of_ymd + " (tolerance " +
+                    std::to_string(tolerance_days) + " days).";
                 if (use_override_date) {
                     WARN(msg + " Proceeding in historical-replay mode.");
                 } else {
@@ -622,6 +642,12 @@ int main(int argc, char* argv[]) {
                                 "feed or raise live.data_staleness_tolerance_days.");
                     return 1;
                 }
+            } else {
+                INFO("Equity feed freshness: stalest of " +
+                     std::to_string(freshness.symbols) + " symbols (" +
+                     freshness.stalest_symbol + ") at " + freshness.stalest_date + ", " +
+                     std::to_string(freshness.days_behind) + " days behind " + as_of_ymd +
+                     " (tolerance " + std::to_string(tolerance_days) + ").");
             }
         }
 

--- a/apps/strategies/live_equity_mean_reversion.cpp
+++ b/apps/strategies/live_equity_mean_reversion.cpp
@@ -1256,6 +1256,11 @@ int main(int argc, char* argv[]) {
                           "them. Refusing to adjust positions.");
                     return 1;
                 }
+                // E2-F23: the run's OWN as-of date, not the wall clock. Every dedup
+                // row this pass writes is stamped with it, and load() refuses to run
+                // behind a row a LATER pass wrote -- the case the ex-date detector
+                // below cannot see, because that row's ex-date is in the past.
+                audit_log.set_run_date(today_date_str);
                 auto dedup_loaded = audit_log.load();
                 if (dedup_loaded.is_error()) {
                     // Abort rather than adjust positions against an unknown
@@ -2239,6 +2244,12 @@ int main(int argc, char* argv[]) {
                                                          portfolio_id,
                                                          "LIVE_EQUITY_MEAN_REVERSION",
                                                          "EQUITY_MEAN_REVERSION");
+                // Stamp only, not enforce: the class-1 block above already committed
+                // THIS run's dedup rows, all stamped with today's date, so enforcing
+                // here would make the run refuse its own output (E2-F23). The check
+                // belongs on the first load of the run, which is where it is.
+                lifecycle_audit.set_run_date(as_of_date,
+                                             CorporateActionsAuditLog::RunDateCheck::StampOnly);
                 auto lc_loaded = lifecycle_audit.load();
                 if (lc_loaded.is_error()) {
                     // Fail closed, matching the class-1 block: a dedup record that cannot be

--- a/apps/strategies/live_equity_mean_reversion.cpp
+++ b/apps/strategies/live_equity_mean_reversion.cpp
@@ -1876,7 +1876,21 @@ int main(int argc, char* argv[]) {
             std::vector<TerminationEvent> terminations;
             std::unordered_map<std::string, TerminationEvent*> by_symbol;
 
-            auto delist_result = db->get_delisting_dates(symbols);
+            // BA-8: bound the read by the same 90-day termination lookback this
+            // block already uses. delisting_date is keyed on the ticker and the
+            // reader takes max() over all history, so without a floor a reused
+            // ticker inherits a dead company's row (HPC 2008-11-24, MER
+            // 2008-12-31) and exits a live position at a stale price. The
+            // bars-contradict guard below cannot cover it alone:
+            // delisting_is_stale() is false when last_bar is EMPTY, which is
+            // precisely the symbol that stopped printing.
+            //
+            // Direction: missing an old termination leaves a dead position
+            // carried, which is loud (the "Missing T-1 price" path). Acting on a
+            // stale one closes a live position, which is silent and wrong. The
+            // 90-day bound is this block's own definition of "in window".
+            auto delist_result =
+                db->get_delisting_dates(symbols, std::string(lifecycle_start_buf));
             if (delist_result.is_error()) {
                 WARN("Failed to fetch delisting dates: " +
                      std::string(delist_result.error()->what()) +

--- a/apps/strategies/live_portfolio.cpp
+++ b/apps/strategies/live_portfolio.cpp
@@ -223,7 +223,11 @@ int main(int argc, char* argv[]) {
         // Sort strategy names for deterministic combined ID (Tier 2)
         std::sort(strategy_names.begin(), strategy_names.end());
 
-        // Generate combined strategy_id: LIVE_<sorted_names_joined_by_&>
+        // Generate combined strategy_id: LIVE_<sorted_names_joined_by_underscore>.
+        // NEW-2: this line said "&" while the loop below has joined with "_" since
+        // a88085ec, and "&" was never the separator in tree. The orphaned "&"-keyed
+        // rows in the DB come from an out-of-tree binary; no runner can read them back
+        // because the id is matched exactly.
         std::string combined_strategy_id = "LIVE_";
         for (size_t i = 0; i < strategy_names.size(); ++i) {
             if (i > 0)

--- a/apps/strategies/live_portfolio.cpp
+++ b/apps/strategies/live_portfolio.cpp
@@ -736,6 +736,17 @@ int main(int argc, char* argv[]) {
         // Check if yesterday was a holiday using HolidayChecker
         // Phase 6 §6a: path resolved via HolidayChecker::resolve_holidays_path.
         HolidayChecker holiday_checker(HolidayChecker::resolve_holidays_path());
+        // BA-1: fail closed on a calendar that did not load fully. is_holiday
+        // cannot distinguish "the market was open" from "the calendar is
+        // missing", so a partial load silently turns a closure into a trading
+        // day and the non-trading-day branch below never fires.
+        if (!holiday_checker.loaded()) {
+            std::cerr << "FATAL: market holiday calendar failed to load from "
+                      << HolidayChecker::resolve_holidays_path()
+                      << " - refusing to run. Every date would report as a trading day."
+                      << std::endl;
+            return 1;
+        }
         auto yesterday_for_check = now - std::chrono::hours(24);
         auto yesterday_time_t_check = std::chrono::system_clock::to_time_t(yesterday_for_check);
         std::tm yesterday_tm_check = *std::gmtime(&yesterday_time_t_check);

--- a/apps/strategies/live_portfolio_conservative.cpp
+++ b/apps/strategies/live_portfolio_conservative.cpp
@@ -224,7 +224,11 @@ int main(int argc, char* argv[]) {
         // Sort strategy names for deterministic combined ID (Tier 2)
         std::sort(strategy_names.begin(), strategy_names.end());
 
-        // Generate combined strategy_id: LIVE_<sorted_names_joined_by_&>
+        // Generate combined strategy_id: LIVE_<sorted_names_joined_by_underscore>.
+        // NEW-2: this line said "&" while the loop below has joined with "_" since
+        // a88085ec, and "&" was never the separator in tree. The orphaned "&"-keyed
+        // rows in the DB come from an out-of-tree binary; no runner can read them back
+        // because the id is matched exactly.
         std::string combined_strategy_id = "LIVE_";
         for (size_t i = 0; i < strategy_names.size(); ++i) {
             if (i > 0)

--- a/apps/strategies/live_portfolio_conservative.cpp
+++ b/apps/strategies/live_portfolio_conservative.cpp
@@ -741,6 +741,17 @@ int main(int argc, char* argv[]) {
         // Check if yesterday was a holiday using HolidayChecker
         // Phase 6 §6a: path resolved via HolidayChecker::resolve_holidays_path.
         HolidayChecker holiday_checker(HolidayChecker::resolve_holidays_path());
+        // BA-1: fail closed on a calendar that did not load fully. is_holiday
+        // cannot distinguish "the market was open" from "the calendar is
+        // missing", so a partial load silently turns a closure into a trading
+        // day and the non-trading-day branch below never fires.
+        if (!holiday_checker.loaded()) {
+            std::cerr << "FATAL: market holiday calendar failed to load from "
+                      << HolidayChecker::resolve_holidays_path()
+                      << " - refusing to run. Every date would report as a trading day."
+                      << std::endl;
+            return 1;
+        }
         auto yesterday_for_check = now - std::chrono::hours(24);
         auto yesterday_time_t_check = std::chrono::system_clock::to_time_t(yesterday_for_check);
         std::tm yesterday_tm_check = *std::gmtime(&yesterday_time_t_check);

--- a/config_template/defaults.json
+++ b/config_template/defaults.json
@@ -31,6 +31,7 @@
   "live": {
     "historical_days": 730,
     "data_staleness_tolerance_days": 4,
+    "execution_price_max_staleness_days": 5,
     "_note": "Must match backtest.lookback_years (2 yrs ≈ 730 days). Strategy needs 256+ trading days for longest EMA and 252 for vol_lookback_long."
   },
   "strategy_defaults": {

--- a/include/trade_ngin/core/holiday_checker.hpp
+++ b/include/trade_ngin/core/holiday_checker.hpp
@@ -95,9 +95,23 @@ public:
      */
     explicit HolidayChecker(const std::string& json_path = "holidays.json")
         : json_path_(json_path) {
-        if (!load_holidays()) {
+        loaded_ = load_holidays();
+        if (!loaded_) {
             ERROR("Failed to load holidays from: " + json_path_);
         }
+    }
+
+    /**
+     * @brief Whether the calendar loaded completely.
+     *
+     * False means the file was missing, unreadable, or threw part way through.
+     * A caller whose correctness depends on the calendar must refuse to run on
+     * false rather than proceed: `is_holiday` cannot distinguish "open" from
+     * "never loaded", and a half-loaded file used to advertise coverage it did
+     * not have (BA-1).
+     */
+    bool loaded() const {
+        return loaded_;
     }
 
     /**
@@ -178,7 +192,14 @@ public:
      * @return true if successful, false otherwise
      */
     bool reload() {
-        return load_holidays();
+        // On failure the staged-swap leaves the calendar already in force
+        // untouched, so `loaded_` keeps its previous value rather than
+        // reporting a working calendar as unloaded.
+        if (load_holidays()) {
+            loaded_ = true;
+            return true;
+        }
+        return false;
     }
 
     /**
@@ -224,6 +245,7 @@ private:
     std::string json_path_;
     std::unordered_map<std::string, HolidayInfo> holidays_;
     std::set<int> covered_years_;
+    bool loaded_ = false;
 
     // is_holiday is const and may be called per-bar, so the warn-once state is
     // mutable and guarded. One warning per out-of-range year, not per query.
@@ -252,6 +274,23 @@ private:
      * @return true if successful, false otherwise
      */
     bool load_holidays() {
+        // BA-1: stage into locals and swap only on FULL success.
+        //
+        // This used to clear the live maps up front and fill them in place, and
+        // it inserted each year key BEFORE parsing that year's entries. A file
+        // that threw part way through therefore left the object advertising
+        // coverage for years whose closures were missing -- and the outer catch
+        // returned false without undoing any of it. `covers_date` then answered
+        // true, every fail-closed caller passed, `is_holiday` returned false
+        // with no warning because the year WAS covered, and
+        // `find_previous_trading_day` walked onto a closed day. The guard only
+        // fired when the load failed TOTALLY, which is the easy case.
+        //
+        // Staging also makes a failed reload() non-destructive: the calendar
+        // already in force survives.
+        std::unordered_map<std::string, HolidayInfo> staged_holidays;
+        std::set<int> staged_years;
+
         try {
             std::ifstream file(json_path_);
             if (!file.is_open()) {
@@ -262,41 +301,50 @@ private:
             nlohmann::json j;
             file >> j;
 
-            holidays_.clear();
-            covered_years_.clear();
-
             // Iterate through each year
             for (auto& [year, holidays_array] : j.items()) {
+                int year_number = 0;
                 try {
-                    covered_years_.insert(std::stoi(year));
+                    year_number = std::stoi(year);
                 } catch (const std::exception&) {
-                    WARN("Holiday calendar has a non-numeric year key: " + year);
+                    // A key that is not a year is the whole file's problem, not
+                    // one year's: we cannot tell what range the calendar covers,
+                    // so we refuse the file rather than load part of it.
+                    ERROR("Holiday calendar has a non-numeric year key: " + year);
+                    return false;
                 }
+
                 for (auto& holiday : holidays_array) {
                     HolidayInfo info;
                     info.date = holiday["date"].get<std::string>();
                     info.name = holiday["name"].get<std::string>();
                     info.type = holiday["type"].get<std::string>();
-                    
+
                     if (holiday.contains("day_of_week")) {
                         info.day_of_week = holiday["day_of_week"].get<std::string>();
                     }
-                    
+
                     if (holiday.contains("note")) {
                         info.note = holiday["note"].get<std::string>();
                     }
 
-                    holidays_[info.date] = info;
+                    staged_holidays[info.date] = info;
                 }
+
+                // Only after every entry for the year parsed.
+                staged_years.insert(year_number);
             }
 
-            INFO("Loaded " + std::to_string(holidays_.size()) + " holidays from " + json_path_);
-            return true;
-
         } catch (const std::exception& e) {
-            ERROR("Exception loading holidays: " + std::string(e.what()));
+            ERROR("Exception loading holidays: " + std::string(e.what()) +
+                  " - the calendar was NOT loaded and no coverage is claimed");
             return false;
         }
+
+        holidays_ = std::move(staged_holidays);
+        covered_years_ = std::move(staged_years);
+        INFO("Loaded " + std::to_string(holidays_.size()) + " holidays from " + json_path_);
+        return true;
     }
 };
 

--- a/include/trade_ngin/core/holiday_checker.hpp
+++ b/include/trade_ngin/core/holiday_checker.hpp
@@ -209,6 +209,30 @@ public:
      * covers worst-case US closure stacks (Christmas + week-of-holidays +
      * weekends, or 9/11-style multi-day exchange closures).
      *
+     * **The candidate is tested in UTC, because that is the frame it is
+     * returned in.** This used to test with `safe_localtime` and return the raw
+     * `candidate`, which every caller then formats with `gmtime` -- the two
+     * frames agree only while a candidate's local and UTC calendar dates are the
+     * same day. Since `95679ea2` the equity runner's run date is UTC MIDNIGHT
+     * (`parse_utc_date`; `now_tm` is `gmtime_r` at every consumer), so on a
+     * negative-offset host the candidate's local date is the day BEFORE its UTC
+     * date: the walk validated day D-1 and handed back day D. Measured on the
+     * 2026-06-15 replay in America/New_York -- Monday resolved to Saturday
+     * 2026-06-13, no T-1 close existed, the Day T-1 finalization was refused for
+     * the whole window, and every day-T row was marked from the widened fallback
+     * (E2-F45).
+     *
+     * Testing in the returned frame makes the function self-consistent for any
+     * caller. The two futures runners still parse their CLI date with
+     * `std::mktime` (local midnight, E2-F42); on a negative-offset host that
+     * lands at 04:00/05:00Z on the SAME calendar day, so the walk sees the same
+     * days and their answer does not move -- pinned by
+     * `PreviousTradingDayFrameTest.LocalMidnightRunDateResolvesTheSameCalendarDate`.
+     *
+     * The previous comment justified local time as consistency with
+     * `EquityInstrument::is_market_open`. That function has no production
+     * callers (only tests), so it was never a constraint on this one.
+     *
      * @param start Reference timestamp; the search begins at `start - 24h`.
      * @param max_lookback_days Maximum days to walk back before giving up.
      * @return time_point of the previous trading day, or std::nullopt if the
@@ -217,15 +241,11 @@ public:
     std::optional<std::chrono::system_clock::time_point>
     find_previous_trading_day(std::chrono::system_clock::time_point start,
                               int max_lookback_days = 14) const {
-        // Ultrareview follow-up (Phase 6 §6b carry-over): use the thread-safe
-        // safe_localtime wrapper instead of std::localtime. Local-time
-        // semantics are preserved to stay consistent with
-        // EquityInstrument::is_market_open which also uses safe_localtime.
         auto candidate = start - std::chrono::hours(24);
         for (int i = 0; i < max_lookback_days; ++i) {
             auto t = std::chrono::system_clock::to_time_t(candidate);
             std::tm tm{};
-            if (!trade_ngin::core::safe_localtime(&t, &tm)) {
+            if (gmtime_r(&t, &tm) == nullptr) {
                 return std::nullopt;
             }
             bool is_weekend = (tm.tm_wday == 0 || tm.tm_wday == 6);

--- a/include/trade_ngin/core/time_utils.hpp
+++ b/include/trade_ngin/core/time_utils.hpp
@@ -115,6 +115,43 @@ inline bool parse_utc_datetime(const std::string& text,
     return true;
 }
 
+/**
+ * @brief Parse a `YYYY-MM-DD` CALENDAR DATE as UTC midnight.
+ *
+ * The date-only counterpart to parse_utc_datetime, for the sites that take a
+ * bare date (a CLI run date, an ex-date) rather than a timestamp. std::mktime
+ * reads the broken-down date as LOCAL midnight; every consumer then formats it
+ * back through gmtime (format_utc_date), so on a host at a positive UTC offset
+ * the value lands on the PREVIOUS day and the whole run shifts with it -- the
+ * date key written to trading.positions, the T-1 lookup, the dedup comparison.
+ * A New York host hides this (local midnight is 05:00 UTC, same calendar day),
+ * which is why it survived: the defect only shows east of Greenwich.
+ *
+ * Leading/trailing text is rejected rather than ignored, so a timestamp string
+ * cannot be silently truncated to its date here -- use parse_utc_datetime for
+ * those. Returns false on a malformed string, leaving `out` untouched.
+ */
+inline bool parse_utc_date(const std::string& text,
+                           std::chrono::system_clock::time_point& out) {
+    int year = 0, month = 0, day = 0;
+    char trailing = '\0';
+    // The %c catches any extra character: exactly 3 conversions means the whole
+    // string was "YYYY-MM-DD" and nothing else.
+    if (std::sscanf(text.c_str(), "%4d-%2d-%2d%c", &year, &month, &day, &trailing) != 3) {
+        return false;
+    }
+    if (month < 1 || month > 12 || day < 1 || day > 31) return false;
+    std::tm tm = {};
+    tm.tm_year = year - 1900;
+    tm.tm_mon = month - 1;
+    tm.tm_mday = day;
+    tm.tm_isdst = 0;
+    const time_t t = timegm(&tm);
+    if (t == static_cast<time_t>(-1)) return false;
+    out = std::chrono::system_clock::from_time_t(t);
+    return true;
+}
+
 inline std::string format_utc_datetime(std::chrono::system_clock::time_point tp) {
     auto t = std::chrono::system_clock::to_time_t(tp);
     std::tm tm{};

--- a/include/trade_ngin/data/conversion_utils.hpp
+++ b/include/trade_ngin/data/conversion_utils.hpp
@@ -65,8 +65,28 @@ public:
      * @brief Get an int64 from a ChunkedArray, with type-aware dispatch.
      *
      * Like safe_get_double but for integers. Doubles in the column are
-     * truncated toward zero (with a single WARN about precision loss);
-     * strings are parsed via std::stoll.
+     * truncated toward zero (with a single WARN about precision loss).
+     *
+     * E2-F37 / BA-14 -- temporal columns. The canonical schema stores dates as
+     * `arrow::TimestampArray`, but convert_generic_to_arrow may surface the same
+     * column as utf8 or int64 depending on the source, which is why callers route
+     * timestamps through here at all. Before this there was no TIMESTAMP case, so
+     * such a column hit `default` and errored -- or, worse, arrived as a STRING
+     * and `std::stoll("2026-09-02 00:00:00")` returned **2026**: a silent,
+     * plausible-looking integer that is not a timestamp in any unit.
+     *
+     * UNITS -- read this before using the result:
+     *   * TIMESTAMP: the column's OWN unit (s / ms / us / ns), exactly as an
+     *     int64 column holding the same value would have returned. The canonical
+     *     schema is microseconds and `LiveDataLoader::load_previous_day_data`
+     *     reads it as such. This function does not normalise, because doing so
+     *     would silently change what that caller already computes.
+     *   * DATE32: days since the epoch. DATE64: milliseconds since the epoch.
+     *     Both are Arrow's native units for those types.
+     *   * STRING: a fully-integral string is parsed as an integer. A string that
+     *     is NOT fully integral is parsed as `YYYY-MM-DD[ HH:MM:SS]` and returned
+     *     as MICROSECONDS since the epoch, matching the canonical timestamp unit.
+     *     Anything else is a CONVERSION_ERROR -- never a partial parse.
      */
     static Result<int64_t> safe_get_int64(
         const std::shared_ptr<arrow::ChunkedArray>& col, int64_t row,

--- a/include/trade_ngin/data/database_interface.hpp
+++ b/include/trade_ngin/data/database_interface.hpp
@@ -173,23 +173,6 @@ public:
         const std::string& portfolio_id = "BASE_PORTFOLIO",
         const std::string& table_name = "backtest.signals") = 0;
 
-    /**
-     * @brief Store backtest run metadata
-     * @param run_id Backtest run identifier
-     * @param name Run name
-     * @param description Run description
-     * @param start_date Start date
-     * @param end_date End date
-     * @param hyperparameters JSON configuration
-     * @param table_name Name of the table to insert into
-     * @return Result indicating success or failure
-     */
-    virtual Result<void> store_backtest_metadata(
-        const std::string& run_id, const std::string& name, const std::string& description,
-        const Timestamp& start_date, const Timestamp& end_date,
-        const nlohmann::json& hyperparameters, const std::string& portfolio_id = "BASE_PORTFOLIO",
-        const std::string& table_name = "backtest.run_metadata") = 0;
-
     // ============================================================================
     // NEW METHODS FOR LIVE TRADING DATA STORAGE
     // ============================================================================

--- a/include/trade_ngin/data/postgres_database.hpp
+++ b/include/trade_ngin/data/postgres_database.hpp
@@ -795,6 +795,18 @@ public:
         double qty_held{0.0};
         double dividend_per_share{0.0};
         double total_cash{0.0};
+        /**
+         * Run date of the pass that wrote the row (E2-F23, migration 005).
+         * YYYY-MM-DD, or "" for a legacy row written before the column existed.
+         *
+         * NOT part of the natural key. It exists so a run can tell whether the
+         * dedup rows it is about to trust came from an EARLIER pass or a LATER
+         * one -- the ex-date cannot, because the measured failure (BKNG, ex-date
+         * 2026-04-06, re-run of 04-07 over an un-reset dedup table) has an
+         * ex-date safely in the past, and `applied_at` cannot, because an earlier
+         * chain always carries an earlier wall clock.
+         */
+        std::string run_date;
     };
 
     /**

--- a/include/trade_ngin/data/postgres_database.hpp
+++ b/include/trade_ngin/data/postgres_database.hpp
@@ -626,6 +626,26 @@ public:
         const std::vector<std::string>& actions = {"split", "dividend", "adrratiosplit"});
 
     /**
+     * @brief Last date present in equities_data.corporate_action.
+     *
+     * E4 item 3. The deal-terms feed's stop date used to be a compiled-in
+     * constant (`kCorpActionTableFrozenAfter`) quoted in every termination WARN.
+     * A constant cannot notice a revived subscription: after a backfill the
+     * message keeps naming the old date until someone rebuilds, and the operator
+     * gets no signal that the dormant rollover path just went live. Measuring it
+     * makes the log line true by construction.
+     *
+     * Future-dated placeholder rows are excluded: the table carries tickerchange
+     * rows dated 2027-07-18, and a bare max() would report a feed running two
+     * years ahead of the run.
+     *
+     * @param as_of_date Inclusive upper bound, YYYY-MM-DD. Empty means no bound.
+     * @return YYYY-MM-DD, or "" when the table holds no row at or before the
+     *         bound. An unreachable database is an error, never "".
+     */
+    Result<std::string> get_corp_action_feed_last_date(const std::string& as_of_date = "");
+
+    /**
      * @brief PRICE_RESTATING events sourced from the live per-bar columns.
      *
      * equities_data.ohlcv_1d carries div_cash and split_factor on the bar the

--- a/include/trade_ngin/data/postgres_database.hpp
+++ b/include/trade_ngin/data/postgres_database.hpp
@@ -292,23 +292,6 @@ public:
         const std::string& portfolio_id = "BASE_PORTFOLIO",
         const std::string& table_name = "backtest.signals") override;
 
-    /**
-     * @brief Store backtest run metadata
-     * @param run_id Backtest run identifier
-     * @param name Run name
-     * @param description Run description
-     * @param start_date Start date
-     * @param end_date End date
-     * @param hyperparameters JSON configuration
-     * @param table_name Name of the table to insert into
-     * @return Result indicating success or failure
-     */
-    Result<void> store_backtest_metadata(
-        const std::string& run_id, const std::string& name, const std::string& description,
-        const Timestamp& start_date, const Timestamp& end_date,
-        const nlohmann::json& hyperparameters, const std::string& portfolio_id = "BASE_PORTFOLIO",
-        const std::string& table_name = "backtest.run_metadata") override;
-
     // Multi-strategy version: store metadata with portfolio_run_id, strategy_allocation,
     // portfolio_config
     virtual Result<void> store_backtest_metadata_with_portfolio(

--- a/include/trade_ngin/data/postgres_database.hpp
+++ b/include/trade_ngin/data/postgres_database.hpp
@@ -666,10 +666,24 @@ public:
      * From equities_data.ohlcv_1d.delisting_date, which is maintained
      * independently of the frozen corporate_action feed.
      *
-     * @return symbol -> YYYY-MM-DD for symbols carrying a delisting date.
+     * @param tickers   Symbols to look up.
+     * @param from_date Inclusive YYYY-MM-DD floor; a delisting older than this
+     *        is not returned. Empty means no floor (the pre-BA-8 behaviour).
+     *
+     * BA-8 / C-1 D12: delisting_date is keyed on the TICKER, and this reads
+     * `max(delisting_date)` over the symbol's whole history, so a reused ticker
+     * inherits the dead company's row -- HPC carries 2008-11-24, MER 2008-12-31.
+     * Acting on one exits a live position at a stale price. The runner has a
+     * bars-contradict guard, but that guard needs a bar: `delisting_is_stale`
+     * returns false when `last_bar_date` is EMPTY, so a held symbol with no bar
+     * in the load window is still terminated on a decade-old row. A floor closes
+     * that at the source -- a 2008 delisting has no business reaching a 2026 run.
+     *
+     * @return symbol -> YYYY-MM-DD for symbols carrying a delisting date at or
+     *         after `from_date`.
      */
     virtual Result<std::unordered_map<std::string, std::string>> get_delisting_dates(
-        const std::vector<std::string>& tickers);
+        const std::vector<std::string>& tickers, const std::string& from_date = "");
 
     /**
      * @brief Earliest date each symbol was held (non-zero) by this strategy.

--- a/include/trade_ngin/data/postgres_database.hpp
+++ b/include/trade_ngin/data/postgres_database.hpp
@@ -731,6 +731,36 @@ public:
         const std::string& table_name = "trading.positions");
 
     /**
+     * @brief Date the CURRENT holding of each symbol began -- the class-2 era input.
+     *
+     * `get_position_inception_dates` is `min(date)` over all history and fails WIDE on
+     * purpose, which is right for the class-1 price window and wrong for the rename era
+     * test. Tickers get reused. A strategy that held META (Facebook) in 2021, closed it,
+     * and re-bought META (Meta Platforms) in 2026 has a lifetime inception of 2021, which
+     * satisfies `inception <= effective_until` for our own META -> METV backfill
+     * (effective_until 2022-01-31) and re-keys a live 100-share position onto a symbol
+     * with no bars at all. Class 2 must ask a narrower question: when did the holding we
+     * hold RIGHT NOW start? (BA-2 / C-3 D1.)
+     *
+     * A holding starts after the most recent flat row. A closed position keeps exactly one
+     * row -- quantity 0 on the day it closed (E2-F19, `LiveDailyCycle::is_dead_row`) -- so
+     * that row is the break. Absent such a row the position was never closed and this
+     * equals the lifetime inception.
+     *
+     * Direction of error: too LATE is safe (the rename is skipped and retried next run);
+     * too EARLY re-keys a live holding, which is silent and permanent. This errs late.
+     *
+     * @return symbol -> YYYY-MM-DD the current holding began. Symbols with no non-zero
+     *         row after the last flat row are ABSENT, and class 2 skips them.
+     */
+    virtual Result<std::unordered_map<std::string, std::string>> get_current_holding_start_dates(
+        const std::string& strategy_id,
+        const std::string& strategy_name,
+        const std::string& portfolio_id,
+        const std::vector<std::string>& symbols,
+        const std::string& table_name = "trading.positions");
+
+    /**
      * @brief Latest date this strategy BOUGHT each symbol, on or after `on_or_after`.
      *
      * E2-F17 basis provenance. A class-1 corporate action may only restate a cost basis that

--- a/include/trade_ngin/live/corp_action_feed_status.hpp
+++ b/include/trade_ngin/live/corp_action_feed_status.hpp
@@ -1,0 +1,92 @@
+// include/trade_ngin/live/corp_action_feed_status.hpp
+#pragma once
+
+#include <string>
+
+#include "trade_ngin/live/corporate_actions_classification.hpp"
+
+namespace trade_ngin {
+
+/**
+ * @brief Whether the equities_data.corporate_action deal-terms feed is still frozen.
+ *
+ * E4 item 3. The termination handler's WARN text named a COMPILED-IN date
+ * (`kCorpActionTableFrozenAfter`, "2025-08-29") as the point the feed stopped.
+ * That is a fact about the database, not about the code, and the code cannot
+ * know it: the day the vendor subscription is restarted and the ACTIONS ingest
+ * backfills, every one of those WARNs starts asserting something false, and it
+ * takes a rebuild to stop it. Worse, the operator reading the log has no signal
+ * that the revival happened at all -- the message is identical before and after.
+ *
+ * So the date is MEASURED at startup (`SELECT max(date) FROM
+ * equities_data.corporate_action`) and reported. The constant survives only as
+ * the fallback for the case where the measurement itself failed, and as the
+ * reference point that tells us the feed moved.
+ *
+ * Note this is the DEAL-TERMS feed (class-3 acquisitions, mergers, delistings,
+ * and the class-2 renames), not the price feed. Bar freshness is a different
+ * question with a different answer -- see live/data_freshness.hpp.
+ */
+struct CorpActionFeedStatus {
+    /// True when the last-row date came from the database rather than the constant.
+    bool measured{false};
+    /// Last date present in equities_data.corporate_action, YYYY-MM-DD.
+    std::string last_row_date;
+    /// True when `last_row_date` is strictly before the run's as-of date.
+    bool frozen{false};
+    /// True when the measured date is later than the compiled-in constant: the
+    /// feed has been revived since this binary was built, and the paths that
+    /// were dormant (deal-terms rollover) are now live.
+    bool revived_since_build{false};
+};
+
+/**
+ * @brief Build the status from a measured max date.
+ *
+ * @param measured_max_date `max(date)` from equities_data.corporate_action, or
+ *        "" when the query failed or the table is empty. An empty value falls
+ *        back to the compiled-in constant with `measured = false`, so the log
+ *        line and the WARN text degrade to the old behaviour rather than to a
+ *        blank.
+ * @param as_of_ymd the run's as-of date, YYYY-MM-DD.
+ *
+ * Future-dated placeholder rows are the reason `frozen` compares against the
+ * as-of date rather than "is there anything recent": equities_data.corporate_action
+ * carries tickerchange rows dated 2027-07-18, so a naive max() reports a feed
+ * that is ahead of the run. `frozen` answers "did the feed stop before this run",
+ * which is what the WARN needs to say, and a max beyond the as-of date makes it
+ * false -- correctly, because such a feed has not stopped.
+ */
+inline CorpActionFeedStatus assess_corp_action_feed(const std::string& measured_max_date,
+                                                    const std::string& as_of_ymd) {
+    CorpActionFeedStatus s;
+    if (measured_max_date.empty()) {
+        s.measured = false;
+        s.last_row_date = kCorpActionTableFrozenAfter;
+    } else {
+        s.measured = true;
+        s.last_row_date = measured_max_date;
+        s.revived_since_build = measured_max_date > std::string(kCorpActionTableFrozenAfter);
+    }
+    s.frozen = !as_of_ymd.empty() && s.last_row_date < as_of_ymd;
+    return s;
+}
+
+/// One log line, the same shape whether measured or fallen back, so a grep over
+/// two runs shows the feed moving.
+inline std::string describe_corp_action_feed(const CorpActionFeedStatus& s) {
+    std::string out = "deal-terms feed last row " + s.last_row_date + ", frozen: " +
+                      (s.frozen ? "yes" : "no");
+    if (!s.measured) {
+        out += " (NOT MEASURED -- could not read equities_data.corporate_action, "
+               "falling back to the compiled-in date " +
+               std::string(kCorpActionTableFrozenAfter) + ")";
+    } else if (s.revived_since_build) {
+        out += " (REVIVED since this binary was built, which recorded " +
+               std::string(kCorpActionTableFrozenAfter) +
+               " -- the deal-terms and rename paths that were dormant are now live)";
+    }
+    return out;
+}
+
+}  // namespace trade_ngin

--- a/include/trade_ngin/live/corp_action_window.hpp
+++ b/include/trade_ngin/live/corp_action_window.hpp
@@ -94,6 +94,63 @@ inline CorpActionWindow derive_corp_action_window(
     return w;
 }
 
+/**
+ * @brief Fill in an inception date for every held symbol the read did not answer for.
+ *
+ * BA-9 / C-1 D13. `get_position_inception_dates` returns one row per symbol that
+ * has EVER been held non-zero under this (strategy, portfolio) triple. A held
+ * symbol absent from that result is not "established recently" -- it is
+ * "established at a date this run cannot determine", which is the same epistemic
+ * state as a failed read. Only `is_error()` used to widen the window, so a
+ * successful read that answered for none of the held symbols, or for only some,
+ * silently contributed nothing and left the window at its `min_days` floor.
+ *
+ * That is the exact shape of the regression this derivation replaced: a 14-day
+ * window that dropped 8 of the 9 dividends the configured universe saw. The rule
+ * for class 1 is stated in the runner and does not change here -- under-applying a
+ * price rescale is the PERMANENT error, so an unknown inception fails WIDE, to the
+ * bulk edge. Over-fetching only costs query time; `trading.corp_action_applied`
+ * rejects an event that was already applied.
+ *
+ * A malformed date is treated as missing for the same reason: `derive_corp_action_window`
+ * skips anything that will not parse, so leaving it in place is indistinguishable
+ * from having no answer at all.
+ *
+ * @param held_symbols     Symbols held non-zero going into today.
+ * @param read             What the inception read returned (possibly partial or empty).
+ * @param bulk_start_ymd   The bulk price load's lower bound, YYYY-MM-DD.
+ * @return One entry per held symbol: the read's date where usable, else bulk_start_ymd.
+ */
+inline std::unordered_map<std::string, std::string> inception_with_unknowns_widened(
+    const std::vector<std::string>& held_symbols,
+    const std::unordered_map<std::string, std::string>& read,
+    const std::string& bulk_start_ymd) {
+    std::unordered_map<std::string, std::string> out;
+    out.reserve(held_symbols.size());
+    for (const auto& sym : held_symbols) {
+        auto it = read.find(sym);
+        if (it != read.end() && parse_ymd_utc(it->second) > 0) {
+            out[sym] = it->second;
+        } else {
+            out[sym] = bulk_start_ymd;
+        }
+    }
+    return out;
+}
+
+/// Symbols held but not answered for by the inception read -- reported so a
+/// widened window says WHY it widened rather than only that it did.
+inline std::vector<std::string> held_symbols_without_inception(
+    const std::vector<std::string>& held_symbols,
+    const std::unordered_map<std::string, std::string>& read) {
+    std::vector<std::string> missing;
+    for (const auto& sym : held_symbols) {
+        auto it = read.find(sym);
+        if (it == read.end() || parse_ymd_utc(it->second) <= 0) missing.push_back(sym);
+    }
+    return missing;
+}
+
 /// Format a UTC instant as YYYY-MM-DD (bar keys are UTC, never localtime).
 inline std::string format_ymd_utc(std::time_t t) {
     std::tm tm{};

--- a/include/trade_ngin/live/corporate_actions_audit_log.hpp
+++ b/include/trade_ngin/live/corporate_actions_audit_log.hpp
@@ -97,6 +97,46 @@ public:
     Result<bool> load();
 
     /**
+     * @brief The run's own as-of date, which every row this pass writes is stamped
+     *        with and which load() refuses to run behind.
+     *
+     * E2-F23 (audit option C-prime). A live run is correct exactly when the dedup
+     * rows and the T-1 position row come from the SAME pass. Reset the book but
+     * not this table and it is not: the event is skipped as "already applied"
+     * against a T-1 row that predates it, T-1 is finalized in the wrong frame, and
+     * nothing notices -- the G3 basis/mark guard only inspects events that were
+     * APPLIED, and a deduped event never enters that list. Measured: BKNG 25:1,
+     * ex-date 2026-04-06, re-run of 2026-04-07 over an un-reset dedup table,
+     * -4,824 of phantom unrealized P&L.
+     *
+     * The existing ex-date detector cannot see that case (2026-04-06 is safely in
+     * the past) and `applied_at` cannot either (an earlier chain always has an
+     * earlier wall clock). The run date of the writing pass is the only value that
+     * separates an earlier pass from a later one.
+     *
+     * Pass the runner's as-of date -- the replay date, NOT today's wall clock -- or
+     * a replay of 2026-04-07 executed tonight would stamp tonight and every later
+     * chain would look stale. Leaving it empty disables both the stamping and the
+     * check, which is the pre-005 behaviour and what the file-backed tests use.
+     */
+    enum class RunDateCheck {
+        /// Stamp writes AND refuse to load behind a later pass's rows.
+        Enforce,
+        /// Stamp writes only. For a SECOND log opened later in the same run: this
+        /// run's own rows are already committed by then, so enforcing would make
+        /// the run refuse itself.
+        StampOnly
+    };
+
+    void set_run_date(std::string run_date_ymd,
+                      RunDateCheck check = RunDateCheck::Enforce) {
+        run_date_ = std::move(run_date_ymd);
+        enforce_run_date_ = (check == RunDateCheck::Enforce);
+    }
+
+    const std::string& run_date() const { return run_date_; }
+
+    /**
      * @brief Has this (symbol, ex_date, action) tuple already been applied?
      */
     /**
@@ -230,6 +270,10 @@ private:
     std::string portfolio_id_;
     std::string strategy_id_;
     std::string strategy_name_;
+    // The run's as-of date (E2-F23). Empty disables stamping and the staleness
+    // check; see set_run_date.
+    std::string run_date_;
+    bool enforce_run_date_{true};
     // Rows recorded since the last save(), so save() writes a delta rather
     // than re-inserting the whole lifetime set on every run.
     mutable std::vector<PostgresDatabase::AppliedCorpActionRow> pending_;

--- a/include/trade_ngin/live/corporate_actions_audit_log.hpp
+++ b/include/trade_ngin/live/corporate_actions_audit_log.hpp
@@ -171,8 +171,14 @@ public:
 
     const std::string& state_dir() const { return state_dir_; }
 
-private:
-    using AppliedKey = std::tuple<std::string, std::string, CorpActionType>;
+    /**
+     * @brief Dividend detail as the legacy state file carried it.
+     *
+     * Public because `dividend_detail_for` below takes and returns it, and that
+     * rule has to be testable without a database (E2-F39 / BA-15). Note there is
+     * no action_type here: every entry in this list IS a dividend, which is
+     * precisely why the import needs the type passed in alongside.
+     */
     struct DividendEvent {
         std::string symbol;
         std::string ex_date;
@@ -180,6 +186,39 @@ private:
         double dividend_per_share{0.0};
         double total_cash{0.0};
     };
+
+    /**
+     * @brief Which legacy dividend detail belongs to an applied event, if any.
+     *
+     * E2-F39 / BA-15. The legacy state file records applied events keyed on
+     * (symbol, ex_date, action_type) but carries dividend detail keyed only on
+     * (symbol, ex_date) -- DividendEvent has no action_type, because every entry
+     * in it IS a dividend. The import matched on (symbol, ex_date) alone, so when
+     * a symbol had a SPLIT and a DIVIDEND on the SAME ex-date, the SPLIT row also
+     * inherited the dividend's qty_held, dividend_per_share and total_cash. The
+     * cash then appears twice in cumulative dividend income: once on the dividend
+     * row, once on the split row that never paid anything.
+     *
+     * Returns nullptr when the event is not a dividend, or when no detail matches.
+     *
+     * Static and public so the rule is testable without a database: the import it
+     * serves runs inside migrate_state_file_to_db(), which requires a live
+     * connection and a file on disk.
+     */
+    static const DividendEvent* dividend_detail_for(
+        const std::string& symbol, const std::string& ex_date, CorpActionType type,
+        const std::vector<DividendEvent>& events) {
+        // A split, an ADR split or a termination pays no dividend. Only a
+        // DIVIDEND event may carry dividend detail.
+        if (type != CorpActionType::DIVIDEND) return nullptr;
+        for (const auto& de : events) {
+            if (de.symbol == symbol && de.ex_date == ex_date) return &de;
+        }
+        return nullptr;
+    }
+
+private:
+    using AppliedKey = std::tuple<std::string, std::string, CorpActionType>;
 
     std::string state_dir_;
     std::set<AppliedKey> applied_;

--- a/include/trade_ngin/live/corporate_actions_classification.hpp
+++ b/include/trade_ngin/live/corporate_actions_classification.hpp
@@ -65,11 +65,23 @@ const char* corp_action_class_to_string(CorpActionClass c);
 const std::vector<std::string>& vendor_labels_for_class(CorpActionClass c);
 
 /**
- * @brief Last date on which equities_data.corporate_action received events.
+ * @brief FALLBACK ONLY: the date equities_data.corporate_action was last seen
+ *        receiving events, as of the commit that wrote this line.
  *
- * The feed stopped here; anything after this date is not in that table. The
- * TERMINATION deal-terms path queries it anyway (finding nothing today) so a
- * revived feed activates the handler with no code change.
+ * NOT the answer to "is the feed frozen" -- that is a fact about the database,
+ * and the runner MEASURES it (`PostgresDatabase::get_corp_action_feed_last_date`,
+ * `assess_corp_action_feed` in live/corp_action_feed_status.hpp) and logs it at
+ * startup. A compiled-in date cannot notice a restarted subscription: after a
+ * backfill every WARN quoting it asserts something false until somebody
+ * rebuilds, and nothing tells the operator the dormant deal-terms path just went
+ * live.
+ *
+ * This constant survives for two jobs only: the fallback when the measurement
+ * itself failed, and the reference point that lets the startup line say the feed
+ * has MOVED since the build. Do not read it as current fact.
+ *
+ * The TERMINATION deal-terms path queries the table regardless (finding nothing
+ * today) so a revived feed activates the handler with no code change.
  */
 inline constexpr const char* kCorpActionTableFrozenAfter = "2025-08-29";
 

--- a/include/trade_ngin/live/corporate_actions_lifecycle.hpp
+++ b/include/trade_ngin/live/corporate_actions_lifecycle.hpp
@@ -134,10 +134,19 @@ public:
      *
      * @param final_closes Last traded price per symbol; required for exits.
      */
+    /**
+     * @param feed_last_date MEASURED last row date of
+     *        equities_data.corporate_action, YYYY-MM-DD. Quoted in the "no deal
+     *        terms" WARNs so the operator reads what the database actually holds
+     *        rather than a date compiled into the binary (E4 item 3). Empty
+     *        falls back to `kCorpActionTableFrozenAfter`, which is what every
+     *        caller got before the measurement existed.
+     */
     static std::vector<LifecycleAdjustment> apply_terminations(
         std::unordered_map<std::string, Position>& positions,
         const std::vector<TerminationEvent>& events,
-        const std::unordered_map<std::string, double>& final_closes);
+        const std::unordered_map<std::string, double>& final_closes,
+        const std::string& feed_last_date = "");
 
     /**
      * @brief Is a `delisting_date` contradicted by the symbol's own bars?

--- a/include/trade_ngin/live/corporate_actions_lifecycle.hpp
+++ b/include/trade_ngin/live/corporate_actions_lifecycle.hpp
@@ -79,6 +79,47 @@ struct LifecycleAdjustment {
 class CorporateActionsLifecycle {
 public:
     /**
+     * @brief historical ticker -> its eras, ascending by `effective_until`.
+     *
+     * Each entry is (effective_until, current_symbol). ISO YYYY-MM-DD compares
+     * lexicographically, so a plain sort orders the eras. An alias with no
+     * `effective_until` cannot be era-bounded and is DROPPED, not applied
+     * unconditionally: class 2 fails narrow, and an unbounded alias is exactly
+     * the shape that re-keys a currently-trading ticker.
+     */
+    using RenameMap =
+        std::unordered_map<std::string, std::vector<std::pair<std::string, std::string>>>;
+
+    static RenameMap build_rename_map(const std::vector<TickerAlias>& aliases);
+
+    /**
+     * @brief The successor a ticker had at `date`: the first rename on or after it.
+     *
+     * A date later than every rename maps NOWHERE -- the ticker belongs to whoever
+     * holds it now, not to the old company. The compare is inclusive on purpose:
+     * `effective_until` conventions differ by a day between curated rows
+     * (day-after) and backfilled rows (source date), so on the boundary day `<=`
+     * errs toward NOT applying a backfilled rename, which is simply retried next run.
+     *
+     * @return (effective_until, current_symbol); both empty when nothing applies.
+     */
+    static std::pair<std::string, std::string> successor_at(const RenameMap& renames,
+                                                            const std::string& symbol,
+                                                            const std::string& date);
+
+    /**
+     * @brief The tickers `apply_renames` would move this holding onto, in hop order.
+     *
+     * Same chain, same era test, same as-of guard as apply_renames -- shared so the
+     * universe the runner loads bars for cannot disagree with the re-keying that
+     * happens later in the same run (E2-F34). Empty when no rename applies.
+     */
+    static std::vector<std::string> rename_chain(const RenameMap& renames,
+                                                 const std::string& symbol,
+                                                 const std::string& holding_start,
+                                                 const std::string& as_of_date);
+
+    /**
      * @brief Class 2 -- re-key positions held under a superseded ticker.
      *
      * A position still keyed by a historical ticker is moved to the current

--- a/include/trade_ngin/live/data_freshness.hpp
+++ b/include/trade_ngin/live/data_freshness.hpp
@@ -1,0 +1,117 @@
+// include/trade_ngin/live/data_freshness.hpp
+#pragma once
+
+#include <ctime>
+#include <string>
+#include <unordered_map>
+
+namespace trade_ngin {
+
+/**
+ * @brief How current the price feed is for the symbols a run actually loaded.
+ *
+ * BA-12 / C-1 C8. The freshness guard used to take the GLOBAL maximum bar
+ * timestamp across every loaded bar. At universe scale that is not a freshness
+ * measure at all: one symbol printing today puts the maximum at today, so 851
+ * symbols could be months stale and the guard would report the feed current.
+ * The question "is the feed fresh" is answered by the STALEST symbol, not the
+ * freshest one.
+ *
+ * Two further properties the old form got wrong:
+ *
+ *  * No data at all was treated as "nothing to check" -- the guard sat behind
+ *    `if (!all_bars.empty())`. An empty load is the MOST stale state reachable,
+ *    not a neutral one, so it is reported as such here and the caller decides.
+ *
+ *  * Staleness was `duration_cast<hours>(end - latest) / 24` on instants. Bars
+ *    are midnight-UTC keys, so an instant subtraction is off by one whenever the
+ *    two ends sit either side of a fractional day. Calendar days between two
+ *    UTC date keys is the quantity the tolerance is expressed in.
+ */
+struct FeedFreshness {
+    /// False when no symbol had a bar. Maximally stale, never neutral.
+    bool any_data{false};
+    /// The oldest "last bar" across all symbols, YYYY-MM-DD. Empty when !any_data.
+    std::string stalest_date;
+    /// Which symbol is furthest behind. Empty when !any_data.
+    std::string stalest_symbol;
+    /// Calendar days from `stalest_date` to the as-of date. 0 when !any_data.
+    long days_behind{0};
+    /// How many symbols were assessed.
+    std::size_t symbols{0};
+};
+
+/// Parse YYYY-MM-DD as a UTC instant; 0 on malformed input. Kept local so this
+/// header stays free of the corp-action window's includes.
+inline std::time_t freshness_parse_ymd_utc(const std::string& ymd) {
+    if (ymd.size() < 10) return 0;
+    std::tm tm{};
+    tm.tm_year = 0;
+    // Hand-parsed rather than via get_time: this is called per symbol and
+    // std::istringstream is needlessly expensive at 852 names.
+    auto digits = [&](std::size_t at, std::size_t n, int& out) -> bool {
+        int v = 0;
+        for (std::size_t i = 0; i < n; ++i) {
+            const char c = ymd[at + i];
+            if (c < '0' || c > '9') return false;
+            v = v * 10 + (c - '0');
+        }
+        out = v;
+        return true;
+    };
+    int y = 0, m = 0, d = 0;
+    if (ymd[4] != '-' || ymd[7] != '-') return 0;
+    if (!digits(0, 4, y) || !digits(5, 2, m) || !digits(8, 2, d)) return 0;
+    if (m < 1 || m > 12 || d < 1 || d > 31) return 0;
+    tm.tm_year = y - 1900;
+    tm.tm_mon = m - 1;
+    tm.tm_mday = d;
+    return timegm(&tm);
+}
+
+/// Whole calendar days from `from_ymd` to `to_ymd`. Negative if `from` is later.
+/// 0 if either date is malformed -- the caller cannot act on an unparseable key,
+/// and reporting a huge staleness for a typo would be its own false alarm.
+inline long calendar_days_between_utc(const std::string& from_ymd, const std::string& to_ymd) {
+    const std::time_t a = freshness_parse_ymd_utc(from_ymd);
+    const std::time_t b = freshness_parse_ymd_utc(to_ymd);
+    if (a <= 0 || b <= 0) return 0;
+    return static_cast<long>((b - a) / (24 * 60 * 60));
+}
+
+/**
+ * @brief Assess feed freshness from the per-symbol newest-bar map.
+ *
+ * @param last_bar_date symbol -> newest loaded bar, YYYY-MM-DD (the map the
+ *        runner already builds for the corp-action horizon gate).
+ * @param as_of_ymd     the run's end date, YYYY-MM-DD.
+ *
+ * Symbols whose date will not parse are counted but cannot set the bound; a map
+ * consisting only of such entries reports `any_data = false`, because nothing in
+ * it establishes that any symbol is current.
+ */
+inline FeedFreshness assess_feed_freshness(
+    const std::unordered_map<std::string, std::string>& last_bar_date,
+    const std::string& as_of_ymd) {
+    FeedFreshness f;
+    f.symbols = last_bar_date.size();
+
+    for (const auto& [symbol, ymd] : last_bar_date) {
+        if (freshness_parse_ymd_utc(ymd) <= 0) continue;
+        // MIN, not max: the stalest symbol is what decides whether the feed is
+        // usable. Ties broken by symbol name so the report is deterministic.
+        if (!f.any_data || ymd < f.stalest_date ||
+            (ymd == f.stalest_date && symbol < f.stalest_symbol)) {
+            f.any_data = true;
+            f.stalest_date = ymd;
+            f.stalest_symbol = symbol;
+        }
+    }
+
+    if (f.any_data) {
+        f.days_behind = calendar_days_between_utc(f.stalest_date, as_of_ymd);
+    }
+    return f;
+}
+
+}  // namespace trade_ngin

--- a/include/trade_ngin/live/live_daily_cycle.hpp
+++ b/include/trade_ngin/live/live_daily_cycle.hpp
@@ -314,6 +314,33 @@ public:
         return unresolved;
     }
 
+    /**
+     * @brief The prices the day-T rows must be marked at.
+     *
+     * One map, so a position row and the live_results aggregate cannot disagree about
+     * what a symbol was worth. `resolve_and_apply_basis` marks from the execution price
+     * map -- T-1 closes plus any widened substitute -- and the aggregate sums those
+     * marks; the row loop used to recompute from the T-1 close map alone, which has no
+     * entry for a widened symbol at all. That symbol's `daily_unrealized_pnl` was
+     * therefore written as 0 while the aggregate carried its real mark, and the in-run
+     * L5 assertion covers realized only, so nothing saw it (E2-F35 / BA-4). It fires on
+     * exactly the halted and thin names the widening exists to rescue.
+     *
+     * An EMPTY `execution_prices` -- the closed-day path, where execute_day_t never runs
+     * -- returns `t1_closes` unchanged, so the carry-forward day is untouched.
+     * Non-positive substitutes are ignored: absent is a better answer than zero, because
+     * a zero mark books the whole notional as a gain.
+     */
+    static std::unordered_map<std::string, double> day_t_mark_prices(
+        const std::unordered_map<std::string, double>& t1_closes,
+        const std::unordered_map<std::string, double>& execution_prices) {
+        std::unordered_map<std::string, double> marks = t1_closes;
+        for (const auto& [symbol, price] : execution_prices) {
+            if (price > 0.0) marks[symbol] = price;
+        }
+        return marks;
+    }
+
     // -----------------------------------------------------------------------
     // trading.positions.daily_realized_pnl -- the row-level realized column.
     //

--- a/include/trade_ngin/live/live_daily_cycle.hpp
+++ b/include/trade_ngin/live/live_daily_cycle.hpp
@@ -27,8 +27,22 @@ namespace trade_ngin {
 class LiveDailyCycle {
 public:
     /**
-     * @brief Put a live strategy into the state signal generation assumes,
-     *        then generate the day's signals.
+     * @brief Put a live strategy into the state signal generation assumes.
+     *
+     * Seeding ONLY. This used to call on_data(bars) as well, and the caller then
+     * ran PortfolioManager::process_market_data over the same vector, which calls
+     * on_data() again (portfolio_manager.cpp). MeanReversionStrategy::on_data
+     * appends unconditionally -- price_history.push_back and volume_sample_count++
+     * per bar -- so every live session fed each bar twice: the history ran to its
+     * trim cap rather than the bar count and the ADV EMA advanced over a series
+     * twice as long as the one that traded, which is what the fractional-share
+     * eligibility gate reads. A backtest feeds each bar once, so live and backtest
+     * could not agree on the same data by construction (E2-F28 / E3 NEW-6).
+     *
+     * The feed belongs to the portfolio manager, which is the component that then
+     * reads the targets. Fixing it here rather than in portfolio_manager.cpp is
+     * deliberate: that file is on the futures path, and removing a feed there would
+     * change what the trend strategies see.
      *
      * A live runner is a fresh process every session: BaseStrategy::positions_
      * starts empty and on_execution() -- its only writer -- does not run until
@@ -50,12 +64,10 @@ public:
      *        have been applied. Order matters here too: splits restate quantity
      *        and dividends restate cost basis, so seeding the pre-adjustment
      *        snapshot would anchor the strategy to a book that no longer exists.
-     * @param bars The day's market data.
      */
     static Result<void> prepare_strategy_for_signals(
         BaseStrategy& strategy,
-        const std::unordered_map<std::string, Position>& previous_positions,
-        const std::vector<Bar>& bars) {
+        const std::unordered_map<std::string, Position>& previous_positions) {
         // E2-F19 / E2-F20: seed quantity, basis and mark -- never yesterday's realized.
         //
         // BaseStrategy::seed_positions is a wholesale copy and on_execution() adds to
@@ -79,9 +91,7 @@ public:
         for (auto& [symbol, position] : seed_book) {
             position.realized_pnl = Decimal(0.0);
         }
-        auto seeded = strategy.seed_positions(seed_book);
-        if (seeded.is_error()) return seeded;
-        return strategy.on_data(bars);
+        return strategy.seed_positions(seed_book);
     }
 
     /** What one day's execution step did, beyond the fills themselves. */

--- a/include/trade_ngin/live/live_daily_cycle.hpp
+++ b/include/trade_ngin/live/live_daily_cycle.hpp
@@ -2,12 +2,14 @@
 #pragma once
 
 #include <algorithm>
+#include <ctime>
 #include <set>
 #include <string>
 #include <unordered_map>
 #include <vector>
 
 #include "trade_ngin/core/error.hpp"
+#include "trade_ngin/core/holiday_checker.hpp"
 #include "trade_ngin/live/corporate_actions_lifecycle.hpp"
 #include "trade_ngin/live/execution_manager.hpp"
 #include "trade_ngin/live/execution_price_resolver.hpp"
@@ -27,6 +29,50 @@ namespace trade_ngin {
  */
 class LiveDailyCycle {
 public:
+    /**
+     * @brief Is the exchange shut on this date?
+     *
+     * The predicate the whole closed-day path branches on, in a named place because it
+     * was five inline copies of `dow == 0 || dow == 6 || is_holiday(...)` in main() and
+     * nothing tested any of them (T-OR.3). A closed market does NOT mean "do nothing":
+     * the book is still held, so the day is processed as a carry-forward -- positions,
+     * live_results and equity_curve written from the previous session, signals and
+     * executions skipped -- which is what the futures runners already do.
+     *
+     * @param utc_tm the date under test, in UTC, with tm_wday populated (gmtime_r does).
+     * @param holidays the loaded calendar. Its own `covers_date` guard is checked by the
+     *        caller before any trading-day arithmetic runs; outside coverage `is_holiday`
+     *        answers false, and a date the calendar cannot speak for must not be silently
+     *        treated as open.
+     */
+    static bool is_non_trading_day(const std::tm& utc_tm, const HolidayChecker& holidays) {
+        if (utc_tm.tm_wday == 0 || utc_tm.tm_wday == 6) return true;
+        std::tm copy = utc_tm;
+        char buf[11];
+        if (std::strftime(buf, sizeof(buf), "%Y-%m-%d", &copy) != 10) {
+            return true;  // undatable: fail closed rather than trade on an unknown day
+        }
+        return holidays.is_holiday(buf);
+    }
+
+    /**
+     * @brief The day-T book on a day the market was shut.
+     *
+     * Quantity, cost basis and mark are the previous session's, unchanged -- no bar
+     * closed, so nothing was traded and nothing was re-marked. Realized is zeroed
+     * because `trading.positions.daily_realized_pnl` is a FLOW and this day realized
+     * nothing; carrying yesterday's figure would make the column a running total under
+     * a name that says daily, which is E2-F19 route 1.
+     */
+    static std::unordered_map<std::string, Position> carry_forward(
+        const std::unordered_map<std::string, Position>& previous_positions) {
+        std::unordered_map<std::string, Position> carried = previous_positions;
+        for (auto& [symbol, position] : carried) {
+            position.realized_pnl = Decimal(0.0);
+        }
+        return carried;
+    }
+
     /**
      * @brief Put a live strategy into the state signal generation assumes.
      *

--- a/include/trade_ngin/live/live_daily_cycle.hpp
+++ b/include/trade_ngin/live/live_daily_cycle.hpp
@@ -8,6 +8,7 @@
 #include <vector>
 
 #include "trade_ngin/core/error.hpp"
+#include "trade_ngin/live/corporate_actions_lifecycle.hpp"
 #include "trade_ngin/live/execution_manager.hpp"
 #include "trade_ngin/live/execution_price_resolver.hpp"
 #include "trade_ngin/live/live_pnl_manager.hpp"
@@ -92,6 +93,64 @@ public:
             position.realized_pnl = Decimal(0.0);
         }
         return strategy.seed_positions(seed_book);
+    }
+
+    /**
+     * @brief The symbols this run must load data for: config plus the successors
+     *        of anything currently held.
+     *
+     * The universe used to be fixed from config before the previous day's book was
+     * even read, while `apply_renames` ran ~1,500 lines later. A held position whose
+     * successor is not in config therefore got no bars, no instrument, no cost config
+     * and no target: the day-T pass reported "Missing T-1 price for symbol with a
+     * non-zero position", `execute_day_t` rule 3 rolled the target back to the carried
+     * quantity, and the position was carried again the next session and the one after
+     * -- an unpriceable zombie, persisted under the new key, that no amount of
+     * re-running clears (E2-F34 / E3 F-4). `add_rowless_exits` does not rescue it: its
+     * own contract says a symbol that left the universe is "still closed out", and that
+     * is only true when a price exists.
+     *
+     * So the book has to be known BEFORE the universe is finalized. This is the pure
+     * part of that ordering: given what is held and the alias table, say which extra
+     * tickers the run has to be able to price.
+     *
+     * The era test is the SAME one apply_renames applies -- same rename map, same
+     * as-of guard, same fail-narrow rule -- via CorporateActionsLifecycle::rename_chain,
+     * so the universe cannot admit a rename the re-keying will refuse, or miss one it
+     * will perform.
+     *
+     * @param holding_start symbol -> YYYY-MM-DD the CURRENT holding began. Never the
+     *        lifetime min(date): a ticker closed in 2021 and re-bought in 2026 would
+     *        satisfy the era test for the 2021 alias and the universe would grow a dead
+     *        symbol (BA-2 / C-3 D1). A symbol absent here contributes nothing.
+     * @return `config_symbols` in their configured order, followed by the successors
+     *         that were not already configured, sorted. Deterministic across runs.
+     */
+    static std::vector<std::string> effective_universe(
+        const std::vector<std::string>& config_symbols,
+        const std::unordered_map<std::string, Position>& previous_positions,
+        const std::vector<TickerAlias>& aliases,
+        const std::string& as_of_date,
+        const std::unordered_map<std::string, std::string>& holding_start) {
+
+        std::vector<std::string> universe = config_symbols;
+        std::set<std::string> known(config_symbols.begin(), config_symbols.end());
+
+        const auto renames = CorporateActionsLifecycle::build_rename_map(aliases);
+        if (renames.empty()) return universe;
+
+        std::set<std::string> additions;
+        for (const auto& [symbol, position] : previous_positions) {
+            if (position.quantity.as_double() == 0.0) continue;
+            auto start_it = holding_start.find(symbol);
+            if (start_it == holding_start.end() || start_it->second.empty()) continue;
+            for (const auto& successor : CorporateActionsLifecycle::rename_chain(
+                     renames, symbol, start_it->second, as_of_date)) {
+                if (known.insert(successor).second) additions.insert(successor);
+            }
+        }
+        universe.insert(universe.end(), additions.begin(), additions.end());
+        return universe;
     }
 
     /** What one day's execution step did, beyond the fills themselves. */

--- a/include/trade_ngin/live/live_pnl_manager.hpp
+++ b/include/trade_ngin/live/live_pnl_manager.hpp
@@ -241,7 +241,38 @@ public:
      */
     double get_point_value(const std::string& symbol) const;
 
+    /**
+     * @brief Which asset class this manager's unregistered symbols belong to.
+     *
+     * Only consulted when a symbol is NOT in the InstrumentRegistry. There the
+     * point value has to be guessed, and `get_fallback_multiplier` guesses with
+     * a SUBSTRING match over a futures table -- so a real equity ticker that
+     * happens to contain a contract code inherits that contract's multiplier:
+     * LEN matches "LE" (live cattle, 40000), ZM matches "ZM" (soybean meal,
+     * 100), UBER matches "UB" (ultra T-bond, 1000), HES matches "ES" (5).
+     * A 40000x point value on an equity position is not a rounding error, it is
+     * a P&L report off by four orders of magnitude (E2-F38 / BA-7).
+     *
+     * The default is FUTURE so a caller that says nothing keeps exactly the
+     * behaviour the futures runners have today -- the same convention as
+     * UnrealizedPolicy above. The equity runner sets EQUITY once at startup.
+     *
+     * Latent rather than live for the configured book: all ten equities are
+     * registered, so the registry answers and the fallback is never reached.
+     * It arms at universe scale, where any name not in the registry gets a
+     * guess instead of an answer.
+     */
+    void set_asset_type(AssetType asset_type) {
+        asset_type_ = asset_type;
+    }
+
+    AssetType asset_type() const {
+        return asset_type_;
+    }
+
 private:
+    AssetType asset_type_ = AssetType::FUTURE;
+
     /**
      * Get fallback multiplier for known symbols
      * These are calculated as: minimum_price_fluctuation / tick_size

--- a/include/trade_ngin/live/trading_days_anchor.hpp
+++ b/include/trade_ngin/live/trading_days_anchor.hpp
@@ -1,0 +1,104 @@
+// include/trade_ngin/live/trading_days_anchor.hpp
+#pragma once
+
+#include <string>
+
+#include "trade_ngin/live/data_freshness.hpp"
+
+namespace trade_ngin {
+
+/**
+ * @brief Is the annualization anchor consistent with the book it annualizes?
+ *
+ * E2-F32. `trading.get_trading_days(strategy, target, portfolio)` takes its
+ * start date from `trading.strategy_trading_days_metadata.live_start_date` and
+ * falls back to `MIN(date)` over that portfolio's `live_results` only when no
+ * row exists. A row that is LATER than the book's own first day is therefore
+ * strictly worse than no row at all, and nothing anywhere notices:
+ *
+ *   EQUITY_MR_PORTFOLIO carries live_start_date 2026-07-24 (seeded by hand for a
+ *   10-day window) while the replayed book starts 2026-04-01. Every date before
+ *   07-24 gets `GREATEST(1, target - start + 1)` = 1 trading day, so
+ *   total_annualized_return collapses onto total_cumulative_return for 115 rows;
+ *   at 07-27 the count is 4 and a -3.5 % cumulative return annualizes to
+ *   -1674 %. The run exits 0 and the number is stored.
+ *
+ * The check is one comparison the DB function cannot make, because the function
+ * stops looking the moment it finds a metadata row. `effective_anchor` is the
+ * anchor that should have been used: the earlier of the two, which is the metadata
+ * row when it is sound and the book's own first day when it is not.
+ *
+ * This is NOT equity-specific. Futures carries the same shape -- as of 2026-09-03
+ * LIVE_TREND_FOLLOWING_TREND_FOLLOWING_FAST / BASE_PORTFOLIO is anchored at
+ * 2025-11-11 against live_results from 2025-01-29 -- so the check belongs beside
+ * the function, not inside one runner. Wiring the futures runners is a separate
+ * change with its own regression, deliberately not made here.
+ */
+struct TradingDaysAnchor {
+    /// True when strategy_trading_days_metadata has a row for this (strategy, portfolio).
+    bool has_metadata{false};
+    /// live_start_date from that row, YYYY-MM-DD. Empty when there is no row.
+    std::string metadata_anchor;
+    /// MIN(date) over this portfolio's live_results, YYYY-MM-DD. Empty when the book is new.
+    std::string earliest_result;
+    /// The anchor annualization should use.
+    std::string effective_anchor;
+    /// True when the metadata row is LATER than the book's own first day -- the defect.
+    bool anchor_is_late{false};
+};
+
+/**
+ * @param metadata_anchor live_start_date, or "" when no metadata row exists.
+ * @param earliest_result MIN(date) over live_results for this (strategy, portfolio),
+ *        or "" when the book has no rows yet (a genuine first run).
+ *
+ * Both are ISO YYYY-MM-DD and compare lexicographically.
+ *
+ * A metadata row EARLIER than the first result is not flagged: that is the
+ * normal shape for a book seeded before its first run, and it annualizes
+ * conservatively (more days, smaller figure) rather than explosively.
+ */
+inline TradingDaysAnchor assess_trading_days_anchor(const std::string& metadata_anchor,
+                                                    const std::string& earliest_result) {
+    TradingDaysAnchor a;
+    a.has_metadata = !metadata_anchor.empty();
+    a.metadata_anchor = metadata_anchor;
+    a.earliest_result = earliest_result;
+
+    if (!a.has_metadata) {
+        // No row: the DB function already falls back to MIN(date), which is right.
+        a.effective_anchor = earliest_result;
+        return a;
+    }
+    if (earliest_result.empty()) {
+        // Nothing to contradict the row with. A first run has no history, and a
+        // seeded anchor is exactly what it is for.
+        a.effective_anchor = metadata_anchor;
+        return a;
+    }
+
+    a.anchor_is_late = metadata_anchor > earliest_result;
+    a.effective_anchor = a.anchor_is_late ? earliest_result : metadata_anchor;
+    return a;
+}
+
+/**
+ * @brief Trading days from an anchor to a target date, matching the SQL exactly.
+ *
+ * `trading.get_trading_days` computes `GREATEST(1, (target - start) + 1)` in
+ * whole days. This reproduces it so an override computed here is the same
+ * quantity the function would have returned from the same anchor -- not a
+ * differently-defined number that happens to be near it.
+ *
+ * Returns 1 for an empty or malformed anchor, which is the function's own
+ * "I do not know" answer.
+ */
+inline int trading_days_from_anchor(const std::string& anchor_ymd,
+                                    const std::string& target_ymd) {
+    if (anchor_ymd.empty() || target_ymd.empty()) return 1;
+    const long days = calendar_days_between_utc(anchor_ymd, target_ymd);
+    const long count = days + 1;
+    return count < 1 ? 1 : static_cast<int>(count);
+}
+
+}  // namespace trade_ngin

--- a/include/trade_ngin/storage/backtest_results_manager.hpp
+++ b/include/trade_ngin/storage/backtest_results_manager.hpp
@@ -99,7 +99,6 @@ public:
     Result<void> save_final_positions(const std::string& run_id);
     Result<void> save_executions_batch(const std::string& run_id);
     Result<void> save_signals_batch(const std::string& run_id);
-    Result<void> save_metadata(const std::string& run_id);
 
     // Multi-strategy storage methods
     Result<void> save_strategy_positions(const std::string& portfolio_run_id);

--- a/include/trade_ngin/transaction_cost/transaction_cost_manager.hpp
+++ b/include/trade_ngin/transaction_cost/transaction_cost_manager.hpp
@@ -77,7 +77,10 @@ public:
      * @brief Calculate all transaction costs for an execution
      *
      * @param symbol Instrument symbol
-     * @param quantity Trade quantity (signed; absolute value used)
+     * @param quantity Trade quantity. MUST be signed: negative is a sell. Every cost term
+     *        takes |quantity| EXCEPT the SEC/TAF regulatory fees, which are sell-side only
+     *        and are gated on `quantity < 0`. Passing an absolute value silently drops them
+     *        (E2-F29).
      * @param reference_price Fill price (previous day close)
      * @return Detailed cost breakdown
      *
@@ -96,7 +99,8 @@ public:
      * Use this overload when you want to provide ADV/volatility externally.
      *
      * @param symbol Instrument symbol
-     * @param quantity Trade quantity (signed; absolute value used)
+     * @param quantity Trade quantity. MUST be signed: negative is a sell. See the overload
+     *        above -- the sign is load-bearing for the SEC/TAF regulatory fees (E2-F29).
      * @param reference_price Fill price
      * @param adv Average daily volume
      * @param volatility_multiplier Volatility regime multiplier (0.8-1.5)

--- a/migrations/005_corp_action_applied_run_date.sql
+++ b/migrations/005_corp_action_applied_run_date.sql
@@ -1,0 +1,111 @@
+-- 005_corp_action_applied_run_date.sql
+--
+-- Add a nullable `run_date` to trading.corp_action_applied so a run can tell whether the
+-- dedup rows it is about to trust were written by an EARLIER pass or a LATER one
+-- (E2-F23, audit option C-prime).
+--
+-- WHY THIS COLUMN EXISTS
+--
+-- A live equity run is path-dependent. It loads the T-1 book, applies the corporate actions
+-- the dedup table says are not yet applied, and finalizes T-1 from the resulting frame. That
+-- is correct exactly when the dedup rows and the T-1 position row come from the SAME pass.
+--
+-- Reset the book but not the dedup table and it is not. Measured: re-seed the equity book at
+-- 2026-04-02 and re-run 2026-04-07 while the dedup row (BKNG, SPLIT, 2026-04-06) survives
+-- from the previous chain. The 25:1 split is skipped as "already applied" against a T-1 row
+-- that is still PRE-split, the position is marked at the post-split close, and the run stores
+-- an unrealized P&L of -4,824 on 1.2 shares. Nothing catches it: the G3 basis/mark guard only
+-- inspects events that were APPLIED, and a deduped event never enters that list.
+--
+-- The existing detector -- refuse when a dedup row has ex_date >= the run date -- catches the
+-- same-day case only. BKNG's ex-date is 2026-04-06 and the run is 2026-04-07, so it passes
+-- the ex_date test while being exactly the failure. `applied_at` cannot substitute: an
+-- earlier chain always has an earlier wall-clock, and so does legitimate history. The run
+-- date of the pass that wrote the row is the only value that separates them.
+--
+-- WHAT USES IT
+--
+-- Detection only. `store_applied_corp_actions_in` stamps the runner's own `now` date on every
+-- row it writes; `load_applied_corp_actions` returns it; and CorporateActionsAuditLog::load()
+-- REFUSES the run (the runner exits 1, naming the offending rows) when any row for this
+-- portfolio/strategy/name carries a run_date on or after today.
+--
+-- It deliberately does NOT self-heal. Deleting such rows automatically -- audit option C --
+-- is only correct when the book was also reset, which the runner cannot verify, and it turns
+-- today's accidentally-correct plain re-run of a deferred-apply day into a silent
+-- double-apply for any event under 5x. The remedy is the protocol that was always required:
+-- reset trading.corp_action_applied together with positions/live_results/equity_curve/
+-- executions from the replay start date, then replay in order.
+--
+-- Legacy rows written before this migration have run_date NULL and are accepted. That is the
+-- only safe reading -- NULL means "unknown", and refusing every pre-existing row would make
+-- the next run unstartable.
+--
+-- FUTURES REACHABILITY, AND WHAT A REBUILD COSTS
+--
+-- trading.corp_action_applied is written and read by exactly two files:
+-- src/live/corporate_actions_audit_log.cpp and apps/strategies/live_equity_mean_reversion.cpp.
+-- live_portfolio.cpp and live_portfolio_conservative.cpp contain no reference to
+-- corp_action, CorporateAction, or dividend. So no futures runner touches this table and no
+-- futures number can move because of this migration.
+--
+-- The rebuild risk is the mirror of 004's. `trade_ngin` is a SHARED library, so the futures
+-- binaries relink against the new code even though their call graph never reaches it -- their
+-- sha256 changes and a checksum-only gate would report a difference that is not a behaviour
+-- difference. Argue preservation from the call graph, not from the hash.
+--
+-- The equity-side rebuild risk is the one to respect: on a database rebuilt or restored
+-- WITHOUT this migration, every INSERT into trading.corp_action_applied names a column that
+-- does not exist. That is not silent -- store_applied_corp_actions_in returns an error and
+-- the transaction that carries the adjusted positions rolls back with it, so the run fails
+-- loudly rather than storing positions with no dedup record. Apply 005 before running the
+-- equity book against a fresh database.
+--
+-- SAFETY
+--   * Additive and idempotent: ADD COLUMN IF NOT EXISTS, nullable, no default, no rewrite of
+--     existing rows and no table rewrite on PostgreSQL 11+.
+--   * Touches no other table, no index, no constraint. The primary key is unchanged --
+--     run_date is NOT part of the natural key (audit option D1 showed keying on it is unsafe:
+--     the old row is ignored, ON CONFLICT DO NOTHING keeps the later run_date, and the event
+--     re-applies every day).
+--   * Transactional.
+
+BEGIN;
+
+DO $$
+BEGIN
+    IF NOT EXISTS (
+        SELECT 1 FROM information_schema.tables
+        WHERE table_schema = 'trading' AND table_name = 'corp_action_applied'
+    ) THEN
+        RAISE EXCEPTION 'migration 002 has not been applied: trading.corp_action_applied does not exist';
+    END IF;
+END $$;
+
+ALTER TABLE trading.corp_action_applied
+    ADD COLUMN IF NOT EXISTS run_date DATE;
+
+COMMENT ON COLUMN trading.corp_action_applied.run_date IS
+    'Run date of the pass that wrote this row (the runner''s own as-of date, not a '
+    'wall clock). NULL on rows written before migration 005 and accepted as unknown. '
+    'A row whose run_date is on or after the current run date was written by a LATER '
+    'pass over this book: the run refuses to start, because trusting it would skip an '
+    'event whose effect is not in the T-1 position row (E2-F23 / E2-F16). Detection '
+    'only -- nothing deletes these rows; reset the dedup table and the book together.';
+
+COMMIT;
+
+-- ---------------------------------------------------------------------------
+-- VERIFICATION -- run after applying.
+--
+--   SELECT column_name, data_type, is_nullable
+--     FROM information_schema.columns
+--    WHERE table_schema = 'trading' AND table_name = 'corp_action_applied'
+--      AND column_name = 'run_date';
+--   -- expect: run_date | date | YES
+--
+--   SELECT count(*) AS total, count(run_date) AS stamped
+--     FROM trading.corp_action_applied;
+--   -- expect stamped = 0 immediately after applying; every row written from now on
+--   -- carries a date.
+-- ---------------------------------------------------------------------------

--- a/migrations/005_corp_action_applied_run_date_rollback.sql
+++ b/migrations/005_corp_action_applied_run_date_rollback.sql
@@ -1,0 +1,49 @@
+-- 005_corp_action_applied_run_date_rollback.sql
+--
+-- Rollback for 005. Drops trading.corp_action_applied.run_date.
+--
+-- READ THIS BEFORE RUNNING IT.
+--
+-- Unlike 004's rollback, this one is safe to run under live code but NOT safe to run and
+-- forget. Order matters and is the reverse of the forward migration:
+--
+--   1. Revert the CODE first. With 005's code in place and the column gone, every INSERT
+--      into trading.corp_action_applied names a column that does not exist, and because the
+--      dedup write shares a transaction with the adjusted positions, the whole unit rolls
+--      back -- the equity run fails rather than half-applying. Loud, but a hard stop.
+--   2. Rebuild and confirm nothing references the column:
+--        grep -rn "run_date" src/ apps/ include/ | grep corp_action     -> expect 0
+--   3. Only then run this file.
+--
+-- What is lost: the ability to tell an earlier pass's dedup rows from a later pass's. The
+-- ex_date >= today detector remains and still catches the same-day case, but the measured
+-- E2-F23 failure (BKNG, ex-date 2026-04-06, re-run of 2026-04-07 over an un-reset dedup
+-- table, -4,824 of phantom unrealized P&L) passes that detector and would go back to being
+-- undetectable. The replay protocol -- reset trading.corp_action_applied together with the
+-- book -- becomes the only defence again, and forgetting it is silent.
+--
+-- Dropping the column destroys no dedup record: run_date is detection metadata, never part
+-- of the natural key, so idempotency is unaffected by its absence.
+
+BEGIN;
+
+DO $$
+BEGIN
+    IF NOT EXISTS (
+        SELECT 1 FROM information_schema.columns
+        WHERE table_schema = 'trading' AND table_name = 'corp_action_applied'
+          AND column_name = 'run_date'
+    ) THEN
+        RAISE EXCEPTION 'migration 005 was never applied: trading.corp_action_applied.run_date does not exist';
+    END IF;
+END $$;
+
+ALTER TABLE trading.corp_action_applied DROP COLUMN run_date;
+
+COMMIT;
+
+-- Verify the column is gone and the dedup rows survive:
+--   SELECT count(*) FROM information_schema.columns
+--    WHERE table_schema='trading' AND table_name='corp_action_applied'
+--      AND column_name='run_date';                       -- expect 0
+--   SELECT count(*) FROM trading.corp_action_applied;    -- expect the pre-rollback count

--- a/src/backtest/backtest_coordinator.cpp
+++ b/src/backtest/backtest_coordinator.cpp
@@ -1115,13 +1115,6 @@ Result<void> BacktestCoordinator::save_daily_positions(std::shared_ptr<Portfolio
             Position pos_with_date = pos;
             pos_with_date.last_update = timestamp;
             positions_vec.push_back(pos_with_date);
-
-            // STICKY_DEBUG: Trace average_price at DB save point
-            if (symbol == "MBT.v.0" || symbol == "NQ.v.0") {
-                INFO("STICKY_DEBUG_SAVE: strategy=" + strategy_id + " symbol=" + symbol +
-                     " avg_price=" + std::to_string(static_cast<double>(pos.average_price)) +
-                     " qty=" + std::to_string(static_cast<double>(pos.quantity)));
-            }
         }
 
         if (!positions_vec.empty()) {

--- a/src/backtest/backtest_coordinator.cpp
+++ b/src/backtest/backtest_coordinator.cpp
@@ -641,7 +641,13 @@ Result<void> BacktestCoordinator::process_portfolio_day(
 
                 // TransactionCostManager is the single source of truth.
                 double ref_price = static_cast<double>(exec.fill_price);
+                // E2-F29: sign the quantity from the report's side. filled_quantity is always
+                // positive, so passing it raw made the sell-side-only SEC/TAF gate
+                // (`quantity < 0`) unreachable; every other cost term takes |qty|.
                 double qty = static_cast<double>(exec.filled_quantity);
+                if (exec.side == Side::SELL) {
+                    qty = -qty;
+                }
 
                 auto cost_result =
                     execution_manager_->get_transaction_cost_manager().calculate_costs(

--- a/src/backtest/backtest_execution_manager.cpp
+++ b/src/backtest/backtest_execution_manager.cpp
@@ -82,8 +82,10 @@ ExecutionReport BacktestExecutionManager::generate_execution(
     // Fill price stays as pure reference price (no embedded slippage).
     exec.fill_price = Price(execution_price);
 
+    // E2-F29: pass the SIGNED quantity so the sell-side-only SEC/TAF gate
+    // (`quantity < 0`) is reachable; every other cost term takes |qty|.
     auto cost_result = transaction_cost_manager_.calculate_costs(
-        symbol, abs_quantity, execution_price);
+        symbol, quantity_change, execution_price);
 
     exec.commissions_fees = Decimal(cost_result.commissions_fees);
     exec.implicit_price_impact = Decimal(cost_result.implicit_price_impact);

--- a/src/core/email_sender.cpp
+++ b/src/core/email_sender.cpp
@@ -1082,17 +1082,53 @@ std::string EmailSender::format_positions_table(
                 // long / 150% short) and futures get total dollars (now
                 // multiplied internally by FuturesInstrument's new override).
                 const double signed_qty = position.quantity.as_double();
-                const double price_for_margin = position.average_price.as_double();
-                double total_initial_margin =
-                    instrument->get_margin_requirement(price_for_margin, signed_qty);
-                if (total_initial_margin <= 0) {
-                    ERROR("CRITICAL: Invalid margin requirement " +
-                          std::to_string(total_initial_margin) + " for " + lookup_sym +
-                          " (price=" + std::to_string(price_for_margin) +
-                          ", qty=" + std::to_string(signed_qty) + ")");
-                    throw std::runtime_error("Invalid margin requirement for: " + lookup_sym);
+
+                // D9 / BA-16: margin is priced from a MARK, not a cost basis.
+                //
+                // This read average_price only. On the equity path that column is a
+                // cost basis, and 0 is its documented "no basis known" value
+                // (AVERAGE_PRICE_LIFECYCLE rule 5) -- reachable for a held position
+                // whose basis could not be resolved, which the runner already reports
+                // as an ERROR. get_margin_requirement(0, qty) then returns 0, this
+                // threw, and the bare `throw;` below aborted the WHOLE daily email:
+                // one unpriceable row and nobody gets a report at all.
+                //
+                // Margin asks what the position is worth now, so the current close is
+                // the right input and average_price is the fallback -- the same
+                // preference the notional/market-price block below already applies.
+                double price_for_margin = 0.0;
+                auto margin_price_it = current_prices.find(symbol);
+                if (margin_price_it != current_prices.end() && margin_price_it->second > 0.0) {
+                    price_for_margin = margin_price_it->second;
+                } else if (position.average_price.as_double() > 0.0) {
+                    price_for_margin = position.average_price.as_double();
                 }
-                total_margin_posted += total_initial_margin;
+
+                if (price_for_margin <= 0.0) {
+                    // Neither a close nor a basis. Report it and leave this row out of
+                    // the margin total; the email still goes out, and the row still
+                    // appears with the figures that ARE known.
+                    WARN("Daily email: no usable price for " + lookup_sym +
+                         " (quantity " + std::to_string(signed_qty) +
+                         ", no current close and average_price is 0) -- excluded from the "
+                         "margin total. The email is still sent; margin posted is "
+                         "understated by this position.");
+                } else {
+                    double total_initial_margin =
+                        instrument->get_margin_requirement(price_for_margin, signed_qty);
+                    if (total_initial_margin <= 0) {
+                        // A positive price that still yields no margin is an instrument
+                        // configuration problem, not a missing-data problem. Report it
+                        // and carry on rather than suppressing the whole report.
+                        WARN("Daily email: instrument " + lookup_sym +
+                             " returned margin " + std::to_string(total_initial_margin) +
+                             " for price=" + std::to_string(price_for_margin) +
+                             ", qty=" + std::to_string(signed_qty) +
+                             " -- excluded from the margin total.");
+                    } else {
+                        total_margin_posted += total_initial_margin;
+                    }
+                }
 
             } catch (const std::exception& e) {
                 ERROR("CRITICAL: Failed to get instrument data for " + position.symbol + ": " +

--- a/src/data/conversion_utils.cpp
+++ b/src/data/conversion_utils.cpp
@@ -1,7 +1,9 @@
 // src/data/conversion_utils.cpp
 #include "trade_ngin/data/conversion_utils.hpp"
 
+#include <cctype>
 #include <cstdint>
+#include <ctime>
 #include <stdexcept>
 #include <string>
 
@@ -12,6 +14,58 @@
 namespace trade_ngin {
 
 namespace {
+
+// Parse "YYYY-MM-DD" or "YYYY-MM-DD HH:MM:SS" (also accepting the 'T'
+// separator) as MICROSECONDS since the Unix epoch. UTC by construction --
+// timegm, never mktime, because a stored timestamptz is already a UTC instant
+// and mktime would re-interpret it in the host zone (E2-F22).
+//
+// Returns false on anything else, so a caller can distinguish "not a datetime"
+// from a datetime at the epoch.
+bool parse_ymd_hms_to_micros(const std::string& text, int64_t& out_micros) {
+    if (text.size() < 10) return false;
+    if (text[4] != '-' || text[7] != '-') return false;
+
+    auto digits = [&](std::size_t at, std::size_t n, int& out) -> bool {
+        if (at + n > text.size()) return false;
+        int v = 0;
+        for (std::size_t i = 0; i < n; ++i) {
+            const char c = text[at + i];
+            if (c < '0' || c > '9') return false;
+            v = v * 10 + (c - '0');
+        }
+        out = v;
+        return true;
+    };
+
+    int year = 0, month = 0, day = 0, hour = 0, minute = 0, second = 0;
+    if (!digits(0, 4, year) || !digits(5, 2, month) || !digits(8, 2, day)) return false;
+    if (month < 1 || month > 12 || day < 1 || day > 31) return false;
+
+    if (text.size() >= 19) {
+        const char sep = text[10];
+        if (sep != ' ' && sep != 'T') return false;
+        if (text[13] != ':' || text[16] != ':') return false;
+        if (!digits(11, 2, hour) || !digits(14, 2, minute) || !digits(17, 2, second)) {
+            return false;
+        }
+        if (hour > 23 || minute > 59 || second > 60) return false;
+    } else if (text.size() != 10) {
+        return false;  // a partial time is not a datetime
+    }
+
+    std::tm tm{};
+    tm.tm_year = year - 1900;
+    tm.tm_mon = month - 1;
+    tm.tm_mday = day;
+    tm.tm_hour = hour;
+    tm.tm_min = minute;
+    tm.tm_sec = second;
+    const std::time_t seconds = timegm(&tm);
+    if (seconds == static_cast<std::time_t>(-1)) return false;
+    out_micros = static_cast<int64_t>(seconds) * 1000000;
+    return true;
+}
 
 // Resolve a logical row index into a ChunkedArray to (chunk pointer,
 // offset within that chunk). Returns nullptr on out-of-range so the
@@ -317,6 +371,20 @@ Result<int64_t> DataConversionUtils::safe_get_int64(
                      column_name + " at row " + std::to_string(row));
                 return Result<int64_t>(static_cast<int64_t>(d));
             }
+            // E2-F37 / BA-14: temporal columns. The canonical schema stores dates as
+            // TimestampArray; without these cases such a column fell through to
+            // `default` and errored. The value is returned in the column's OWN unit
+            // (the canonical schema is microseconds, which is what
+            // LiveDataLoader::load_previous_day_data reads) -- see the header.
+            case arrow::Type::TIMESTAMP:
+                return Result<int64_t>(
+                    static_cast<const arrow::TimestampArray*>(chunk)->Value(off));
+            case arrow::Type::DATE32:  // days since epoch
+                return Result<int64_t>(static_cast<int64_t>(
+                    static_cast<const arrow::Date32Array*>(chunk)->Value(off)));
+            case arrow::Type::DATE64:  // milliseconds since epoch
+                return Result<int64_t>(
+                    static_cast<const arrow::Date64Array*>(chunk)->Value(off));
             case arrow::Type::STRING:
             case arrow::Type::LARGE_STRING: {
                 std::string s;
@@ -325,15 +393,38 @@ Result<int64_t> DataConversionUtils::safe_get_int64(
                 } else {
                     s = static_cast<const arrow::LargeStringArray*>(chunk)->GetString(off);
                 }
+                // A FULLY integral string is an integer. `std::stoll` stops at the
+                // first non-digit, so "2026-09-02 00:00:00" used to come back as
+                // 2026 -- a silent, plausible integer that is not a timestamp in any
+                // unit. Require the whole string to be consumed before believing it.
                 try {
-                    return Result<int64_t>(static_cast<int64_t>(std::stoll(s)));
-                } catch (const std::exception& e) {
-                    WARN("safe_get_int64: bad value '" + s + "' in column " + column_name +
-                         " at row " + std::to_string(row) + " (" + e.what() + ")");
-                    return make_error<int64_t>(ErrorCode::CONVERSION_ERROR,
-                                               "safe_get_int64 parse failure",
-                                               "DataConversionUtils");
+                    std::size_t consumed = 0;
+                    const long long v = std::stoll(s, &consumed);
+                    while (consumed < s.size() &&
+                           std::isspace(static_cast<unsigned char>(s[consumed]))) {
+                        ++consumed;
+                    }
+                    if (consumed == s.size()) {
+                        return Result<int64_t>(static_cast<int64_t>(v));
+                    }
+                } catch (const std::exception&) {
+                    // fall through to the datetime attempt
                 }
+
+                // Not an integer. The one shape a temporal column legitimately takes
+                // as text: YYYY-MM-DD, optionally with a time. Returned as
+                // MICROSECONDS since the epoch, the canonical timestamp unit.
+                int64_t micros = 0;
+                if (parse_ymd_hms_to_micros(s, micros)) {
+                    return Result<int64_t>(micros);
+                }
+
+                WARN("safe_get_int64: bad value '" + s + "' in column " + column_name +
+                     " at row " + std::to_string(row) +
+                     " (neither an integer nor YYYY-MM-DD[ HH:MM:SS])");
+                return make_error<int64_t>(ErrorCode::CONVERSION_ERROR,
+                                           "safe_get_int64 parse failure",
+                                           "DataConversionUtils");
             }
             default: {
                 const std::string actual = chunk->type()->ToString();

--- a/src/data/postgres_database.cpp
+++ b/src/data/postgres_database.cpp
@@ -2511,6 +2511,39 @@ PostgresDatabase::get_corporate_actions(
     }
 }
 
+Result<std::string> PostgresDatabase::get_corp_action_feed_last_date(
+    const std::string& as_of_date) {
+
+    auto validation = validate_connection();
+    if (validation.is_error()) {
+        return make_error<std::string>(validation.error()->code(), validation.error()->what());
+    }
+
+    try {
+        pqxx::work txn(*connection_);
+        // Text comparison for the same reason get_corporate_actions uses one:
+        // the column is TEXT holding ISO-8601, so max() and the bound are both
+        // lexicographic and index-friendly, and no row can throw on a cast.
+        pqxx::result r =
+            as_of_date.empty()
+                ? txn.exec("SELECT COALESCE(max(date), '') FROM equities_data.corporate_action")
+                : txn.exec_params(
+                      "SELECT COALESCE(max(date), '') FROM equities_data.corporate_action "
+                      "WHERE date <= $1",
+                      as_of_date);
+        std::string last;
+        if (!r.empty() && !r[0][0].is_null()) last = r[0][0].c_str();
+        txn.commit();
+        return Result<std::string>(std::move(last));
+
+    } catch (const std::exception& e) {
+        return make_error<std::string>(
+            ErrorCode::DATABASE_ERROR,
+            "Failed to read the corporate-action feed's last row date: " + std::string(e.what()),
+            "PostgresDatabase");
+    }
+}
+
 Result<std::vector<PostgresDatabase::CorpActionRow>>
 PostgresDatabase::get_per_bar_corporate_actions(
     const std::vector<std::string>& tickers,

--- a/src/data/postgres_database.cpp
+++ b/src/data/postgres_database.cpp
@@ -2048,43 +2048,6 @@ Result<void> PostgresDatabase::store_backtest_signals(
     }
 }
 
-Result<void> PostgresDatabase::store_backtest_metadata(
-    const std::string& run_id, const std::string& name, const std::string& description,
-    const Timestamp& start_date, const Timestamp& end_date, const nlohmann::json& hyperparameters,
-    const std::string& portfolio_id, const std::string& table_name) {
-    auto validation = validate_connection();
-    if (validation.is_error())
-        return validation;
-
-    try {
-        pqxx::work txn(*connection_);
-
-        std::string actual_portfolio_id = portfolio_id.empty() ? "BASE_PORTFOLIO" : portfolio_id;
-
-        std::string query =
-            "INSERT INTO " + table_name +
-            " (run_id, portfolio_id, name, description, start_date, end_date, hyperparameters) "
-            "VALUES ($1, $2, $3, $4, $5, $6, $7) "
-            "ON CONFLICT (run_id) "
-            "DO UPDATE SET portfolio_id = EXCLUDED.portfolio_id, name = EXCLUDED.name, description "
-            "= EXCLUDED.description, "
-            "start_date = EXCLUDED.start_date, end_date = EXCLUDED.end_date, "
-            "hyperparameters = EXCLUDED.hyperparameters";
-
-        txn.exec(query, pqxx::params{run_id, actual_portfolio_id, name, description,
-                        format_timestamp(start_date), format_timestamp(end_date),
-                        hyperparameters.dump()});
-
-        txn.commit();
-        INFO("Successfully stored backtest metadata for run: " + run_id);
-        return Result<void>();
-    } catch (const std::exception& e) {
-        return make_error<void>(ErrorCode::DATABASE_ERROR,
-                                "Failed to store backtest metadata: " + std::string(e.what()),
-                                "PostgresDatabase");
-    }
-}
-
 Result<void> PostgresDatabase::store_backtest_metadata_with_portfolio(
     const std::string& run_id, const std::string& portfolio_run_id, const std::string& strategy_id,
     double strategy_allocation, const nlohmann::json& portfolio_config, const std::string& name,

--- a/src/data/postgres_database.cpp
+++ b/src/data/postgres_database.cpp
@@ -2795,6 +2795,67 @@ PostgresDatabase::get_position_inception_dates(const std::string& strategy_id,
 }
 
 Result<std::unordered_map<std::string, std::string>>
+PostgresDatabase::get_current_holding_start_dates(const std::string& strategy_id,
+                                                  const std::string& strategy_name,
+                                                  const std::string& portfolio_id,
+                                                  const std::vector<std::string>& symbols,
+                                                  const std::string& table_name) {
+    using Map = std::unordered_map<std::string, std::string>;
+
+    auto validation = validate_connection();
+    if (validation.is_error()) {
+        return make_error<Map>(validation.error()->code(), validation.error()->what());
+    }
+    if (symbols.empty()) return Result<Map>(Map{});
+
+    // table_name is an internal default (trading.positions), never user input --
+    // same contract as load_positions_by_date, which interpolates it likewise.
+
+    try {
+        pqxx::work txn(*connection_);
+
+        // The start of the holding we hold NOW: the earliest non-zero row that is
+        // NEWER than the most recent flat row for the same key. A close writes exactly
+        // one quantity-0 row on its own date (E2-F19), so that row is the break between
+        // a previous holding and this one. No flat row => never closed => this equals
+        // min(date), the lifetime inception.
+        //
+        // Deliberately NOT the same question as get_position_inception_dates. That one
+        // fails wide for the class-1 price window; this one is the class-2 rename era
+        // and must fail narrow (BA-2).
+        auto result = txn.exec(
+            "SELECT symbol, min(date)::text AS holding_start "
+            "FROM " + table_name + " p "
+                " WHERE strategy_id = $1 AND strategy_name = $2 AND portfolio_id = $3 "
+                "  AND symbol = ANY($4) AND quantity <> 0 "
+                "  AND date > COALESCE(("
+                "        SELECT max(z.date) FROM " + table_name + " z "
+                "         WHERE z.strategy_id = p.strategy_id "
+                "           AND z.strategy_name = p.strategy_name "
+                "           AND z.portfolio_id = p.portfolio_id "
+                "           AND z.symbol = p.symbol AND z.quantity = 0), "
+                "      DATE '1900-01-01') "
+                "GROUP BY symbol",
+            pqxx::params{strategy_id, strategy_name, portfolio_id, symbols});
+
+        Map out;
+        for (const auto& row : result) {
+            if (row["holding_start"].is_null()) continue;
+            out.emplace(row["symbol"].c_str(), row["holding_start"].c_str());
+        }
+
+        txn.commit();
+        return Result<Map>(std::move(out));
+
+    } catch (const std::exception& e) {
+        return make_error<Map>(
+            ErrorCode::DATABASE_ERROR,
+            "Failed to fetch current holding start dates: " + std::string(e.what()),
+            "PostgresDatabase");
+    }
+}
+
+Result<std::unordered_map<std::string, std::string>>
 PostgresDatabase::get_last_buy_dates(const std::string& strategy_id,
                                      const std::string& strategy_name,
                                      const std::string& portfolio_id,

--- a/src/data/postgres_database.cpp
+++ b/src/data/postgres_database.cpp
@@ -2912,7 +2912,11 @@ PostgresDatabase::load_applied_corp_actions(const std::string& portfolio_id,
             "SELECT symbol, action_type, ex_date::text AS ex_date, "
             "COALESCE(qty_held, 0) AS qty_held, "
             "COALESCE(dividend_per_share, 0) AS dividend_per_share, "
-            "COALESCE(total_cash, 0) AS total_cash "
+            "COALESCE(total_cash, 0) AS total_cash, "
+            // E2-F23 / migration 005. Empty string for a legacy row, which the
+            // caller reads as "unknown" and accepts -- refusing every row written
+            // before the column existed would make the next run unstartable.
+            "COALESCE(run_date::text, '') AS run_date "
             "FROM trading.corp_action_applied "
             "WHERE portfolio_id = $1 AND strategy_id = $2 AND strategy_name = $3",
             portfolio_id, strategy_id, strategy_name);
@@ -2927,6 +2931,7 @@ PostgresDatabase::load_applied_corp_actions(const std::string& portfolio_id,
             r.qty_held = row["qty_held"].as<double>();
             r.dividend_per_share = row["dividend_per_share"].as<double>();
             r.total_cash = row["total_cash"].as<double>();
+            r.run_date = row["run_date"].c_str();
             out.push_back(std::move(r));
         }
 
@@ -2995,15 +3000,21 @@ Result<void> PostgresDatabase::store_applied_corp_actions_in(
         // authoritative one. A repeated run must not rewrite qty_held with a
         // post-adjustment quantity.
         for (const auto& r : rows) {
+            // run_date is the writing pass's OWN as-of date (E2-F23, migration
+            // 005), not now(): a replay of 2026-04-07 executed tonight must stamp
+            // 2026-04-07, or a later chain's rows would look like an earlier
+            // chain's and the detector would never fire. Empty stores NULL rather
+            // than an epoch date, so an unstamped row stays honestly unknown.
             txn.exec_params(
                 "INSERT INTO trading.corp_action_applied "
                 "(portfolio_id, strategy_id, strategy_name, symbol, action_type, "
-                " ex_date, qty_held, dividend_per_share, total_cash) "
-                "VALUES ($1, $2, $3, $4, $5, $6::date, $7, $8, $9) "
+                " ex_date, qty_held, dividend_per_share, total_cash, run_date) "
+                "VALUES ($1, $2, $3, $4, $5, $6::date, $7, $8, $9, "
+                "        NULLIF($10, '')::date) "
                 "ON CONFLICT (portfolio_id, strategy_id, strategy_name, symbol, "
                 "             action_type, ex_date) DO NOTHING",
                 portfolio_id, strategy_id, strategy_name, r.symbol, r.action_type,
-                r.ex_date, r.qty_held, r.dividend_per_share, r.total_cash);
+                r.ex_date, r.qty_held, r.dividend_per_share, r.total_cash, r.run_date);
         }
         return Result<void>();
 

--- a/src/data/postgres_database.cpp
+++ b/src/data/postgres_database.cpp
@@ -2637,7 +2637,8 @@ PostgresDatabase::get_ticker_aliases() {
 }
 
 Result<std::unordered_map<std::string, std::string>>
-PostgresDatabase::get_delisting_dates(const std::vector<std::string>& tickers) {
+PostgresDatabase::get_delisting_dates(const std::vector<std::string>& tickers,
+                                     const std::string& from_date) {
     using Map = std::unordered_map<std::string, std::string>;
 
     auto validation = validate_connection();
@@ -2655,12 +2656,34 @@ PostgresDatabase::get_delisting_dates(const std::vector<std::string>& tickers) {
         // idx_ohlcv_1d_delisting (migration 003) covers the IS NOT NULL
         // predicate, which is what took this from 14.1 s to 1.9 s at 852
         // symbols.
-        auto result = txn.exec(
-            "SELECT symbol, max(delisting_date)::text AS delisting_date "
-            "FROM equities_data.ohlcv_1d "
-            "WHERE symbol = ANY($1) AND delisting_date IS NOT NULL "
-            "GROUP BY symbol",
-            pqxx::params{tickers});
+        // BA-8: bound the row by date. Without a floor this returns
+        // max(delisting_date) over the symbol's ENTIRE history, so a reused
+        // ticker inherits a dead company's delisting (HPC 2008-11-24, MER
+        // 2008-12-31) and a held position is exited at a stale price. The
+        // runner's bars-contradict guard cannot cover this on its own:
+        // delisting_is_stale() is false when last_bar_date is empty, which is
+        // exactly the symbol that stopped printing.
+        //
+        // Compared as text -- delisting_date is a date column and the bound is
+        // ISO, which orders lexicographically; cast the bound, not the column,
+        // so the partial index idx_ohlcv_1d_delisting still applies.
+        pqxx::result result;
+        if (from_date.empty()) {
+            result = txn.exec(
+                "SELECT symbol, max(delisting_date)::text AS delisting_date "
+                "FROM equities_data.ohlcv_1d "
+                "WHERE symbol = ANY($1) AND delisting_date IS NOT NULL "
+                "GROUP BY symbol",
+                pqxx::params{tickers});
+        } else {
+            result = txn.exec(
+                "SELECT symbol, max(delisting_date)::text AS delisting_date "
+                "FROM equities_data.ohlcv_1d "
+                "WHERE symbol = ANY($1) AND delisting_date IS NOT NULL "
+                "  AND delisting_date >= $2::date "
+                "GROUP BY symbol",
+                pqxx::params{tickers, from_date});
+        }
 
         Map out;
         for (const auto& row : result) {

--- a/src/data/postgres_database.cpp
+++ b/src/data/postgres_database.cpp
@@ -2455,15 +2455,24 @@ PostgresDatabase::get_corporate_actions(
 
         // Parameter arrays rather than concatenated IN-lists: at the full
         // 852-symbol universe the string form built a 5 kB literal per call.
-        // equities_data.corporate_action stores dates as text, so the column
-        // still needs a cast; the index on (ticker, date) carries the ticker
-        // side, which is what makes this bounded.
+        //
+        // G6-4: equities_data.corporate_action stores `date` as TEXT, and this
+        // compared it as `date::date BETWEEN $3::date AND $4::date`. The cast
+        // is evaluated per row and throws on the first value that is not a
+        // parseable date, taking the whole query -- and the run -- with it; it
+        // also makes the predicate non-sargable, so the (ticker, date) index
+        // covers only the ticker side. Every value in the column is a 10-char
+        // ISO-8601 date (verified: 0 of 627,169 rows fail
+        // '^[0-9]{4}-[0-9]{2}-[0-9]{2}$'), and ISO-8601 sorts lexicographically,
+        // so a plain text comparison selects exactly the same rows, index-native
+        // and with no cast to fail. The ISO precondition is pinned by
+        // tests/live/corp_actions/test_corp_action_query_bounds_db.cpp.
         const std::string query =
             "SELECT date, action, ticker, value, contraticker, contraname, name "
             "FROM equities_data.corporate_action "
             "WHERE ticker = ANY($1) "
             "  AND action = ANY($2) "
-            "  AND date::date BETWEEN $3::date AND $4::date "
+            "  AND date >= $3 AND date <= $4 "
             "ORDER BY date, ticker, action";
 
         auto result = txn.exec(query, pqxx::params{tickers, actions, start_date, end_date});

--- a/src/execution/execution_engine.cpp
+++ b/src/execution/execution_engine.cpp
@@ -997,7 +997,13 @@ double ExecutionEngine::calculate_transaction_costs(const ExecutionReport& execu
     tc_config.explicit_fee_per_contract = config.explicit_fee_per_contract;
     transaction_cost::TransactionCostManager cost_manager(tc_config);
 
+    // E2-F29: sign the quantity from the report's side. filled_quantity is always positive, so
+    // passing it raw made the sell-side-only SEC/TAF gate (`quantity < 0`) unreachable; every
+    // other cost term takes |qty|.
     double qty = static_cast<double>(execution.filled_quantity);
+    if (execution.side == Side::SELL) {
+        qty = -qty;
+    }
     double price = static_cast<double>(execution.fill_price);
 
     auto cost_result = cost_manager.calculate_costs(execution.symbol, qty, price);

--- a/src/live/corporate_actions_audit_log.cpp
+++ b/src/live/corporate_actions_audit_log.cpp
@@ -50,14 +50,16 @@ bool CorporateActionsAuditLog::migrate_state_file_to_db() {
         r.symbol = std::get<0>(key);
         r.ex_date = std::get<1>(key);
         r.action_type = CorporateActionsApplier::type_to_string(std::get<2>(key));
-        // Dividend detail attaches where the file carried it.
-        for (const auto& de : file_log.dividend_events_) {
-            if (de.symbol == r.symbol && de.ex_date == r.ex_date) {
-                r.qty_held = de.qty_held;
-                r.dividend_per_share = de.dividend_per_share;
-                r.total_cash = de.total_cash;
-                break;
-            }
+        // Dividend detail attaches where the file carried it -- and ONLY to a
+        // dividend. E2-F39 / BA-15: this used to match on (symbol, ex_date) alone,
+        // so a SPLIT sharing an ex-date with a DIVIDEND inherited the dividend's
+        // cash and cumulative dividend income counted it twice.
+        if (const auto* de = dividend_detail_for(r.symbol, r.ex_date,
+                                                 std::get<2>(key),
+                                                 file_log.dividend_events_)) {
+            r.qty_held = de->qty_held;
+            r.dividend_per_share = de->dividend_per_share;
+            r.total_cash = de->total_cash;
         }
         rows.push_back(std::move(r));
     }

--- a/src/live/corporate_actions_audit_log.cpp
+++ b/src/live/corporate_actions_audit_log.cpp
@@ -61,6 +61,10 @@ bool CorporateActionsAuditLog::migrate_state_file_to_db() {
             r.dividend_per_share = de->dividend_per_share;
             r.total_cash = de->total_cash;
         }
+        // Deliberately NOT stamped with this run's date: these events were applied
+        // by some earlier pass whose run date is unrecoverable from the file. NULL
+        // is the honest value, and it is accepted as "unknown" by the check below
+        // -- stamping today would make the very next run refuse to start.
         rows.push_back(std::move(r));
     }
 
@@ -112,6 +116,55 @@ Result<bool> CorporateActionsAuditLog::load() {
                 return make_error<bool>(ErrorCode::DATABASE_ERROR,
                                         "re-read after legacy import failed: " +
                                             std::string(existing.error()->what()),
+                                        "CorporateActionsAuditLog");
+            }
+        }
+
+        // E2-F23 (audit option C-prime). A row stamped with a run date on or after
+        // this run's was written by a LATER pass over this book. Honouring it skips
+        // an event whose effect is NOT in the T-1 position row this run just
+        // loaded, so T-1 is finalized in the wrong frame and the position is marked
+        // against a basis that never moved -- the E2-F16 phantom, measured at
+        // -4,824 on BKNG. No guard downstream can see it: skipped events never
+        // reach the basis/mark bound, which only inspects events that were applied.
+        //
+        // Detection only, deliberately. Deleting the rows automatically is correct
+        // ONLY when the book was also reset, which this process cannot verify, and
+        // it converts today's accidentally-correct plain re-run of a deferred-apply
+        // day into a silent double-apply for any event under 5x. The remedy is the
+        // protocol: reset trading.corp_action_applied together with positions,
+        // live_results, equity_curve and executions from the replay start date,
+        // then replay in order.
+        //
+        // Legacy rows carry no run_date and are accepted -- NULL means unknown, and
+        // refusing them would make the first run after migration 005 unstartable.
+        if (!run_date_.empty() && enforce_run_date_) {
+            std::vector<std::string> stale;
+            for (const auto& r : existing.value()) {
+                if (!r.run_date.empty() && r.run_date >= run_date_) {
+                    stale.push_back(r.symbol + " " + r.action_type + " ex " + r.ex_date +
+                                    " written by the run of " + r.run_date);
+                }
+            }
+            if (!stale.empty()) {
+                std::string detail;
+                for (size_t i = 0; i < stale.size() && i < 20; ++i) {
+                    detail += (i ? "; " : "") + stale[i];
+                }
+                if (stale.size() > 20) {
+                    detail += "; and " + std::to_string(stale.size() - 20) + " more";
+                }
+                const std::string msg =
+                    std::to_string(stale.size()) +
+                    " corp-action dedup row(s) were written by a LATER pass over this book "
+                    "(run date on or after " + run_date_ + "): " + detail +
+                    ". Trusting them would skip events whose effect is not in the T-1 "
+                    "position row and finalize it in the wrong frame (E2-F23/E2-F16). "
+                    "Refusing to run: reset trading.corp_action_applied for this portfolio "
+                    "TOGETHER with the book (positions, live_results, equity_curve, "
+                    "executions) from the replay start date, then replay in order.";
+                ERROR("CorporateActionsAuditLog: " + msg);
+                return make_error<bool>(ErrorCode::INVALID_ARGUMENT, msg,
                                         "CorporateActionsAuditLog");
             }
         }
@@ -263,6 +316,9 @@ void CorporateActionsAuditLog::record(const PositionAdjustment& adj) {
         row.symbol = adj.symbol;
         row.ex_date = adj.event_date;
         row.action_type = CorporateActionsApplier::type_to_string(adj.type);
+        // E2-F23 / migration 005: the pass's own as-of date, so a later pass's
+        // rows are distinguishable from an earlier pass's. Empty stores NULL.
+        row.run_date = run_date_;
         if (adj.type == CorpActionType::DIVIDEND) {
             row.qty_held = adj.quantity_after;
             row.dividend_per_share = adj.event_value;

--- a/src/live/corporate_actions_lifecycle.cpp
+++ b/src/live/corporate_actions_lifecycle.cpp
@@ -156,7 +156,13 @@ std::vector<LifecycleAdjustment> CorporateActionsLifecycle::apply_renames(
 std::vector<LifecycleAdjustment> CorporateActionsLifecycle::apply_terminations(
     std::unordered_map<std::string, Position>& positions,
     const std::vector<TerminationEvent>& events,
-    const std::unordered_map<std::string, double>& final_closes) {
+    const std::unordered_map<std::string, double>& final_closes,
+    const std::string& feed_last_date) {
+
+    // The date the WARNs quote. Measured by the caller; the compiled-in constant
+    // is only the fallback for a caller that could not read the table.
+    const std::string feed_through =
+        feed_last_date.empty() ? std::string(kCorpActionTableFrozenAfter) : feed_last_date;
 
     std::vector<LifecycleAdjustment> log;
     log.reserve(events.size());
@@ -279,8 +285,8 @@ std::vector<LifecycleAdjustment> CorporateActionsLifecycle::apply_terminations(
             !std::isfinite(price_it->second)) {
             adj.outcome = LifecycleOutcome::SKIPPED_NO_PRICE;
             WARN("Corp action TERMINATION/" + ev.vendor_label + " for " + ev.symbol +
-                 " on " + ev.event_date + ": no deal terms (corporate_action feed frozen "
-                 "after " + std::string(kCorpActionTableFrozenAfter) +
+                 " on " + ev.event_date +
+                 ": no deal terms (corporate_action feed last row " + feed_through +
                  ") AND no final close available -- position left untouched, "
                  "operator review required");
             log.push_back(std::move(adj));
@@ -301,8 +307,8 @@ std::vector<LifecycleAdjustment> CorporateActionsLifecycle::apply_terminations(
         adj.realized_delta = realized_delta;
 
         WARN("Corp action TERMINATION/" + ev.vendor_label + " for " + ev.symbol +
-             " on " + ev.event_date + ": deal terms unavailable (corporate_action feed "
-             "frozen after " + std::string(kCorpActionTableFrozenAfter) +
+             " on " + ev.event_date +
+             ": deal terms unavailable (corporate_action feed last row " + feed_through +
              ") -- exiting " + std::to_string(qty_before) + " shares at final close " +
              std::to_string(exit_price) + " (realized " + std::to_string(realized_delta) +
              "). Correct for a cash deal; a stock-for-stock deal would instead roll into "

--- a/src/live/corporate_actions_lifecycle.cpp
+++ b/src/live/corporate_actions_lifecycle.cpp
@@ -20,22 +20,9 @@ const char* CorporateActionsLifecycle::outcome_to_string(LifecycleOutcome o) {
     return "SKIPPED_NO_POSITION";
 }
 
-std::vector<LifecycleAdjustment> CorporateActionsLifecycle::apply_renames(
-    std::unordered_map<std::string, Position>& positions,
-    const std::vector<TickerAlias>& aliases,
-    const std::string& as_of_date,
-    const std::unordered_map<std::string, std::string>& position_inception) {
-
-    std::vector<LifecycleAdjustment> log;
-
-    // Group by historical ticker, ascending by effective_until. ISO YYYY-MM-DD
-    // compares lexicographically, so a plain sort orders the eras.
-    //
-    // An alias with no effective_until cannot be era-bounded, and class 2 fails
-    // narrow: it is dropped rather than applied unconditionally. That is the same
-    // rule the dedup mirror uses, and it matters because an unbounded alias is
-    // exactly the shape that re-keys a currently-trading ticker.
-    std::unordered_map<std::string, std::vector<std::pair<std::string, std::string>>> renames;
+CorporateActionsLifecycle::RenameMap CorporateActionsLifecycle::build_rename_map(
+    const std::vector<TickerAlias>& aliases) {
+    RenameMap renames;
     for (const auto& a : aliases) {
         if (a.historical_ticker.empty() || a.current_symbol.empty()) continue;
         if (a.historical_ticker == a.current_symbol) continue;
@@ -46,28 +33,51 @@ std::vector<LifecycleAdjustment> CorporateActionsLifecycle::apply_renames(
         }
         renames[a.historical_ticker].emplace_back(a.effective_until, a.current_symbol);
     }
-    if (renames.empty()) return log;
     for (auto& entry : renames) {
         std::sort(entry.second.begin(), entry.second.end());
     }
+    return renames;
+}
 
-    // The successor a ticker had at `date`: the first rename on or after it.
-    // A date later than every rename maps NOWHERE -- the ticker belongs to
-    // whoever holds it now, not to the old company.
-    //
-    // The compare is inclusive on purpose. effective_until conventions differ by
-    // a day between curated rows (day-after) and backfilled rows (source date),
-    // so on the boundary day `<=` errs toward NOT applying a backfilled rename.
-    // That is the safe direction: the rename is simply retried next run.
-    auto successor_at = [&renames](const std::string& sym, const std::string& date)
-        -> std::pair<std::string, std::string> {  // (effective_until, current_symbol)
-        auto it = renames.find(sym);
-        if (it == renames.end()) return {};
-        for (const auto& candidate : it->second) {
-            if (date <= candidate.first) return candidate;
-        }
-        return {};
-    };
+std::pair<std::string, std::string> CorporateActionsLifecycle::successor_at(
+    const RenameMap& renames, const std::string& symbol, const std::string& date) {
+    auto it = renames.find(symbol);
+    if (it == renames.end()) return {};
+    for (const auto& candidate : it->second) {
+        if (date <= candidate.first) return candidate;
+    }
+    return {};
+}
+
+std::vector<std::string> CorporateActionsLifecycle::rename_chain(
+    const RenameMap& renames, const std::string& symbol, const std::string& holding_start,
+    const std::string& as_of_date) {
+    std::vector<std::string> chain;
+    if (holding_start.empty()) return chain;
+    std::string sym = symbol;
+    for (int hop = 0; hop < 8; ++hop) {
+        auto [effective_until, successor] = successor_at(renames, sym, holding_start);
+        if (successor.empty() || successor == sym) break;
+        // The rename must also have already happened as of this run.
+        if (!as_of_date.empty() && as_of_date <= effective_until) break;
+        chain.push_back(successor);
+        sym = successor;
+    }
+    return chain;
+}
+
+std::vector<LifecycleAdjustment> CorporateActionsLifecycle::apply_renames(
+    std::unordered_map<std::string, Position>& positions,
+    const std::vector<TickerAlias>& aliases,
+    const std::string& as_of_date,
+    const std::unordered_map<std::string, std::string>& position_inception) {
+
+    std::vector<LifecycleAdjustment> log;
+
+    // One rename map, shared with LiveDailyCycle::effective_universe so the universe
+    // the run loads bars for and the re-keying done here cannot drift apart (E2-F34).
+    const RenameMap renames = build_rename_map(aliases);
+    if (renames.empty()) return log;
 
     // Snapshot the keys: the loop below erases from and inserts into `positions`.
     std::vector<std::string> held;
@@ -96,7 +106,7 @@ std::vector<LifecycleAdjustment> CorporateActionsLifecycle::apply_renames(
             auto old_it = positions.find(sym);
             if (old_it == positions.end()) break;  // already merged away
 
-            auto [effective_until, successor] = successor_at(sym, inception);
+            auto [effective_until, successor] = successor_at(renames, sym, inception);
             if (successor.empty() || successor == sym) break;
 
             // The rename must also have already happened as of this run.

--- a/src/live/execution_manager.cpp
+++ b/src/live/execution_manager.cpp
@@ -201,16 +201,30 @@ void ExecutionManager::update_market_data(const std::string& symbol, double volu
 }
 
 std::string ExecutionManager::generate_date_string(const Timestamp& timestamp) {
-    // Convert timestamp to time_t
+    // UTC, because this is the RUN DATE and every other artefact of the same run
+    // is stamped in UTC: the equity runner parses the CLI date as UTC midnight
+    // (95679ea2) and formats `now_tm` with gmtime_r at every consumer, and the
+    // rows this id belongs to are keyed on that UTC date.
+    //
+    // std::localtime here took the previous calendar day on any negative-offset
+    // host -- the 2026-06-15 run wrote DAILY_AAPL_20260614 (E2-F46). That id is
+    // what delete_stale_executions matches on and what a broker statement is
+    // reconciled against, so naming the wrong day is not cosmetic.
+    //
+    // Futures are unmoved: they still pass local midnight (E2-F42), which lands
+    // at 04:00/05:00Z on the same calendar day, so reading it in UTC yields the
+    // YYYYMMDD they always got. gmtime_r, not std::gmtime: this is called from
+    // the same paths the thread-safety sweep covered.
     std::time_t time = std::chrono::system_clock::to_time_t(timestamp);
-    std::tm* tm = std::localtime(&time);
+    std::tm tm{};
+    if (gmtime_r(&time, &tm) == nullptr) return std::string();
 
     // Create date string in YYYYMMDD format
     std::stringstream date_ss;
     date_ss << std::setfill('0')
-            << std::setw(4) << (tm->tm_year + 1900)
-            << std::setw(2) << (tm->tm_mon + 1)
-            << std::setw(2) << tm->tm_mday;
+            << std::setw(4) << (tm.tm_year + 1900)
+            << std::setw(2) << (tm.tm_mon + 1)
+            << std::setw(2) << tm.tm_mday;
     return date_ss.str();
 }
 

--- a/src/live/execution_manager.cpp
+++ b/src/live/execution_manager.cpp
@@ -153,14 +153,16 @@ ExecutionReport ExecutionManager::generate_execution(
     exec.filled_quantity = std::abs(quantity_change);
     exec.fill_time = timestamp;
 
-    double abs_quantity = exec.filled_quantity.as_double();
-
     // TransactionCostManager is the single source of truth.
     // Keep fill_price as pure reference price (no embedded slippage).
     exec.fill_price = market_price;
 
+    // E2-F29: pass the SIGNED quantity. TransactionCostManager takes |qty| for every cost
+    // term except the SEC/TAF regulatory fees, which are sell-side only and are gated on
+    // `quantity < 0`. Passing |quantity_change| made that gate unreachable, so a config with
+    // apply_regulatory_fees charged a sell exactly what it charged a buy.
     auto cost_result = cost_manager_->calculate_costs(
-        symbol, abs_quantity, market_price);
+        symbol, quantity_change, market_price);
 
     exec.commissions_fees = Decimal(cost_result.commissions_fees);
     exec.implicit_price_impact = Decimal(cost_result.implicit_price_impact);

--- a/src/live/live_pnl_manager.cpp
+++ b/src/live/live_pnl_manager.cpp
@@ -326,6 +326,22 @@ double LivePnLManager::get_point_value(const std::string& symbol) const {
         }
     }
 
+    // E2-F38 / BA-7: the fallback table below is a SUBSTRING match over futures
+    // contract codes, so it must only be consulted for futures. Real equity
+    // tickers collide with it: AAPL contains "PL" (platinum, 50), LEN contains
+    // "LE" (live cattle, 40000), ZM is soybean meal (100), UBER contains "UB"
+    // (ultra T-bond, 1000), HES contains "ES" (5). Every one of those is a P&L
+    // report wrong by orders of magnitude on a position that merely failed to
+    // register.
+    //
+    // A share is a share: one unit, point value 1.0. There is nothing to guess.
+    if (asset_type_ != AssetType::FUTURE) {
+        WARN("No registry entry for " + symbol + "; it is not a futures symbol, so its "
+             "point value is 1.0. The futures fallback table is a substring match and "
+             "would have guessed a contract multiplier for it.");
+        return 1.0;
+    }
+
     // Fall back to known values if registry lookup fails
     double fallback = get_fallback_multiplier(base_symbol);
     if (fallback > 0) {

--- a/src/portfolio/portfolio_manager.cpp
+++ b/src/portfolio/portfolio_manager.cpp
@@ -542,9 +542,11 @@ Result<void> PortfolioManager::process_market_data(const std::vector<Bar>& data,
                                                  ? current_timestamp.value()
                                                  : (data.empty() ? std::chrono::system_clock::now()
                                                                  : data[0].timestamp);
-                            // Calculate transaction costs using TransactionCostManager
-                            auto cost_result = cost_manager_.calculate_costs(
-                                symbol, std::abs(trade_size), latest_price);
+                            // Calculate transaction costs using TransactionCostManager.
+                            // E2-F29: pass the SIGNED trade so the sell-side-only SEC/TAF gate
+                            // (`quantity < 0`) is reachable; every other term takes |qty|.
+                            auto cost_result =
+                                cost_manager_.calculate_costs(symbol, trade_size, latest_price);
                             exec.commissions_fees = Decimal(cost_result.commissions_fees);
                             exec.implicit_price_impact = Decimal(cost_result.implicit_price_impact);
                             exec.slippage_market_impact =
@@ -629,9 +631,11 @@ Result<void> PortfolioManager::process_market_data(const std::vector<Bar>& data,
                                              ? current_timestamp.value()
                                              : (data.empty() ? std::chrono::system_clock::now()
                                                              : data[0].timestamp);
-                        // Calculate transaction costs using TransactionCostManager
-                        auto cost_result = cost_manager_.calculate_costs(
-                            symbol, std::abs(trade_size), latest_price);
+                        // Calculate transaction costs using TransactionCostManager.
+                        // E2-F29: pass the SIGNED trade so the sell-side-only SEC/TAF gate
+                        // (`quantity < 0`) is reachable; every other term takes |qty|.
+                        auto cost_result =
+                            cost_manager_.calculate_costs(symbol, trade_size, latest_price);
                         exec.commissions_fees = Decimal(cost_result.commissions_fees);
                         exec.implicit_price_impact = Decimal(cost_result.implicit_price_impact);
                         exec.slippage_market_impact = Decimal(cost_result.slippage_market_impact);

--- a/src/portfolio/portfolio_manager.cpp
+++ b/src/portfolio/portfolio_manager.cpp
@@ -236,16 +236,6 @@ Result<void> PortfolioManager::process_market_data(const std::vector<Bar>& data,
                         attr_strategy_target[id][sym] = static_cast<double>(pos.quantity);
                     }
 
-                    // STICKY_DEBUG: Trace average_price after get_target_positions
-                    for (const auto& [sym, tpos] : info.target_positions) {
-                        if (sym == "MBT.v.0" || sym == "NQ.v.0") {
-                            INFO("STICKY_DEBUG_TP: strategy=" + id + " symbol=" + sym +
-                                 " avg_price=" +
-                                 std::to_string(static_cast<double>(tpos.average_price)) +
-                                 " qty=" + std::to_string(static_cast<double>(tpos.quantity)));
-                        }
-                    }
-
                     processed_strategies.push_back(id);
 
                 } catch (const std::exception& e) {
@@ -447,15 +437,6 @@ Result<void> PortfolioManager::process_market_data(const std::vector<Bar>& data,
             // This ensures get_strategy_positions() returns integer positions, not fractional ones
             for (auto& [id, info] : strategies_) {
                 info.current_positions = info.target_positions;
-
-                // STICKY_DEBUG: Trace average_price after current_positions = target_positions
-                for (const auto& [sym, cpos] : info.current_positions) {
-                    if (sym == "MBT.v.0" || sym == "NQ.v.0") {
-                        INFO("STICKY_DEBUG_CP: strategy=" + id + " symbol=" + sym + " avg_price=" +
-                             std::to_string(static_cast<double>(cpos.average_price)) +
-                             " qty=" + std::to_string(static_cast<double>(cpos.quantity)));
-                    }
-                }
             }
         }
 

--- a/src/storage/backtest_results_manager.cpp
+++ b/src/storage/backtest_results_manager.cpp
@@ -97,10 +97,10 @@ Result<void> BacktestResultsManager::save_all_results(const std::string& run_id,
     }
 
     // Metadata is written per-strategy by BacktestCoordinator::save_portfolio_results_to_db
-    // via save_strategy_metadata() (correct ON CONFLICT (run_id, strategy_id)). A portfolio-level
-    // write here used ON CONFLICT (run_id), which has no matching unique constraint on
-    // backtest.run_metadata, so it logged a non-fatal ERROR on every run and wrote nothing useful.
-    // (save_metadata()/store_backtest_metadata() remain defined for the interface contract.)
+    // via save_strategy_metadata() (correct ON CONFLICT (run_id, strategy_id)). The portfolio-level
+    // pair save_metadata()/store_backtest_metadata() used ON CONFLICT (run_id), which has no
+    // matching unique constraint on backtest.run_metadata, and omitted the NOT NULL strategy_id --
+    // it could never succeed, and its only caller was a unit test. Both were deleted (F-5).
 
     INFO("Successfully saved all backtest results for run_id: " + run_id);
     return Result<void>();
@@ -205,24 +205,6 @@ Result<void> BacktestResultsManager::save_signals_batch(const std::string& run_i
     }
 
     return Result<void>();
-}
-
-Result<void> BacktestResultsManager::save_metadata(const std::string& run_id) {
-    if (!store_enabled_) {
-        return Result<void>();
-    }
-
-    if (hyperparameters_.empty()) {
-        DEBUG("No metadata to save for run_id: " + run_id);
-        return Result<void>();
-    }
-
-    INFO("Saving metadata for run_id: " + run_id);
-
-    // Use existing database method
-    return db_->store_backtest_metadata(run_id, run_name_, run_description_,
-                                       start_date_, end_date_, hyperparameters_,
-                                       portfolio_id_, "backtest.run_metadata");
 }
 
 Result<void> BacktestResultsManager::save_strategy_positions(const std::string& portfolio_run_id) {

--- a/src/strategy/base_strategy.cpp
+++ b/src/strategy/base_strategy.cpp
@@ -1,6 +1,8 @@
 // src/strategy/base_strategy.cpp
 
 #include "trade_ngin/strategy/base_strategy.hpp"
+#include <algorithm>
+#include <cmath>
 #include <iostream>
 #include <sstream>
 #include "trade_ngin/core/logger.hpp"
@@ -197,18 +199,32 @@ Result<void> BaseStrategy::on_execution(const ExecutionReport& report) {
     try {
         auto& pos = positions_[report.symbol];
 
-        // Calculate realized PnL if closing position
+        // Calculate realized PnL if closing position.
+        //
+        // E2-F27 / T-OR.4: realize on the CLOSED quantity, not on the whole fill. A fill that
+        // crosses zero -- long 100, SELL 150 -- closes 100 shares against the existing basis and
+        // OPENS 50 new ones at the fill price. Multiplying the price difference by the full 150
+        // books P&L on 50 shares that were never held (measured: 3000 where the trade made 2000),
+        // and the overstatement is permanent: it lands in pos.realized_pnl and metrics_.realized_pnl,
+        // which live_results and trading.positions.daily_realized_pnl are built from.
+        //
+        // Latent rather than live today only because MeanReversionStrategy cannot flip in a single
+        // bar and TF/TFF/TFS override on_execution; an optimizer-driven QP_FLIP/RISK_SCALE_FLIP on
+        // any non-overriding strategy reaches this path.
         if ((pos.quantity > 0 && report.side == Side::SELL) ||
             (pos.quantity < 0 && report.side == Side::BUY)) {
+            const double closed_quantity =
+                std::min(std::abs(static_cast<double>(pos.quantity)),
+                         static_cast<double>(report.filled_quantity));
             double realized_pnl = 0.0;
             if (report.side == Side::SELL) {
                 realized_pnl = (static_cast<double>(report.fill_price) -
                                 static_cast<double>(pos.average_price)) *
-                               static_cast<double>(report.filled_quantity);
+                               closed_quantity;
             } else {
                 realized_pnl = (static_cast<double>(pos.average_price) -
                                 static_cast<double>(report.fill_price)) *
-                               static_cast<double>(report.filled_quantity);
+                               closed_quantity;
             }
 
             pos.realized_pnl += Decimal(realized_pnl);

--- a/src/strategy/trend_following.cpp
+++ b/src/strategy/trend_following.cpp
@@ -184,14 +184,6 @@ Result<void> TrendFollowingStrategy::on_data(const std::vector<Bar>& data) {
             for (const auto& bar : symbol_bars) {
                 instrument_data.price_history.push_back(static_cast<double>(bar.close));
 
-                // STICKY_DEBUG: Trace on_data push for MBT
-                if (symbol == "MBT.v.0") {
-                    INFO("STICKY_DEBUG_ONDATA: symbol=" + symbol + " bar.close=" +
-                         std::to_string(static_cast<double>(bar.close)) + " price_history.size()=" +
-                         std::to_string(instrument_data.price_history.size()) + " bar.timestamp=" +
-                         std::to_string(std::chrono::system_clock::to_time_t(bar.timestamp)));
-                }
-
                 // MEMORY FIX: Limit price history to maximum needed lookback
                 if (instrument_data.price_history.size() > trend_config_.max_history_size) {
                     instrument_data.price_history.pop_front();
@@ -635,17 +627,6 @@ std::unordered_map<std::string, Position> TrendFollowingStrategy::get_target_pos
 
         pos.last_update = instrument_data.last_update;
         target_positions[symbol] = pos;
-
-        // STICKY_DEBUG: Trace average_price at get_target_positions stage
-        if (symbol == "MBT.v.0" || symbol == "NQ.v.0") {
-            INFO("STICKY_DEBUG_GTP: symbol=" + symbol + " price_history.size()=" +
-                 std::to_string(instrument_data.price_history.size()) + " price_history.back()=" +
-                 (instrument_data.price_history.empty()
-                      ? "EMPTY"
-                      : std::to_string(instrument_data.price_history.back())) +
-                 " pos.average_price=" + std::to_string(static_cast<double>(pos.average_price)) +
-                 " pos.quantity=" + std::to_string(static_cast<double>(pos.quantity)));
-        }
     }
 
     return target_positions;

--- a/src/strategy/trend_following_fast.cpp
+++ b/src/strategy/trend_following_fast.cpp
@@ -617,17 +617,6 @@ std::unordered_map<std::string, Position> TrendFollowingFastStrategy::get_target
 
         pos.last_update = instrument_data.last_update;
         target_positions[symbol] = pos;
-
-        // STICKY_DEBUG: Trace average_price at FAST get_target_positions stage
-        if (symbol == "MBT.v.0" || symbol == "NQ.v.0") {
-            INFO("STICKY_DEBUG_GTP_FAST: symbol=" + symbol + " price_history.size()=" +
-                 std::to_string(instrument_data.price_history.size()) + " price_history.back()=" +
-                 (instrument_data.price_history.empty()
-                      ? "EMPTY"
-                      : std::to_string(instrument_data.price_history.back())) +
-                 " pos.average_price=" + std::to_string(static_cast<double>(pos.average_price)) +
-                 " pos.quantity=" + std::to_string(static_cast<double>(pos.quantity)));
-        }
     }
 
     return target_positions;

--- a/src/transaction_cost/transaction_cost_manager.cpp
+++ b/src/transaction_cost/transaction_cost_manager.cpp
@@ -98,6 +98,16 @@ TransactionCostResult TransactionCostManager::calculate_costs(
     }
 
     // 1b. Regulatory fees (equity sell-side only)
+    //
+    // E2-F29: this is the ONLY place the SIGN of `quantity` is read; everything else uses
+    // abs_qty. Every caller used to pass |qty| -- generate_execution() had already split the
+    // trade into a positive filled_quantity plus a Side -- so the gate was unreachable and
+    // these fees were dead code. The callers now pass the signed trade; do not "normalise"
+    // the argument at a call site.
+    //
+    // Note this is latent rather than live: every production config sets
+    // apply_regulatory_fees = false (IBKR Pro FIXED is all-inclusive, E2-C3). It arms the
+    // day anyone switches an equity config to Tiered, where fees are passed through.
     if (asset_config.apply_regulatory_fees && quantity < 0) {
         double trade_value = abs_qty * reference_price;
         // SEC Transaction Fee (sell-side only)

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -102,6 +102,7 @@ set(TEST_SOURCES
     strategy/test_volatility_size_1_nan_guard.cpp
     strategy/test_stale_unrealized_pnl_zero_avg_price.cpp
     strategy/test_live_daily_cycle_seeding.cpp
+    strategy/test_penny_stock_lifecycle.cpp
     statistics/test_normalizer.cpp
     statistics/test_pca.cpp
     statistics/test_adf.cpp

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -45,6 +45,7 @@ set(TEST_SOURCES
     live/corp_actions/test_rename_eras.cpp
     live/corp_actions/test_denominator_frame.cpp
     live/corp_actions/test_denominator_range_db.cpp
+    live/corp_actions/test_corp_action_query_bounds_db.cpp
     live/corp_actions/test_audit_log.cpp
     live/corp_actions/test_income.cpp
     live/test_live_metrics_includes_dividend_income.cpp

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -9,6 +9,7 @@ set(TEST_SOURCES
     core/test_config_version.cpp
     core/test_config_base.cpp
     core/test_holiday_checker.cpp
+    core/test_email_positions_table.cpp
     core/test_run_id_generator.cpp
     core/test_config_loader.cpp
     data/test_db_utils.cpp

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -65,6 +65,8 @@ set(TEST_SOURCES
     portfolio/test_portfolio_manager.cpp
     core/test_equity_portfolio_namespace.cpp
     live/corp_actions/test_window.cpp
+    live/test_effective_universe.cpp
+    data/test_current_holding_start_db.cpp
     instruments/test_equity_margin_cash_regt.cpp
     instruments/test_futures_margin_overload.cpp
     portfolio/test_portfolio_aggregation.cpp

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -50,6 +50,7 @@ set(TEST_SOURCES
     live/corp_actions/test_income.cpp
     live/test_live_metrics_includes_dividend_income.cpp
     live/test_daily_pnl_identity.cpp
+    live/test_trading_days_anchor.cpp
     backtest/test_slippage_model.cpp
     backtest/test_backtest_execution_manager.cpp
     backtest/test_backtest_price_manager.cpp

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -66,6 +66,7 @@ set(TEST_SOURCES
     core/test_equity_portfolio_namespace.cpp
     live/corp_actions/test_window.cpp
     live/test_effective_universe.cpp
+    live/test_live_daily_cycle_carry_forward.cpp
     data/test_current_holding_start_db.cpp
     instruments/test_equity_margin_cash_regt.cpp
     instruments/test_futures_margin_overload.cpp

--- a/tests/backtest/test_backtest_execution_manager.cpp
+++ b/tests/backtest/test_backtest_execution_manager.cpp
@@ -189,3 +189,27 @@ TEST_F(BacktestExecutionManagerTest, GetTransactionCostManagerReturnsLiveReferen
     // Reading via the manager wrapper should now see the same data.
     EXPECT_GT(manager_->get_adv("ES"), 0.0);
 }
+
+// E2-F29: the backtest execution path must also charge SEC/TAF on the sell side only.
+TEST_F(BacktestExecutionManagerTest, SellSideCarriesRegulatoryFeesWhenConfigured) {
+    transaction_cost::AssetCostConfig cfg;
+    cfg.symbol = "TIERD";
+    cfg.asset_type = AssetType::EQUITY;
+    cfg.commission_per_unit = 0.0035;
+    cfg.min_commission_per_order = 0.35;
+    cfg.max_commission_per_order = 1e9;
+    cfg.apply_regulatory_fees = true;
+    manager_->get_transaction_cost_manager().register_asset_config(cfg);
+
+    const double qty = 1000.0, px = 50.0;
+    auto buy = manager_->generate_execution("TIERD", +qty, px, ts_);
+    auto sell = manager_->generate_execution("TIERD", -qty, px, ts_);
+    ASSERT_EQ(buy.side, Side::BUY);
+    ASSERT_EQ(sell.side, Side::SELL);
+
+    const double sec_fee = (qty * px / 1e6) * cfg.sec_fee_per_million;
+    const double taf = std::min(qty * cfg.finra_taf_per_share, cfg.finra_taf_cap_per_trade);
+    EXPECT_NEAR(sell.commissions_fees.as_double() - buy.commissions_fees.as_double(),
+                sec_fee + taf, 1e-9)
+        << "SELL must carry SEC + TAF on top of the BUY-side commission";
+}

--- a/tests/core/test_config_loader.cpp
+++ b/tests/core/test_config_loader.cpp
@@ -425,3 +425,71 @@ TEST_F(ConfigLoaderTest, DeepMergeReplacesNonObjectsWithoutRecursion) {
     EXPECT_EQ(target["x"].size(), 1u);
     EXPECT_EQ(target["x"][0], 4);
 }
+
+// ──────────────────────────────────────────────────────────────────────────
+// BA-11 / C-1 C5 (T2.9) -- the staleness bounds must be CONFIGURABLE, not
+// hardcoded defaults that only look configurable.
+//
+// LiveSpecificConfig has read both keys from JSON all along, but
+// config_template/defaults.json declared only data_staleness_tolerance_days and
+// the config the runners actually load declared NEITHER, so the value in force
+// was always the struct default. The template is the tracked artefact a fresh
+// checkout copies, so a key missing there is a key nobody can set.
+// ──────────────────────────────────────────────────────────────────────────
+
+TEST(LiveStalenessConfig, BothBoundsRoundTripThroughJson) {
+    LiveSpecificConfig c;
+    // The documented defaults: 4 absorbs a weekend plus a holiday; 5 covers a
+    // three-day weekend plus a further holiday.
+    EXPECT_EQ(c.data_staleness_tolerance_days, 4);
+    EXPECT_EQ(c.execution_price_max_staleness_days, 5);
+
+    c.from_json(nlohmann::json{{"data_staleness_tolerance_days", 9},
+                               {"execution_price_max_staleness_days", 11}});
+    EXPECT_EQ(c.data_staleness_tolerance_days, 9) << "the configured value must win";
+    EXPECT_EQ(c.execution_price_max_staleness_days, 11);
+
+    const auto j = c.to_json();
+    EXPECT_EQ(j.at("data_staleness_tolerance_days").get<int>(), 9);
+    EXPECT_EQ(j.at("execution_price_max_staleness_days").get<int>(), 11);
+}
+
+TEST(LiveStalenessConfig, OmittedKeysKeepTheDocumentedDefaults) {
+    LiveSpecificConfig c;
+    c.from_json(nlohmann::json{{"historical_days", 730}});
+    EXPECT_EQ(c.data_staleness_tolerance_days, 4) << "default unchanged (BA-11)";
+    EXPECT_EQ(c.execution_price_max_staleness_days, 5) << "default unchanged (BA-11)";
+}
+
+// The drift pin. This is what C-1 C5 actually found: the struct grew a field and
+// the tracked template did not, so the knob existed in code and nowhere an
+// operator could reach it. Asserting the template declares every key the struct
+// serialises catches the next one automatically.
+TEST(LiveStalenessConfig, TrackedTemplateDeclaresEveryLiveKeyTheStructSerialises) {
+    namespace fs = std::filesystem;
+    fs::path dir = fs::current_path();
+    fs::path found;
+    for (int i = 0; i < 8 && !dir.empty(); ++i) {
+        if (fs::exists(dir / "config_template" / "defaults.json")) {
+            found = dir / "config_template" / "defaults.json";
+            break;
+        }
+        dir = dir.parent_path();
+    }
+    if (found.empty()) GTEST_SKIP() << "config_template/defaults.json not reachable";
+
+    std::ifstream in(found);
+    const nlohmann::json tmpl = nlohmann::json::parse(in);
+    ASSERT_TRUE(tmpl.contains("live")) << "the template must carry a live block";
+    const auto& live = tmpl.at("live");
+
+    // Bound to a local: to_json() returns by value and items() holds a reference
+    // into it, so iterating the temporary directly reads freed memory.
+    const nlohmann::json serialised = LiveSpecificConfig{}.to_json();
+    for (const auto& [key, _] : serialised.items()) {
+        EXPECT_TRUE(live.contains(key))
+            << "config_template/defaults.json omits live." << key
+            << " -- the struct reads it but no operator can set it, so the hardcoded "
+               "default is silently in force (C-1 C5 / T2.9)";
+    }
+}

--- a/tests/core/test_email_positions_table.cpp
+++ b/tests/core/test_email_positions_table.cpp
@@ -1,0 +1,166 @@
+// tests/core/test_email_positions_table.cpp
+//
+// D9 / BA-16: one unpriceable row must not suppress the whole daily email.
+//
+// format_positions_table computed margin from Position::average_price alone.
+// On the equity path that column is a COST BASIS, and 0 is its documented "no
+// basis known" value (docs/AVERAGE_PRICE_LIFECYCLE.md rule 5) -- reachable for a
+// held position whose basis could not be resolved, a state the runner already
+// reports as an ERROR and carries inert. get_margin_requirement(0, qty) then
+// returned 0, the function threw, and the bare `throw;` in its catch propagated
+// out: one such row and nobody received a report at all.
+//
+// Margin asks what a position is WORTH, so the current close is the right input
+// and the basis is the fallback -- the same preference the notional block in the
+// same loop already applies.
+
+#include <gtest/gtest.h>
+
+#include <map>
+#include <memory>
+#include <string>
+#include <unordered_map>
+
+// format_positions_table is private; reach it the way this suite already
+// reaches ConfigLoader's internals. Every std header the target transitively
+// pulls must be loaded BEFORE the macro flip, or libc++'s own private members
+// are redeclared public and its internals stop compiling.
+#include <algorithm>
+#include <chrono>
+#include <functional>
+#include <iomanip>
+#include <ios>
+#include <iterator>
+#include <numeric>
+#include <optional>
+#include <ostream>
+#include <ranges>
+#include <set>
+#include <sstream>
+#include <tuple>
+#include <utility>
+#include <vector>
+
+#define private public
+#include "trade_ngin/core/email_sender.hpp"
+#undef private
+
+#include "trade_ngin/instruments/equity.hpp"
+#include "trade_ngin/instruments/instrument_registry.hpp"
+
+using namespace trade_ngin;
+
+namespace {
+
+EquitySpec equity_spec() {
+    EquitySpec s;
+    s.exchange = "NASDAQ";
+    s.currency = "USD";
+    s.lot_size = 1.0;
+    s.tick_size = 0.01;
+    s.commission_per_share = 0.005;
+    s.is_etf = false;
+    s.is_marginable = true;
+    s.account_mode = EquityAccountMode::REG_T;
+    s.sector = "Technology";
+    s.industry = "Software";
+    s.trading_hours = "09:30-16:00";
+    return s;
+}
+
+Position held(const std::string& symbol, double qty, double average_price) {
+    Position p;
+    p.symbol = symbol;
+    p.quantity = Quantity(qty);
+    p.average_price = Decimal(average_price);
+    p.unrealized_pnl = Decimal(0.0);
+    p.realized_pnl = Decimal(0.0);
+    p.last_update = std::chrono::system_clock::now();
+    return p;
+}
+
+class EmailPositionsTableTest : public ::testing::Test {
+protected:
+    void SetUp() override {
+        auto& registry = InstrumentRegistry::instance();
+        registry.register_instrument(
+            "ZBASIS", std::make_shared<EquityInstrument>("ZBASIS", equity_spec()));
+        registry.register_instrument(
+            "ZPRICED", std::make_shared<EquityInstrument>("ZPRICED", equity_spec()));
+    }
+
+    EmailSender sender_{EmailSenderConfig{}};
+};
+
+}  // namespace
+
+// The defect, directly: a held row with no basis and no close must not throw.
+TEST_F(EmailPositionsTableTest, AZeroBasisHeldRowDoesNotAbortTheEmail) {
+    const std::unordered_map<std::string, Position> positions{
+        {"ZBASIS", held("ZBASIS", 100.0, 0.0)}};
+
+    std::string html;
+    ASSERT_NO_THROW({
+        html = sender_.format_positions_table(positions, true, {}, {});
+    }) << "a single unresolved basis used to abort the entire daily report";
+
+    EXPECT_NE(html.find("ZBASIS"), std::string::npos)
+        << "the row must still appear; excluding it silently would hide the position";
+    EXPECT_NE(html.find("<table>"), std::string::npos) << "a real table, not an empty string";
+}
+
+// The same row alongside a normal one: the healthy position's figures survive.
+TEST_F(EmailPositionsTableTest, AZeroBasisRowDoesNotSuppressTheOtherPositions) {
+    const std::unordered_map<std::string, Position> positions{
+        {"ZBASIS", held("ZBASIS", 100.0, 0.0)},
+        {"ZPRICED", held("ZPRICED", 50.0, 200.0)},
+    };
+    const std::unordered_map<std::string, double> prices{{"ZPRICED", 210.0}};
+
+    std::string html;
+    ASSERT_NO_THROW({ html = sender_.format_positions_table(positions, true, prices, {}); });
+
+    EXPECT_NE(html.find("ZPRICED"), std::string::npos);
+    EXPECT_NE(html.find("ZBASIS"), std::string::npos)
+        << "both rows are reported; one bad row costs the report nothing";
+}
+
+// Margin is priced from a MARK. A current close makes a zero-basis row fully
+// computable, so it must be used rather than falling straight to the warning.
+TEST_F(EmailPositionsTableTest, ACurrentCloseCoversAZeroBasis) {
+    const std::unordered_map<std::string, Position> positions{
+        {"ZBASIS", held("ZBASIS", 100.0, 0.0)}};
+    const std::unordered_map<std::string, double> prices{{"ZBASIS", 150.0}};
+
+    std::string html;
+    ASSERT_NO_THROW({ html = sender_.format_positions_table(positions, true, prices, {}); });
+    EXPECT_NE(html.find("ZBASIS"), std::string::npos);
+    // The close, not the basis, is what the row reports as its market price.
+    EXPECT_NE(html.find("150"), std::string::npos)
+        << "the current close must reach the row; it is also what margin is priced from";
+}
+
+// A normal book is unchanged -- the guard must not alter the healthy path.
+TEST_F(EmailPositionsTableTest, ANormalBookIsUnaffected) {
+    const std::unordered_map<std::string, Position> positions{
+        {"ZPRICED", held("ZPRICED", 50.0, 200.0)}};
+    const std::unordered_map<std::string, double> prices{{"ZPRICED", 210.0}};
+
+    std::string html;
+    ASSERT_NO_THROW({ html = sender_.format_positions_table(positions, true, prices, {}); });
+    EXPECT_NE(html.find("ZPRICED"), std::string::npos);
+    EXPECT_NE(html.find("210"), std::string::npos);
+}
+
+// A closed row carries no basis by design (rule 5) and is skipped by the
+// quantity filter, so it can never reach the margin path at all. Pinned so a
+// future change to that filter surfaces here.
+TEST_F(EmailPositionsTableTest, AClosedRowIsNotReportedAsAPosition) {
+    const std::unordered_map<std::string, Position> positions{
+        {"ZBASIS", held("ZBASIS", 0.0, 0.0)}};
+
+    std::string html;
+    ASSERT_NO_THROW({ html = sender_.format_positions_table(positions, true, {}, {}); });
+    EXPECT_EQ(html.find("ZBASIS"), std::string::npos)
+        << "a zero-quantity row is not an open position";
+}

--- a/tests/core/test_equity_portfolio_namespace.cpp
+++ b/tests/core/test_equity_portfolio_namespace.cpp
@@ -59,3 +59,94 @@ TEST(EquityPortfolioNamespace, EquityAndFuturesPortfolioIdsAreDistinct) {
         << "equity and futures portfolios must write to separate namespaces; "
            "sharing one lets a live equity run overwrite futures positions";
 }
+
+// ──────────────────────────────────────────────────────────────────────────
+// BA-5 / C-1 D3 -- real pins for 9b0d293c.
+//
+// The two tests above read config_template JSON only. They pass with the fix
+// reverted, because reintroducing the "BASE_PORTFOLIO" literal at the runner's
+// storage sites does not change any config file. What follows pins the two
+// things that can actually regress: the loader must REFUSE a config with no
+// portfolio_id (rather than defaulting to the futures book), and the equity
+// runner must not carry the literal at all.
+// ──────────────────────────────────────────────────────────────────────────
+
+// Linkable pin. validate_config is reached via the `#define private public`
+// technique this suite already uses for ConfigLoader internals.
+#include <map>
+#include <string>
+#include <vector>
+#define private public
+#include "trade_ngin/core/config_loader.hpp"
+#undef private
+
+using namespace trade_ngin;
+
+namespace {
+
+AppConfig config_with_portfolio_id(const std::string& id) {
+    AppConfig c;
+    c.portfolio_id = id;
+    c.database.host = "h";
+    c.database.username = "u";
+    c.database.password = "p";
+    c.database.name = "n";
+    c.initial_capital = 500000.0;
+    c.reserve_capital_pct = 0.10;
+    c.strategies_config = nlohmann::json{{"equity_mean_reversion", {{"enabled", true}}}};
+    return c;
+}
+
+std::string read_repo_text(const std::string& relative) {
+    auto path = find_repo_file(relative);
+    if (path.empty()) return {};
+    std::ifstream in(path);
+    return std::string(std::istreambuf_iterator<char>(in), std::istreambuf_iterator<char>());
+}
+
+}  // namespace
+
+// An absent portfolio_id must be an ERROR, never a silent fall back to the
+// futures namespace. This is the half of 9b0d293c that links.
+TEST(EquityPortfolioNamespace, MissingPortfolioIdIsRejectedRatherThanDefaulted) {
+    auto ok = ConfigLoader::validate_config(config_with_portfolio_id("EQUITY_MR_PORTFOLIO"));
+    EXPECT_TRUE(ok.is_ok()) << "a declared portfolio id must validate";
+
+    auto missing = ConfigLoader::validate_config(config_with_portfolio_id(""));
+    ASSERT_TRUE(missing.is_error())
+        << "an empty portfolio_id must fail validation; defaulting it is how equity rows "
+           "landed in the futures book's namespace";
+    EXPECT_EQ(missing.error()->code(), ErrorCode::INVALID_DATA);
+}
+
+// Source-level pin, because apps/ is not linked into this binary (C-1 F7) and
+// the 10 storage sites live in main(). The literal is what regressed; its
+// absence from the file is therefore the thing to assert. Comments are stripped
+// first so the file may still EXPLAIN the defect it no longer contains.
+TEST(EquityPortfolioNamespace, EquityRunnerCarriesNoBasePortfolioLiteral) {
+    const std::string src = read_repo_text("apps/strategies/live_equity_mean_reversion.cpp");
+    if (src.empty()) {
+        GTEST_SKIP() << "apps/strategies/live_equity_mean_reversion.cpp not reachable";
+    }
+
+    // Strip // line comments so a comment mentioning BASE_PORTFOLIO does not trip this.
+    std::string code;
+    code.reserve(src.size());
+    for (size_t i = 0; i < src.size();) {
+        if (src[i] == '/' && i + 1 < src.size() && src[i + 1] == '/') {
+            while (i < src.size() && src[i] != '\n') ++i;
+        } else {
+            code += src[i++];
+        }
+    }
+
+    // The literal as it would appear in a storage call.
+    EXPECT_EQ(code.find("\"BASE_PORTFOLIO\""), std::string::npos)
+        << "the equity runner must pass its config's portfolio_id to every storage site; "
+           "a \"BASE_PORTFOLIO\" literal here writes equity rows into the futures book";
+
+    // And it must actually thread the config value into the coordinator, which is the
+    // single place the old default lived.
+    EXPECT_NE(code.find("coordinator_config.portfolio_id = portfolio_id;"), std::string::npos)
+        << "the coordinator must be given the equity portfolio id explicitly";
+}

--- a/tests/core/test_holiday_checker.cpp
+++ b/tests/core/test_holiday_checker.cpp
@@ -468,3 +468,186 @@ TEST_F(HolidayPathResolutionTest, ConstructorAcceptsResolvedPath) {
     std::error_code ec;
     std::filesystem::remove(tmp, ec);
 }
+
+// ──────────────────────────────────────────────────────────────────────────
+// Time frame -- the candidate must be tested in the frame it is returned in.
+// (E2-F45, 2026-09-03.)
+//
+// find_previous_trading_day used to test each candidate with safe_localtime and
+// return the raw candidate, which every caller then formatted with gmtime. The
+// two frames only agree when the candidate's local and UTC calendar dates are
+// the same day. Since 95679ea2 the equity runner's run date is UTC MIDNIGHT, so
+// on any negative-offset host the candidate's local date is the day BEFORE its
+// UTC date: the walk validated day D-1 and handed back day D. Measured on the
+// 2026-06-15 replay (America/New_York): Monday resolved its previous trading day
+// to Saturday 2026-06-13, so no T-1 close existed, the Day T-1 finalization was
+// refused, and every day-T row was marked from the widened fallback instead.
+//
+// These pin BOTH frames on purpose. UTC midnight is what the equity runner
+// passes; local midnight is what live_portfolio.cpp:60 and
+// live_portfolio_conservative.cpp:61 still pass (std::mktime, E2-F42). Both must
+// resolve to the same calendar date, or fixing the equity path would move the
+// futures path.
+// ──────────────────────────────────────────────────────────────────────────
+
+namespace {
+
+std::chrono::system_clock::time_point utc_midnight(int y, int m, int d) {
+    std::tm tm{};
+    tm.tm_year = y - 1900;
+    tm.tm_mon = m - 1;
+    tm.tm_mday = d;
+    return std::chrono::system_clock::from_time_t(timegm(&tm));
+}
+
+// The frame the two futures runners still parse their CLI date in.
+std::chrono::system_clock::time_point local_midnight(int y, int m, int d) {
+    std::tm tm{};
+    tm.tm_year = y - 1900;
+    tm.tm_mon = m - 1;
+    tm.tm_mday = d;
+    tm.tm_isdst = -1;
+    return std::chrono::system_clock::from_time_t(std::mktime(&tm));
+}
+
+// The frame every caller reads the answer in: format_ymd_utc, gmtime_r, and the
+// SQL date the row is keyed on.
+std::string ymd_utc(std::chrono::system_clock::time_point tp) {
+    auto t = std::chrono::system_clock::to_time_t(tp);
+    std::tm tm{};
+    gmtime_r(&t, &tm);
+    char buf[11];
+    std::strftime(buf, sizeof(buf), "%Y-%m-%d", &tm);
+    return std::string(buf);
+}
+
+class PreviousTradingDayFrameTest : public ::testing::Test {
+protected:
+    void SetUp() override {
+        // Pinned to a negative-offset zone: that is where UTC midnight and local
+        // midnight fall on different calendar days, and it is the zone the book
+        // actually runs in.
+        if (const char* tz = std::getenv("TZ")) {
+            had_tz_ = true;
+            saved_tz_ = tz;
+        }
+        setenv("TZ", "America/New_York", 1);
+        tzset();
+
+        path_ = shipped_calendar_path();
+        if (path_.empty()) {
+            GTEST_SKIP() << "shipped holidays.json not reachable from cwd";
+        }
+    }
+
+    void TearDown() override {
+        if (had_tz_) {
+            setenv("TZ", saved_tz_.c_str(), 1);
+        } else {
+            unsetenv("TZ");
+        }
+        tzset();
+    }
+
+    bool had_tz_ = false;
+    std::string saved_tz_;
+    std::string path_;
+};
+
+}  // namespace
+
+// The fixture's own inputs, asserted before anything rests on them: without
+// these two holidays the 06-22 and 04-06 cases would pass for the wrong reason.
+TEST_F(PreviousTradingDayFrameTest, CalendarCoversTheDatesTheseTestsRestOn) {
+    HolidayChecker checker(path_);
+    ASSERT_TRUE(checker.loaded());
+    ASSERT_TRUE(checker.covers_date("2026-06-15"));
+    EXPECT_TRUE(checker.is_holiday("2026-06-19")) << "Juneteenth 2026";
+    EXPECT_TRUE(checker.is_holiday("2026-04-03")) << "Good Friday 2026";
+}
+
+// The regression. A UTC-midnight run date -- what the equity runner has passed
+// since 95679ea2 -- must resolve to the real previous trading day, not to the
+// weekend or holiday one calendar day later.
+TEST_F(PreviousTradingDayFrameTest, UtcMidnightRunDateResolvesTheTrueTradingDay) {
+    HolidayChecker checker(path_);
+    ASSERT_TRUE(checker.loaded());
+
+    struct Case { int y, m, d; const char* expected; const char* why; };
+    const Case cases[] = {
+        {2026, 6, 15, "2026-06-12", "Monday -> Friday"},
+        {2026, 6, 16, "2026-06-15", "Tuesday -> Monday"},
+        {2026, 6, 22, "2026-06-18", "Monday, and 06-19 is Juneteenth -> Thursday"},
+        {2026, 4,  6, "2026-04-02", "Monday, and 04-03 is Good Friday -> Thursday"},
+        {2026, 6, 20, "2026-06-18", "Saturday, and 06-19 is Juneteenth -> Thursday"},
+    };
+
+    for (const auto& c : cases) {
+        auto prev = checker.find_previous_trading_day(utc_midnight(c.y, c.m, c.d));
+        ASSERT_TRUE(prev.has_value()) << c.why;
+        EXPECT_EQ(ymd_utc(*prev), c.expected)
+            << "UTC-midnight " << c.y << "-" << c.m << "-" << c.d << ": " << c.why;
+    }
+}
+
+// Futures preservation. The two futures runners still parse their CLI date with
+// std::mktime, i.e. local midnight (E2-F42). Testing the candidate in UTC must
+// not move their answer: on this zone a local-midnight date lands at 04:00/05:00Z
+// on the SAME calendar day, so the walk sees the same days either way.
+TEST_F(PreviousTradingDayFrameTest, LocalMidnightRunDateResolvesTheSameCalendarDate) {
+    HolidayChecker checker(path_);
+    ASSERT_TRUE(checker.loaded());
+
+    struct Case { int y, m, d; const char* expected; };
+    const Case cases[] = {
+        {2026, 6, 15, "2026-06-12"},
+        {2026, 6, 16, "2026-06-15"},
+        {2026, 6, 22, "2026-06-18"},
+        {2026, 4,  6, "2026-04-02"},
+        {2026, 6, 20, "2026-06-18"},
+    };
+
+    for (const auto& c : cases) {
+        auto prev = checker.find_previous_trading_day(local_midnight(c.y, c.m, c.d));
+        ASSERT_TRUE(prev.has_value());
+        EXPECT_EQ(ymd_utc(*prev), c.expected)
+            << "local-midnight " << c.y << "-" << c.m << "-" << c.d
+            << " must resolve to the same calendar date as the UTC-midnight form";
+    }
+}
+
+// The two frames agree with each other, stated directly: this is the property
+// that lets the equity path be fixed without a futures regression run.
+TEST_F(PreviousTradingDayFrameTest, BothRunDateFramesAgreeAcrossAFullWeek) {
+    HolidayChecker checker(path_);
+    ASSERT_TRUE(checker.loaded());
+
+    for (int day = 15; day <= 26; ++day) {
+        auto from_utc = checker.find_previous_trading_day(utc_midnight(2026, 6, day));
+        auto from_local = checker.find_previous_trading_day(local_midnight(2026, 6, day));
+        ASSERT_TRUE(from_utc.has_value()) << "2026-06-" << day;
+        ASSERT_TRUE(from_local.has_value()) << "2026-06-" << day;
+        EXPECT_EQ(ymd_utc(*from_utc), ymd_utc(*from_local))
+            << "the two run-date frames disagree on 2026-06-" << day;
+    }
+}
+
+// The answer is never a day the market was shut -- the property the name of the
+// function promises, and the one the replay found violated.
+TEST_F(PreviousTradingDayFrameTest, TheAnswerIsNeverAClosedDay) {
+    HolidayChecker checker(path_);
+    ASSERT_TRUE(checker.loaded());
+
+    for (int day = 1; day <= 30; ++day) {
+        auto prev = checker.find_previous_trading_day(utc_midnight(2026, 6, day));
+        ASSERT_TRUE(prev.has_value()) << "2026-06-" << day;
+        const std::string answer = ymd_utc(*prev);
+
+        auto t = std::chrono::system_clock::to_time_t(*prev);
+        std::tm tm{};
+        gmtime_r(&t, &tm);
+        EXPECT_NE(tm.tm_wday, 0) << answer << " is a Sunday";
+        EXPECT_NE(tm.tm_wday, 6) << answer << " is a Saturday";
+        EXPECT_FALSE(checker.is_holiday(answer)) << answer << " is a market holiday";
+    }
+}

--- a/tests/core/test_holiday_checker.cpp
+++ b/tests/core/test_holiday_checker.cpp
@@ -113,6 +113,59 @@ TEST(HolidayCalendarCoverage, MalformedDatesDoNotClaimCoverage) {
     EXPECT_FALSE(checker.covers_date("not-a-date"));
 }
 
+// BA-1 / C-2 D1: a load that throws PART WAY THROUGH must publish nothing.
+//
+// The year key was inserted before that year's entries parsed, and the outer
+// catch returned false without clearing, so a calendar that failed halfway was
+// left marked "covered" with its closures missing. That is worse than an empty
+// calendar: covers_date returns TRUE, the runner's fail-closed guard passes,
+// is_holiday returns false with no warning (the year IS covered), and
+// find_previous_trading_day walks onto a closed day. The guard only ever fired
+// when the load failed TOTALLY.
+TEST(HolidayCalendarCoverage, PartialLoadPublishesNothingRatherThanClaimingCoverage) {
+    // 2025 parses cleanly; 2026's first entry has no "type", so the parse throws
+    // after 2026 has already been inserted into the covered set -- the shape a
+    // hand-edited or truncated calendar actually produces.
+    TempCalendar cal(
+        R"({"2025":[{"date":"2025-01-01","name":"New Year's Day","type":"fixed"}],)"
+        R"("2026":[{"date":"2026-05-25","name":"Memorial Day"},)"
+        R"({"date":"2026-12-25","name":"Christmas Day","type":"fixed"}]})");
+    HolidayChecker checker(cal.path());
+
+    EXPECT_FALSE(checker.loaded())
+        << "a throw part way through the file is a failed load, not a partial success";
+    EXPECT_FALSE(checker.covers_year(2026))
+        << "2026 was inserted before its entries parsed; claiming coverage makes "
+           "is_holiday(\"2026-05-25\") read as \"the market was open\"";
+    EXPECT_FALSE(checker.covers_date("2026-05-26"))
+        << "the runner's fail-closed guard consults covers_date and must fire";
+    EXPECT_FALSE(checker.covers_year(2025))
+        << "all or nothing: a half-applied calendar is not a calendar, so even the "
+           "year that did parse must not be advertised";
+    EXPECT_FALSE(checker.is_holiday("2026-05-25"))
+        << "Memorial Day never loaded; false here means unknown, and covers_date says so";
+}
+
+// The success path still publishes, and says so.
+TEST(HolidayCalendarCoverage, FullLoadReportsLoaded) {
+    TempCalendar cal(R"({"2026":[{"date":"2026-12-25","name":"Christmas Day","type":"fixed"}]})");
+    HolidayChecker checker(cal.path());
+
+    EXPECT_TRUE(checker.loaded());
+    EXPECT_TRUE(checker.covers_year(2026));
+    EXPECT_TRUE(checker.is_holiday("2026-12-25"));
+}
+
+// A file that cannot be opened at all is also a failed load -- the case the
+// original guard did catch, kept so the fix does not narrow it.
+TEST(HolidayCalendarCoverage, MissingFileReportsNotLoaded) {
+    HolidayChecker checker("/nonexistent/path/holidays.json");
+
+    EXPECT_FALSE(checker.loaded());
+    EXPECT_FALSE(checker.covers_year(2026));
+    EXPECT_FALSE(checker.covers_date("2026-05-26"));
+}
+
 // The shipped calendar must span the windows we actually run: historical
 // backtests reach back to the start of the equity data, and live needs runway.
 TEST(HolidayCalendarCoverage, ShippedCalendarSpansBacktestHistoryAndRunway) {

--- a/tests/core/test_time_utils_parse.cpp
+++ b/tests/core/test_time_utils_parse.cpp
@@ -162,3 +162,105 @@ TEST(FeedFreshness, TheCountIsTheSameOnAnyHostTimezone) {
     EXPECT_EQ(newyork, 65);
     EXPECT_EQ(utc, 65);
 }
+
+// ──────────────────────────────────────────────────────────────────────────
+// E3 "mktime sites" -- the two CALENDAR-DATE parses in the equity runner.
+//
+// apps/strategies/live_equity_mean_reversion.cpp:96 turns the CLI argument
+// (`YYYY-MM-DD`) into the run's target_date, and :1337 turns an ex-date into
+// ex_date-1 for load_positions_by_date. Both went through std::mktime, which
+// reads the broken-down date as LOCAL midnight. Everything downstream then
+// formats it back with gmtime (format_utc_date / safe_gmtime), so on a host at
+// a POSITIVE UTC offset the whole run silently moves to the previous day: the
+// date key written to trading.positions, the T-1 lookup, the dedup ex-date
+// comparison. A New York host hides it (local midnight is 05:00 UTC, same day).
+// ──────────────────────────────────────────────────────────────────────────
+
+#include <iomanip>
+#include <sstream>
+
+TEST(TimeUtilsParse, CliDateRoundTripsOnAPositiveOffsetHost) {
+    ForceTimezone tz("Asia/Tokyo");
+    std::chrono::system_clock::time_point tp;
+    ASSERT_TRUE(parse_utc_date("2026-08-06", tp));
+    EXPECT_EQ(format_utc_date(tp), "2026-08-06")
+        << "the run date the operator asked for must survive the parse";
+    EXPECT_EQ(format_utc_datetime(tp), "2026-08-06 00:00:00")
+        << "a calendar date is UTC midnight, not local midnight";
+}
+
+// The defect this replaces, pinned so the reason the helper exists cannot be
+// argued away later. This is the exact expression that was at :96 and :1337.
+TEST(TimeUtilsParse, MktimeIsTheThingThatWasWrong) {
+    ForceTimezone tz("Asia/Tokyo");
+    std::tm tm = {};
+    std::istringstream ss("2026-08-06");
+    ss >> std::get_time(&tm, "%Y-%m-%d");
+    ASSERT_FALSE(ss.fail());
+    const auto mktime_tp = std::chrono::system_clock::from_time_t(std::mktime(&tm));
+    EXPECT_EQ(format_utc_date(mktime_tp), "2026-08-05")
+        << "if this ever says 2026-08-06 the host zone changed, not the code";
+
+    std::chrono::system_clock::time_point fixed;
+    ASSERT_TRUE(parse_utc_date("2026-08-06", fixed));
+    EXPECT_NE(mktime_tp, fixed) << "the two parses must not be confused for each other";
+}
+
+// New York is where this ran, and where it looks fine -- that is why the two
+// sites survived six months of daily runs.
+TEST(TimeUtilsParse, ANewYorkHostAgreesWithTokyoOnlyAfterTheFix) {
+    std::string tokyo, newyork, utc;
+    {
+        ForceTimezone tz("Asia/Tokyo");
+        std::chrono::system_clock::time_point tp;
+        ASSERT_TRUE(parse_utc_date("2026-04-06", tp));
+        tokyo = format_utc_date(tp);
+    }
+    {
+        ForceTimezone tz("America/New_York");
+        std::chrono::system_clock::time_point tp;
+        ASSERT_TRUE(parse_utc_date("2026-04-06", tp));
+        newyork = format_utc_date(tp);
+    }
+    {
+        ForceTimezone tz("UTC");
+        std::chrono::system_clock::time_point tp;
+        ASSERT_TRUE(parse_utc_date("2026-04-06", tp));
+        utc = format_utc_date(tp);
+    }
+    EXPECT_EQ(tokyo, "2026-04-06");
+    EXPECT_EQ(newyork, "2026-04-06");
+    EXPECT_EQ(utc, "2026-04-06");
+}
+
+// ex_date - 1, the :1337 site. Subtracting a day from a UTC-midnight point is
+// exact; subtracting it from a LOCAL-midnight point inherits the same shift and
+// then asks the database for the wrong day's book.
+TEST(TimeUtilsParse, ExDateMinusOneIsExactOnAPositiveOffsetHost) {
+    ForceTimezone tz("Asia/Tokyo");
+    std::chrono::system_clock::time_point ex;
+    ASSERT_TRUE(parse_utc_date("2026-04-06", ex));
+    const auto prior = std::chrono::system_clock::from_time_t(
+        std::chrono::system_clock::to_time_t(ex) - 24 * 60 * 60);
+    EXPECT_EQ(format_utc_date(prior), "2026-04-05");
+
+    // Across a month boundary, and across the US DST switch (2026-03-08), where
+    // a local-midnight arithmetic also drifts by an hour.
+    std::chrono::system_clock::time_point first;
+    ASSERT_TRUE(parse_utc_date("2026-03-09", first));
+    const auto before = std::chrono::system_clock::from_time_t(
+        std::chrono::system_clock::to_time_t(first) - 24 * 60 * 60);
+    EXPECT_EQ(format_utc_date(before), "2026-03-08");
+}
+
+TEST(TimeUtilsParse, MalformedCalendarDateIsRejected) {
+    std::chrono::system_clock::time_point tp;
+    EXPECT_FALSE(parse_utc_date("", tp));
+    EXPECT_FALSE(parse_utc_date("not a date", tp));
+    EXPECT_FALSE(parse_utc_date("2026-13-01", tp)) << "month 13 must not roll into 2027";
+    EXPECT_FALSE(parse_utc_date("2026-00-10", tp));
+    EXPECT_FALSE(parse_utc_date("2026-04-00", tp));
+    // A full timestamp is NOT silently truncated to its date -- callers that
+    // want that must say so with parse_utc_datetime.
+    EXPECT_FALSE(parse_utc_date("2026-04-06 05:00:00+00", tp));
+}

--- a/tests/core/test_time_utils_parse.cpp
+++ b/tests/core/test_time_utils_parse.cpp
@@ -69,3 +69,96 @@ TEST(TimeUtilsParse, MalformedStringIsRejected) {
     EXPECT_FALSE(parse_utc_datetime("not a timestamp", tp));
     EXPECT_FALSE(parse_utc_datetime("2026-07-02", tp));
 }
+
+// ──────────────────────────────────────────────────────────────────────────
+// BA-12 / C-1 C8 -- the data-freshness guard.
+//
+// It used to take the GLOBAL MAX bar timestamp across every loaded bar, so a
+// single symbol printing today reported the whole feed as current no matter how
+// far behind the other 851 were. It also treated an empty load as "nothing to
+// check" and measured staleness by instant subtraction rather than calendar
+// days between UTC date keys.
+//
+// Lives in this file because all three defects are UTC/calendar-date defects and
+// ForceTimezone above is what proves the last of them.
+// ──────────────────────────────────────────────────────────────────────────
+
+#include "trade_ngin/live/data_freshness.hpp"
+
+using trade_ngin::assess_feed_freshness;
+using trade_ngin::calendar_days_between_utc;
+
+TEST(FeedFreshness, OneFreshSymbolDoesNotMaskTheStaleRest) {
+    // The universe-scale failure in one fixture: AAPL printed today, everything
+    // else stopped in June. A max would report 0 days behind.
+    const std::unordered_map<std::string, std::string> last_bar{
+        {"AAPL", "2026-08-06"},
+        {"TMUS", "2026-06-02"},
+        {"NSC", "2026-06-15"},
+        {"ABT", "2026-07-01"},
+    };
+
+    const auto f = assess_feed_freshness(last_bar, "2026-08-06");
+
+    ASSERT_TRUE(f.any_data);
+    EXPECT_EQ(f.stalest_symbol, "TMUS") << "the STALEST symbol decides, not the freshest";
+    EXPECT_EQ(f.stalest_date, "2026-06-02");
+    EXPECT_EQ(f.days_behind, 65) << "2026-06-02 to 2026-08-06 is 65 calendar days";
+    EXPECT_EQ(f.symbols, 4u);
+}
+
+TEST(FeedFreshness, NoDataIsMaximallyStaleNotNeutral) {
+    const auto f = assess_feed_freshness({}, "2026-08-06");
+    EXPECT_FALSE(f.any_data)
+        << "an empty load establishes that NO symbol is current; the caller must not "
+           "read that as a passing check";
+    EXPECT_EQ(f.symbols, 0u);
+    EXPECT_TRUE(f.stalest_symbol.empty());
+}
+
+TEST(FeedFreshness, AMapOfOnlyUnparseableDatesEstablishesNothing) {
+    const std::unordered_map<std::string, std::string> last_bar{
+        {"AAPL", ""}, {"TMUS", "not-a-date"}, {"NSC", "2026-13-99"}};
+    const auto f = assess_feed_freshness(last_bar, "2026-08-06");
+    EXPECT_FALSE(f.any_data) << "nothing in the map shows a symbol is current";
+    EXPECT_EQ(f.symbols, 3u) << "the symbols are still counted, so the caller can say so";
+}
+
+TEST(FeedFreshness, AFreshFeedIsZeroDaysBehind) {
+    const std::unordered_map<std::string, std::string> last_bar{
+        {"AAPL", "2026-08-06"}, {"TMUS", "2026-08-06"}};
+    const auto f = assess_feed_freshness(last_bar, "2026-08-06");
+    ASSERT_TRUE(f.any_data);
+    EXPECT_EQ(f.days_behind, 0);
+}
+
+// Calendar days, not instant arithmetic. A weekend gap is exactly 3 days from
+// Friday to Monday however the hours divide.
+TEST(FeedFreshness, StalenessIsCountedInCalendarDays) {
+    EXPECT_EQ(calendar_days_between_utc("2026-08-07", "2026-08-10"), 3) << "Fri to Mon";
+    EXPECT_EQ(calendar_days_between_utc("2026-08-10", "2026-08-10"), 0);
+    EXPECT_EQ(calendar_days_between_utc("2026-02-28", "2026-03-01"), 1) << "2026 is not a leap year";
+    EXPECT_EQ(calendar_days_between_utc("2024-02-28", "2024-03-01"), 2) << "2024 is";
+    EXPECT_EQ(calendar_days_between_utc("2025-12-31", "2026-01-01"), 1) << "across a year end";
+    // A date ahead of the as-of date reports negative rather than wrapping.
+    EXPECT_EQ(calendar_days_between_utc("2026-08-10", "2026-08-07"), -3);
+    // Malformed input cannot manufacture a huge staleness.
+    EXPECT_EQ(calendar_days_between_utc("", "2026-08-10"), 0);
+    EXPECT_EQ(calendar_days_between_utc("2026-08-10", "garbage"), 0);
+}
+
+// The reason this belongs beside the mktime tests: the count must not move with
+// the host zone. On a New York host an instant-based measure shifts by 5 hours,
+// which flips a boundary day.
+TEST(FeedFreshness, TheCountIsTheSameOnAnyHostTimezone) {
+    const std::unordered_map<std::string, std::string> last_bar{{"AAPL", "2026-06-02"}};
+
+    long tokyo = 0, newyork = 0, utc = 0;
+    { ForceTimezone tz("Asia/Tokyo");        tokyo = assess_feed_freshness(last_bar, "2026-08-06").days_behind; }
+    { ForceTimezone tz("America/New_York");  newyork = assess_feed_freshness(last_bar, "2026-08-06").days_behind; }
+    { ForceTimezone tz("UTC");               utc = assess_feed_freshness(last_bar, "2026-08-06").days_behind; }
+
+    EXPECT_EQ(tokyo, 65);
+    EXPECT_EQ(newyork, 65);
+    EXPECT_EQ(utc, 65);
+}

--- a/tests/data/test_conversion_utils.cpp
+++ b/tests/data/test_conversion_utils.cpp
@@ -419,3 +419,141 @@ TEST(ConversionUtilsSafeGet, NullColumnReturnsError) {
 }
 
 }  // namespace conversion_utils_safe_get_detail
+
+// ──────────────────────────────────────────────────────────────────────────
+// E2-F37 / BA-14 -- safe_get_int64 and temporal columns.
+//
+// The canonical schema stores dates as TimestampArray, but
+// convert_generic_to_arrow may surface the same column as utf8 or int64
+// depending on the source -- which is exactly why LiveDataLoader routes
+// timestamps through safe_get_int64. There was no TIMESTAMP case, so such a
+// column hit `default` and errored; and when it arrived as text,
+// std::stoll("2026-09-02 00:00:00") returned 2026, a silent plausible-looking
+// integer that is not a timestamp in any unit.
+// ──────────────────────────────────────────────────────────────────────────
+namespace {
+
+using conversion_utils_safe_get_detail::make_string_column;
+using conversion_utils_safe_get_detail::make_timestamp_column;
+
+std::shared_ptr<arrow::ChunkedArray> make_timestamp_column_us(int64_t micros) {
+    arrow::TimestampBuilder b(arrow::timestamp(arrow::TimeUnit::MICRO),
+                              arrow::default_memory_pool());
+    EXPECT_TRUE(b.Append(micros).ok());
+    std::shared_ptr<arrow::Array> arr;
+    EXPECT_TRUE(b.Finish(&arr).ok());
+    return std::make_shared<arrow::ChunkedArray>(arr);
+}
+
+std::shared_ptr<arrow::ChunkedArray> make_date32_column(int32_t days) {
+    arrow::Date32Builder b;
+    EXPECT_TRUE(b.Append(days).ok());
+    std::shared_ptr<arrow::Array> arr;
+    EXPECT_TRUE(b.Finish(&arr).ok());
+    return std::make_shared<arrow::ChunkedArray>(arr);
+}
+
+std::shared_ptr<arrow::ChunkedArray> make_date64_column(int64_t millis) {
+    arrow::Date64Builder b;
+    EXPECT_TRUE(b.Append(millis).ok());
+    std::shared_ptr<arrow::Array> arr;
+    EXPECT_TRUE(b.Finish(&arr).ok());
+    return std::make_shared<arrow::ChunkedArray>(arr);
+}
+
+}  // namespace
+
+// A TIMESTAMP column yields its stored value in its own unit -- the same number
+// an int64 column holding that value would have given, which is what
+// LiveDataLoader::load_previous_day_data already reads as microseconds.
+TEST(ConversionUtilsSafeGet, Int64FromTimestampMicrosecondsReturnsTheStoredValue) {
+    // 2026-09-02 00:00:00 UTC in microseconds.
+    const int64_t micros = 1788307200LL * 1000000LL;
+    auto col = make_timestamp_column_us(micros);
+    auto r = DataConversionUtils::safe_get_int64(col, 0, "date");
+    ASSERT_TRUE(r.is_ok()) << r.error()->what();
+    EXPECT_EQ(r.value(), micros);
+}
+
+// Seconds-unit timestamps are equally accepted; the unit is the column's, and
+// this test states that plainly so nobody reads it as normalisation.
+TEST(ConversionUtilsSafeGet, Int64FromTimestampSecondsReturnsSecondsNotMicroseconds) {
+    auto col = make_timestamp_column();  // TimeUnit::SECOND, 1700000000
+    auto r = DataConversionUtils::safe_get_int64(col, 0, "ts");
+    ASSERT_TRUE(r.is_ok()) << r.error()->what();
+    EXPECT_EQ(r.value(), 1700000000)
+        << "the value comes back in the COLUMN's unit; safe_get_int64 does not normalise";
+}
+
+TEST(ConversionUtilsSafeGet, Int64FromDate32IsDaysAndDate64IsMilliseconds) {
+    auto d32 = make_date32_column(20698);  // 2026-09-02
+    auto r32 = DataConversionUtils::safe_get_int64(d32, 0, "date");
+    ASSERT_TRUE(r32.is_ok()) << r32.error()->what();
+    EXPECT_EQ(r32.value(), 20698) << "Date32 is days since the epoch";
+
+    auto d64 = make_date64_column(1788307200LL * 1000LL);
+    auto r64 = DataConversionUtils::safe_get_int64(d64, 0, "date");
+    ASSERT_TRUE(r64.is_ok()) << r64.error()->what();
+    EXPECT_EQ(r64.value(), 1788307200LL * 1000LL) << "Date64 is milliseconds since the epoch";
+}
+
+// The silent-wrong-answer this item exists to close.
+TEST(ConversionUtilsSafeGet, Int64FromDatetimeStringIsNotTheYear) {
+    auto col = make_string_column({"2026-09-02 00:00:00"});
+    auto r = DataConversionUtils::safe_get_int64(col, 0, "date");
+    ASSERT_TRUE(r.is_ok()) << r.error()->what();
+    EXPECT_NE(r.value(), 2026)
+        << "std::stoll stops at the first '-' and used to return the YEAR as if it "
+           "were a timestamp";
+    EXPECT_EQ(r.value(), 1788307200LL * 1000000LL)
+        << "a textual datetime comes back as microseconds since the epoch";
+}
+
+TEST(ConversionUtilsSafeGet, Int64FromDateOnlyStringIsMidnightUtc) {
+    auto col = make_string_column({"2026-09-02"});
+    auto r = DataConversionUtils::safe_get_int64(col, 0, "date");
+    ASSERT_TRUE(r.is_ok()) << r.error()->what();
+    EXPECT_EQ(r.value(), 1788307200LL * 1000000LL);
+
+    // The 'T' separator is accepted too -- the same instant.
+    auto iso = make_string_column({"2026-09-02T00:00:00"});
+    auto r_iso = DataConversionUtils::safe_get_int64(iso, 0, "date");
+    ASSERT_TRUE(r_iso.is_ok()) << r_iso.error()->what();
+    EXPECT_EQ(r_iso.value(), r.value());
+}
+
+// UTC, not the host zone: a stored timestamptz is already a UTC instant, so
+// timegm is required. mktime on a New York host shifts this by five hours.
+TEST(ConversionUtilsSafeGet, Int64FromDatetimeStringIsUtcOnAnyHost) {
+    auto col = make_string_column({"2026-09-02 00:00:00"});
+
+    const char* saved = std::getenv("TZ");
+    setenv("TZ", "America/New_York", 1);
+    tzset();
+    auto r = DataConversionUtils::safe_get_int64(col, 0, "date");
+    if (saved) setenv("TZ", saved, 1); else unsetenv("TZ");
+    tzset();
+
+    ASSERT_TRUE(r.is_ok()) << r.error()->what();
+    EXPECT_EQ(r.value(), 1788307200LL * 1000000LL)
+        << "a UTC instant must not be re-interpreted in the host zone (E2-F22)";
+}
+
+// Integer strings are unchanged -- every existing caller relies on this.
+TEST(ConversionUtilsSafeGet, Int64FromIntegerStringIsStillParsed) {
+    EXPECT_EQ(DataConversionUtils::safe_get_int64(make_string_column({"42"}), 0, "n").value(), 42);
+    EXPECT_EQ(DataConversionUtils::safe_get_int64(make_string_column({"-7"}), 0, "n").value(), -7);
+    // Surrounding whitespace is still an integer.
+    EXPECT_EQ(DataConversionUtils::safe_get_int64(make_string_column({" 13 "}), 0, "n").value(), 13);
+}
+
+// Anything that is neither an integer nor a datetime must ERROR, never return a
+// partial parse.
+TEST(ConversionUtilsSafeGet, Int64FromUnparseableStringErrorsRatherThanTruncating) {
+    for (const char* bad : {"12abc", "abc", "", "2026-13-45", "2026-09-02 99:99:99",
+                            "2026-09-02 00:00"}) {
+        auto r = DataConversionUtils::safe_get_int64(make_string_column({bad}), 0, "n");
+        EXPECT_TRUE(r.is_error()) << "'" << bad << "' must not parse to anything";
+        if (r.is_error()) EXPECT_EQ(r.error()->code(), ErrorCode::CONVERSION_ERROR);
+    }
+}

--- a/tests/data/test_current_holding_start_db.cpp
+++ b/tests/data/test_current_holding_start_db.cpp
@@ -1,0 +1,227 @@
+// tests/data/test_current_holding_start_db.cpp
+//
+// BA-2 / C-3 D1 -- PostgresDatabase::get_current_holding_start_dates.
+//
+// The class-2 rename era must be tested against the start of the CURRENT holding.
+// `get_position_inception_dates` answers min(date) over all history and fails WIDE on
+// purpose (class 1's price window would rather over-fetch than under-fetch); asked the
+// class-2 question it returns a date from a PREVIOUS holding of a reused ticker, which
+// satisfies the era test for an alias belonging to the previous issuer and re-keys a
+// live position onto a symbol with no bars.
+//
+// The rule is expressed in SQL, so it needs the real table to be pinned. Read-only:
+// nothing here writes. The assertions are data-independent -- they compare the shipped
+// query against an INDEPENDENT formulation of the same rule and against the lifetime
+// query, so they hold whatever the book happens to contain on the day they run.
+//
+// Reachability gate matches tests/live/corp_actions/test_corp_action_query_bounds_db.cpp:
+//   * TRADE_NGIN_REQUIRE_DB=1 -- unreachable database FAILS rather than skips.
+//   * unset -- skip (local dev without a server).
+
+#include <gtest/gtest.h>
+#include <pqxx/pqxx>
+
+#include <cstdlib>
+#include <filesystem>
+#include <fstream>
+#include <memory>
+#include <nlohmann/json.hpp>
+#include <string>
+#include <unordered_map>
+#include <vector>
+
+#include "trade_ngin/data/postgres_database.hpp"
+
+using namespace trade_ngin;
+
+namespace {
+
+constexpr const char* kStrategyId = "LIVE_EQUITY_MEAN_REVERSION";
+constexpr const char* kStrategyName = "EQUITY_MEAN_REVERSION";
+
+std::string discover_connection_string() {
+    namespace fs = std::filesystem;
+    fs::path dir = fs::current_path();
+    for (int i = 0; i < 8 && !dir.empty(); ++i) {
+        fs::path candidate = dir / "config" / "defaults.json";
+        if (fs::exists(candidate)) {
+            try {
+                std::ifstream in(candidate);
+                nlohmann::json j = nlohmann::json::parse(in);
+                const auto& d = j.at("database");
+                return "postgresql://" + d.at("username").get<std::string>() + ":" +
+                       d.at("password").get<std::string>() + "@" +
+                       d.at("host").get<std::string>() + ":" + d.at("port").get<std::string>() +
+                       "/" + d.at("name").get<std::string>();
+            } catch (const std::exception&) {
+                return {};
+            }
+        }
+        dir = dir.parent_path();
+    }
+    return {};
+}
+
+}  // namespace
+
+class CurrentHoldingStartDbTest : public ::testing::Test {
+protected:
+    void SetUp() override {
+        const bool require_db = [] {
+            const char* v = std::getenv("TRADE_NGIN_REQUIRE_DB");
+            return v && std::string(v) == "1";
+        }();
+
+        conn_string_ = discover_connection_string();
+        if (conn_string_.empty()) {
+            if (require_db) {
+                FAIL() << "TRADE_NGIN_REQUIRE_DB=1 but config/defaults.json is not reachable, "
+                          "so the class-2 era query goes unverified";
+            }
+            GTEST_SKIP() << "config/defaults.json not reachable; no database to exercise";
+        }
+        db_ = std::make_shared<PostgresDatabase>(conn_string_);
+        auto connected = db_->connect();
+        if (connected.is_error() || !db_->is_connected()) {
+            if (require_db) {
+                FAIL() << "TRADE_NGIN_REQUIRE_DB=1 but the database is unreachable, so the "
+                          "class-2 era query goes unverified";
+            }
+            GTEST_SKIP() << "database unreachable; this rule lives in SQL";
+        }
+
+        pqxx::connection c(conn_string_);
+        pqxx::work w(c);
+        auto rows = w.exec(
+            "SELECT DISTINCT portfolio_id, symbol FROM trading.positions "
+            "WHERE strategy_id = $1 AND strategy_name = $2",
+            pqxx::params{kStrategyId, kStrategyName});
+        for (const auto& row : rows) {
+            portfolio_id_ = row["portfolio_id"].c_str();
+            symbols_.push_back(row["symbol"].c_str());
+        }
+        w.commit();
+        if (symbols_.empty()) {
+            GTEST_SKIP() << "no equity position history to derive holding starts from";
+        }
+    }
+
+    void TearDown() override {
+        if (db_ && db_->is_connected()) db_->disconnect();
+    }
+
+    std::string conn_string_;
+    std::string portfolio_id_;
+    std::vector<std::string> symbols_;
+    std::shared_ptr<PostgresDatabase> db_;
+};
+
+// The shipped query against an INDEPENDENT formulation of the same rule: the earliest
+// non-zero row AFTER the last flat row, found with a partition-wide window function
+// instead of a correlated max(). Two different SQL shapes for one definition; if they
+// disagree the shipped one is wrong, whatever the data looks like.
+//
+// Note what the rule excludes: a symbol whose newest row is flat has no CURRENT holding
+// and is absent from both answers. That is correct -- apply_renames only ever asks about
+// positions it holds -- and it is the case that separates this from a running max()
+// (which would answer with a previous holding start for a symbol that is now closed).
+TEST_F(CurrentHoldingStartDbTest, HoldingStartMatchesAnIndependentFormulationOfTheRule) {
+    auto shipped = db_->get_current_holding_start_dates(kStrategyId, kStrategyName,
+                                                        portfolio_id_, symbols_);
+    ASSERT_TRUE(shipped.is_ok()) << shipped.error()->what();
+
+    pqxx::connection c(conn_string_);
+    pqxx::work w(c);
+    auto rows = w.exec(
+        "WITH marked AS ("
+        "  SELECT symbol, date, quantity,"
+        "         max(CASE WHEN quantity = 0 THEN date END) OVER ("
+        "             PARTITION BY symbol) AS last_flat"
+        "    FROM trading.positions"
+        "   WHERE strategy_id = $1 AND strategy_name = $2 AND portfolio_id = $3"
+        "     AND symbol = ANY($4))"
+        " SELECT symbol, min(date)::text AS holding_start FROM marked"
+        "  WHERE quantity <> 0 AND (last_flat IS NULL OR date > last_flat)"
+        "  GROUP BY symbol",
+        pqxx::params{kStrategyId, kStrategyName, portfolio_id_, symbols_});
+    std::unordered_map<std::string, std::string> expected;
+    for (const auto& row : rows) expected.emplace(row["symbol"].c_str(),
+                                                  row["holding_start"].c_str());
+    w.commit();
+
+    EXPECT_EQ(shipped.value().size(), expected.size());
+    for (const auto& [symbol, start] : expected) {
+        auto it = shipped.value().find(symbol);
+        ASSERT_NE(it, shipped.value().end()) << "shipped query lost " << symbol;
+        EXPECT_EQ(it->second, start) << "shipped query disagrees on " << symbol;
+    }
+}
+
+// The direction of error that matters. A holding start is never EARLIER than the
+// lifetime inception, so class 2 can only ever be handed a date at or after the one
+// class 1 uses -- and "later" is the safe direction: a skipped rename is retried next
+// run, a wrongly applied one is silent, permanent corruption.
+TEST_F(CurrentHoldingStartDbTest, HoldingStartIsNeverEarlierThanTheLifetimeInception) {
+    auto holding = db_->get_current_holding_start_dates(kStrategyId, kStrategyName,
+                                                        portfolio_id_, symbols_);
+    ASSERT_TRUE(holding.is_ok()) << holding.error()->what();
+    auto lifetime = db_->get_position_inception_dates(kStrategyId, kStrategyName,
+                                                      portfolio_id_, symbols_);
+    ASSERT_TRUE(lifetime.is_ok()) << lifetime.error()->what();
+
+    for (const auto& [symbol, start] : holding.value()) {
+        auto it = lifetime.value().find(symbol);
+        ASSERT_NE(it, lifetime.value().end())
+            << symbol << " has a current holding but no lifetime inception, which cannot be";
+        EXPECT_GE(start, it->second)
+            << symbol << ": holding start " << start << " precedes lifetime inception "
+            << it->second;
+    }
+}
+
+// The two questions are not the same question. Every symbol whose history contains a
+// flat row after its first non-zero row was closed and re-opened, and for exactly those
+// the two answers MUST differ -- that difference is the whole point of BA-2. Where the
+// book contains no such symbol the test says so rather than passing silently.
+TEST_F(CurrentHoldingStartDbTest, ReopenedTickersGetADifferentDateFromTheLifetimeQuery) {
+    pqxx::connection c(conn_string_);
+    pqxx::work w(c);
+    auto rows = w.exec(
+        "SELECT symbol FROM trading.positions"
+        " WHERE strategy_id = $1 AND strategy_name = $2 AND portfolio_id = $3"
+        "   AND quantity = 0"
+        "   AND date > (SELECT min(i.date) FROM trading.positions i"
+        "                WHERE i.strategy_id = trading.positions.strategy_id"
+        "                  AND i.strategy_name = trading.positions.strategy_name"
+        "                  AND i.portfolio_id = trading.positions.portfolio_id"
+        "                  AND i.symbol = trading.positions.symbol AND i.quantity <> 0)"
+        " GROUP BY symbol",
+        pqxx::params{kStrategyId, kStrategyName, portfolio_id_});
+    std::vector<std::string> reopened;
+    for (const auto& row : rows) reopened.push_back(row["symbol"].c_str());
+    w.commit();
+
+    auto holding = db_->get_current_holding_start_dates(kStrategyId, kStrategyName,
+                                                        portfolio_id_, symbols_);
+    ASSERT_TRUE(holding.is_ok()) << holding.error()->what();
+    auto lifetime = db_->get_position_inception_dates(kStrategyId, kStrategyName,
+                                                      portfolio_id_, symbols_);
+    ASSERT_TRUE(lifetime.is_ok()) << lifetime.error()->what();
+
+    int compared = 0;
+    for (const auto& symbol : reopened) {
+        auto h = holding.value().find(symbol);
+        if (h == holding.value().end()) continue;  // still flat: no current holding at all
+        auto l = lifetime.value().find(symbol);
+        ASSERT_NE(l, lifetime.value().end());
+        EXPECT_GT(h->second, l->second)
+            << symbol << " was closed and re-opened, so the class-2 era date must be the "
+                         "re-open, not the original purchase";
+        ++compared;
+    }
+    if (compared == 0) {
+        GTEST_SKIP() << "no currently-held symbol in this book has been closed and "
+                        "re-opened; the two queries cannot be shown to differ on this "
+                        "data (the pure tests carry the behaviour)";
+    }
+}

--- a/tests/data/test_db_transaction_atomicity.cpp
+++ b/tests/data/test_db_transaction_atomicity.cpp
@@ -33,6 +33,7 @@
 #include <memory>
 #include <nlohmann/json.hpp>
 #include <string>
+#include <unordered_map>
 #include <vector>
 
 #include "../core/test_base.hpp"
@@ -288,6 +289,84 @@ TEST_F(DbTransactionAtomicityTest, CommitTwiceIsRejectedRatherThanRepeated) {
                     .is_ok());
     ASSERT_TRUE(txn.commit().is_ok());
     EXPECT_TRUE(txn.commit().is_error()) << "a second commit must be refused, not repeated";
+}
+
+// ---------------------------------------------------------------------------
+// E2-F23 / migration 005 -- run_date must survive the round trip.
+//
+// The column is what lets a run tell an EARLIER pass's dedup rows from a LATER
+// pass's. The pure tests in tests/live/corp_actions/test_audit_log.cpp pin the
+// refusal logic against a fake; this pins that the value actually reaches the
+// server and comes back, which is the half a fake cannot prove -- and that a
+// legacy NULL comes back as "unknown" rather than as an epoch date.
+// ---------------------------------------------------------------------------
+
+TEST_F(DbTransactionAtomicityTest, RunDateRoundTripsAndNullStaysUnknown) {
+    // Stamped row.
+    auto stamped = make_applied_row("AAPL", "2026-04-06");
+    stamped.action_type = "SPLIT";
+    stamped.run_date = "2026-04-07";
+
+    // Legacy row: no run_date, which must store NULL rather than an epoch date.
+    auto legacy = make_applied_row("MSFT", "2026-04-06");
+    legacy.action_type = "SPLIT";
+
+    ASSERT_TRUE(db_->store_applied_corp_actions(kScratchPortfolio, kScratchStrategyId,
+                                                kScratchStrategyName, {stamped, legacy})
+                    .is_ok());
+    ASSERT_EQ(dedup_row_count(), 2);
+
+    auto loaded = db_->load_applied_corp_actions(kScratchPortfolio, kScratchStrategyId,
+                                                 kScratchStrategyName);
+    ASSERT_TRUE(loaded.is_ok()) << loaded.error()->what();
+    ASSERT_EQ(loaded.value().size(), 2u);
+
+    std::unordered_map<std::string, std::string> run_date_by_symbol;
+    for (const auto& r : loaded.value()) run_date_by_symbol[r.symbol] = r.run_date;
+
+    EXPECT_EQ(run_date_by_symbol["AAPL"], "2026-04-07")
+        << "the writing pass's run date must survive the round trip verbatim";
+    EXPECT_TRUE(run_date_by_symbol["MSFT"].empty())
+        << "an unstamped row must read back as unknown, not as 1970-01-01 -- an epoch "
+           "date would be < every run date and silently pass the staleness check while "
+           "claiming to have been checked";
+
+    // And the server really holds NULL, not an empty string coerced into a date.
+    EXPECT_EQ(scalar(std::string("SELECT count(*) FROM trading.corp_action_applied "
+                                 "WHERE portfolio_id = '") + kScratchPortfolio +
+                     "' AND run_date IS NULL"),
+              1);
+    EXPECT_EQ(scalar(std::string("SELECT count(*) FROM trading.corp_action_applied "
+                                 "WHERE portfolio_id = '") + kScratchPortfolio +
+                     "' AND run_date = DATE '2026-04-07'"),
+              1);
+}
+
+// The column is additive: a row written with no run_date is byte-identical to
+// what the pre-005 code wrote, so an existing dedup record keeps deduping.
+TEST_F(DbTransactionAtomicityTest, AnUnstampedWriteStillDedupsOnTheNaturalKey) {
+    auto row = make_applied_row("NVDA", "2026-04-06");
+    row.action_type = "SPLIT";
+
+    ASSERT_TRUE(db_->store_applied_corp_actions(kScratchPortfolio, kScratchStrategyId,
+                                                kScratchStrategyName, {row})
+                    .is_ok());
+    // Same natural key, different run_date: ON CONFLICT DO NOTHING, so the first
+    // write stays authoritative and no second row appears. run_date is NOT part
+    // of the key -- keying on it would let the same event re-apply every day
+    // (audit option D1).
+    auto restamped = row;
+    restamped.run_date = "2026-04-09";
+    ASSERT_TRUE(db_->store_applied_corp_actions(kScratchPortfolio, kScratchStrategyId,
+                                                kScratchStrategyName, {restamped})
+                    .is_ok());
+
+    EXPECT_EQ(dedup_row_count(), 1) << "run_date must not widen the natural key";
+    EXPECT_EQ(scalar(std::string("SELECT count(*) FROM trading.corp_action_applied "
+                                 "WHERE portfolio_id = '") + kScratchPortfolio +
+                     "' AND run_date IS NULL"),
+              1)
+        << "and the first write stays authoritative, exactly as qty_held does";
 }
 
 }  // namespace

--- a/tests/data/test_db_utils.hpp
+++ b/tests/data/test_db_utils.hpp
@@ -230,18 +230,6 @@ public:
         return record_call("store_backtest_signals");
     }
 
-    Result<void> store_backtest_metadata(const std::string& run_id, const std::string& name,
-                                         const std::string& description,
-                                         const Timestamp& start_date, const Timestamp& end_date,
-                                         const nlohmann::json& hyperparameters,
-                                         const std::string& portfolio_id,
-                                         const std::string& table_name) override {
-        (void)run_id; (void)name; (void)description;
-        (void)start_date; (void)end_date; (void)hyperparameters;
-        (void)portfolio_id; (void)table_name;
-        return record_call("store_backtest_metadata");
-    }
-
     // Live trading data storage methods
     Result<void> store_trading_results(
         const std::string& strategy_id, const Timestamp& date, double total_return,

--- a/tests/live/corp_actions/test_applier.cpp
+++ b/tests/live/corp_actions/test_applier.cpp
@@ -18,6 +18,7 @@
 #include <unordered_map>
 #include <vector>
 #include "trade_ngin/core/types.hpp"
+#include "trade_ngin/live/corp_action_window.hpp"
 #include "trade_ngin/live/corporate_actions_applier.hpp"
 #include <ctime>
 #include <string>
@@ -283,12 +284,26 @@ TEST(CorpActionFrameConsistency, DividendBasisRescaleMatchesPriceSeriesFactor) {
     ev.ex_date = "2026-08-10";
     ev.type = CorpActionType::DIVIDEND;
     ev.value = dividend;
-    ev.close_at_ex_date = close_on_ex;  // ex-date close, per the fix
+    // BA-5 / C-1 D1: the ex-date close is SELECTED here from the same bar series the
+    // price-adjustment factors were computed from, rather than being assigned the
+    // already-correct literal. Handing the applier `close_on_ex` by name made the
+    // fixture supply the fix, so the test could not distinguish the corrected frame
+    // from the old one -- it asserted an equality it had itself arranged.
+    ev.close_at_ex_date = bars[1].close;  // the bar the dividend goes ex on
+    ASSERT_DOUBLE_EQ(ev.close_at_ex_date, close_on_ex) << "sanity: bars[1] IS the ex-date bar";
 
     const auto adjustments = CorporateActionsApplier::apply(positions, {ev});
     ASSERT_EQ(adjustments.size(), 1u);
 
+    // The adjustment record must report the same ratio it applied, so a reader of the
+    // audit log and the position row cannot disagree about what happened.
+    EXPECT_NEAR(adjustments[0].ratio_change, 1.0 + dividend / bars[1].close, 1e-9);
+
     const double basis_factor = positions["AAPL"].average_price.as_double() / 90.0;
+
+    // Pinned against the rule itself, computed here from the event fields alone. This
+    // is what catches the two frames drifting TOGETHER.
+    EXPECT_NEAR(basis_factor, 1.0 / (1.0 + dividend / bars[1].close), 1e-8);
 
     // The two must scale by the same amount. Decimal carries 8 decimal places,
     // so compare at that resolution rather than machine epsilon.
@@ -299,23 +314,48 @@ TEST(CorpActionFrameConsistency, DividendBasisRescaleMatchesPriceSeriesFactor) {
 }
 
 TEST(CorpActionFrameConsistency, UsingThePriorDaysCloseWouldDriftFromThePriceSeries) {
-    // Guards the specific regression: reverting the denominator to close[T-1]
-    // must visibly disagree with the price series. If this ever stops failing
-    // to differ, the two frames have been silently re-coupled by accident.
+    // BA-5 / C-1 D1: this used to compute `wrong_factor` and `price_series_factor`
+    // from two local expressions and assert they differed. Both were arithmetic on
+    // literals declared three lines above -- no repository code was involved, so it
+    // could not fail however the applier changed. It now drives the APPLIER with each
+    // denominator and asserts which one lands in the price series' frame.
     const double close_before_ex = 101.00;
     const double close_on_ex = 100.00;
     const double dividend = 0.50;
+    const double basis = 90.0;
 
     std::vector<market_data_utils::AdjustmentBar> bars = {
         {close_before_ex, 0.0, 1.0}, {close_on_ex, dividend, 1.0}, {100.75, 0.0, 1.0}};
     const double price_series_factor =
         market_data_utils::compute_backward_adjustment_factors(bars)[0];
 
-    const double wrong_ratio = 1.0 + dividend / close_before_ex;  // the old denominator
-    const double wrong_factor = 1.0 / wrong_ratio;
+    // Run the real applier twice, changing ONLY the close it is handed.
+    auto basis_after = [&](double close_used) {
+        std::unordered_map<std::string, Position> positions;
+        positions["AAPL"] = make_position("AAPL", 100.0, basis);
+        CorpActionEvent ev;
+        ev.symbol = "AAPL";
+        ev.ex_date = "2026-08-10";
+        ev.type = CorpActionType::DIVIDEND;
+        ev.value = dividend;
+        ev.close_at_ex_date = close_used;
+        const auto adj = CorporateActionsApplier::apply(positions, {ev});
+        EXPECT_EQ(adj.size(), 1u);
+        return positions["AAPL"].average_price.as_double();
+    };
 
-    EXPECT_GT(std::abs(wrong_factor - price_series_factor), 1e-9)
-        << "close[T-1] and close[ex-date] must not be interchangeable here";
+    const double with_ex_date_close = basis_after(close_on_ex);
+    const double with_prior_close = basis_after(close_before_ex);
+
+    // The ex-date close is the price series' own denominator, so only it agrees.
+    EXPECT_NEAR(with_ex_date_close / basis, price_series_factor, 1e-8)
+        << "the ex-date close must put the basis in the price series' frame";
+    EXPECT_GT(std::abs(with_prior_close / basis - price_series_factor), 1e-9)
+        << "close[T-1] and close[ex-date] must not be interchangeable in the applier";
+
+    // And the applier's rule is exactly 1 + d/close, measured independently of it.
+    EXPECT_NEAR(with_ex_date_close, basis / (1.0 + dividend / close_on_ex), 1e-8);
+    EXPECT_NEAR(with_prior_close, basis / (1.0 + dividend / close_before_ex), 1e-8);
 }
 
 // Date keys are built from UTC instants. On the deployed image
@@ -323,6 +363,12 @@ TEST(CorpActionFrameConsistency, UsingThePriorDaysCloseWouldDriftFromThePriceSer
 // PREVIOUS day, which shifted every corp-action key and the trading date the
 // run writes under. This pins UTC rendering regardless of the host's zone.
 TEST(CorpActionFrameConsistency, DateKeysAreUtcRegardlessOfHostTimezone) {
+    // BA-5 / C-1 D1: this used to declare its OWN gmtime_r+strftime lambda and assert
+    // that the lambda was timezone-independent. That tests libc, not this repository:
+    // every date-key site could have been reverted to localtime and the test would
+    // still pass. It now exercises format_ymd_utc, the primitive the corp-action
+    // window and the runner's date keys actually go through.
+    //
     // 2026-08-10 00:00:00 UTC.
     std::tm utc{};
     utc.tm_year = 126;
@@ -330,20 +376,12 @@ TEST(CorpActionFrameConsistency, DateKeysAreUtcRegardlessOfHostTimezone) {
     utc.tm_mday = 10;
     const std::time_t t = timegm(&utc);
 
-    auto render = [](std::time_t when) {
-        std::tm out{};
-        gmtime_r(&when, &out);
-        char buf[11];
-        std::strftime(buf, sizeof(buf), "%Y-%m-%d", &out);
-        return std::string(buf);
-    };
-
-    const std::string before = render(t);
+    const std::string before = format_ymd_utc(t);
 
     const char* saved_tz = std::getenv("TZ");
     setenv("TZ", "America/New_York", 1);
     tzset();
-    const std::string under_eastern = render(t);
+    const std::string under_eastern = format_ymd_utc(t);
     if (saved_tz) {
         setenv("TZ", saved_tz, 1);
     } else {
@@ -355,6 +393,10 @@ TEST(CorpActionFrameConsistency, DateKeysAreUtcRegardlessOfHostTimezone) {
     EXPECT_EQ(under_eastern, "2026-08-10")
         << "date keys must not shift with the host timezone; localtime here "
            "would yield 2026-08-09 and mis-key every corp-action lookup";
+
+    // The round trip the window derivation depends on: a formatted key must parse
+    // back to the instant it came from.
+    EXPECT_EQ(parse_ymd_utc(format_ymd_utc(t)), t);
 }
 
 }  // namespace applier_frame

--- a/tests/live/corp_actions/test_audit_log.cpp
+++ b/tests/live/corp_actions/test_audit_log.cpp
@@ -906,3 +906,172 @@ TEST(LegacyImportDividendDetail, AnEmptyDetailListYieldsNothingForAnyType) {
                   nullptr);
     }
 }
+
+// ---------------------------------------------------------------------------
+// E2-F23 (audit option C-prime) -- dedup rows from a LATER pass must stop the run.
+//
+// A live run is correct exactly when the dedup rows and the T-1 position row come
+// from the SAME pass. Reset the book but not trading.corp_action_applied and it is
+// not: the event is skipped as "already applied" against a T-1 row that predates
+// it, T-1 is finalized in the wrong frame, and the position is marked against a
+// basis that never moved. Measured: BKNG 25:1, ex-date 2026-04-06, re-run of
+// 2026-04-07 over an un-reset dedup table, -4,824 of phantom unrealized P&L.
+//
+// Nothing downstream can catch it. The G3 basis/mark bound only inspects events
+// that were APPLIED, and a deduped event never enters that list. The existing
+// ex_date >= today detector cannot see it either: 2026-04-06 is safely in the
+// past. `applied_at` cannot, because an earlier chain always carries an earlier
+// wall clock. The RUN DATE of the writing pass is the only value that separates
+// an earlier pass from a later one.
+// ---------------------------------------------------------------------------
+
+namespace audit_run_date {
+
+using namespace trade_ngin;
+using audit_dedup::FakeDedupDatabase;
+using audit_dedup::make_temp_state_dir;
+
+namespace {
+
+PositionAdjustment split_adjustment(const std::string& symbol, const std::string& ex_date,
+                                    double factor) {
+    PositionAdjustment adj;
+    adj.symbol = symbol;
+    adj.event_date = ex_date;
+    adj.type = CorpActionType::SPLIT;
+    adj.event_value = factor;
+    return adj;
+}
+
+}  // namespace
+
+TEST(CorpActionRunDateGuard, ARowFromALaterPassRefusesTheRun) {
+    const auto state_dir = make_temp_state_dir("rundate_later");
+    auto db = std::make_shared<FakeDedupDatabase>();
+
+    // Pass 1 runs 2026-04-07 and applies the split, stamping its own run date.
+    {
+        CorporateActionsAuditLog first(state_dir.string(), db, "EQUITY_MR_PORTFOLIO",
+                                       "LIVE_EQUITY_MEAN_REVERSION", "EQUITY_MEAN_REVERSION");
+        first.set_run_date("2026-04-07");
+        ASSERT_FALSE(first.load().is_error());
+        first.record(split_adjustment("BKNG", "2026-04-06", 25.0));
+        ASSERT_TRUE(first.save());
+    }
+
+    // The book is re-seeded and 2026-04-07 is replayed, but the dedup table was
+    // not reset. This is the measured F23 case, and it must not start.
+    CorporateActionsAuditLog rerun(state_dir.string(), db, "EQUITY_MR_PORTFOLIO",
+                                   "LIVE_EQUITY_MEAN_REVERSION", "EQUITY_MEAN_REVERSION");
+    rerun.set_run_date("2026-04-07");
+    auto loaded = rerun.load();
+    ASSERT_TRUE(loaded.is_error())
+        << "a dedup row written by the run of 2026-04-07 must stop a second run of "
+           "2026-04-07: the T-1 book it would be trusted against is a different pass's";
+    const std::string what = loaded.error()->what();
+    EXPECT_NE(what.find("BKNG"), std::string::npos) << "the message must name the stale rows";
+    EXPECT_NE(what.find("2026-04-06"), std::string::npos) << "and their ex-dates";
+    EXPECT_NE(what.find("2026-04-07"), std::string::npos) << "and the run date that wrote them";
+
+    // The ex-date detector could never have caught this one.
+    EXPECT_LT(std::string("2026-04-06"), std::string("2026-04-07"))
+        << "the ex-date is in the past, which is why run_date is the load-bearing column";
+
+    // And a run of a LATER date, whose T-1 book really is this pass's output, is
+    // unaffected -- the guard must not block ordinary forward progress.
+    CorporateActionsAuditLog next_day(state_dir.string(), db, "EQUITY_MR_PORTFOLIO",
+                                      "LIVE_EQUITY_MEAN_REVERSION", "EQUITY_MEAN_REVERSION");
+    next_day.set_run_date("2026-04-08");
+    auto ok = next_day.load();
+    ASSERT_FALSE(ok.is_error()) << "forward-only running must stay unblocked";
+    EXPECT_TRUE(ok.value());
+    EXPECT_TRUE(next_day.is_applied("BKNG", "2026-04-06", CorpActionType::SPLIT));
+
+    std::filesystem::remove_all(state_dir);
+}
+
+TEST(CorpActionRunDateGuard, LegacyRowsWithNoRunDatePass) {
+    const auto state_dir = make_temp_state_dir("rundate_legacy");
+    auto db = std::make_shared<FakeDedupDatabase>();
+
+    // A row written before migration 005: no run date, so nothing is known about
+    // which pass wrote it. Refusing it would make the first run after the
+    // migration unstartable, on a table that is append-only and years old.
+    {
+        CorporateActionsAuditLog legacy(state_dir.string(), db, "EQUITY_MR_PORTFOLIO",
+                                        "LIVE_EQUITY_MEAN_REVERSION", "EQUITY_MEAN_REVERSION");
+        // No set_run_date: this is exactly the pre-005 write path.
+        ASSERT_FALSE(legacy.load().is_error());
+        legacy.record(split_adjustment("BKNG", "2026-04-06", 25.0));
+        ASSERT_TRUE(legacy.save());
+    }
+
+    CorporateActionsAuditLog after(state_dir.string(), db, "EQUITY_MR_PORTFOLIO",
+                                   "LIVE_EQUITY_MEAN_REVERSION", "EQUITY_MEAN_REVERSION");
+    after.set_run_date("2026-04-07");
+    auto loaded = after.load();
+    ASSERT_FALSE(loaded.is_error())
+        << "a NULL run_date means UNKNOWN, and unknown must not block the run";
+    EXPECT_TRUE(loaded.value());
+    EXPECT_TRUE(after.is_applied("BKNG", "2026-04-06", CorpActionType::SPLIT))
+        << "and the legacy row still dedups, or the migration would re-apply history";
+
+    std::filesystem::remove_all(state_dir);
+}
+
+TEST(CorpActionRunDateGuard, StampOnlyLetsASecondLogInTheSameRunProceed) {
+    // The class-3 lifecycle log opens AFTER the class-1 block has committed this
+    // run's rows. Enforcing there would make the run refuse its own output.
+    const auto state_dir = make_temp_state_dir("rundate_stamponly");
+    auto db = std::make_shared<FakeDedupDatabase>();
+
+    CorporateActionsAuditLog class1(state_dir.string(), db, "EQUITY_MR_PORTFOLIO",
+                                    "LIVE_EQUITY_MEAN_REVERSION", "EQUITY_MEAN_REVERSION");
+    class1.set_run_date("2026-04-07");
+    ASSERT_FALSE(class1.load().is_error());
+    class1.record(split_adjustment("BKNG", "2026-04-06", 25.0));
+    ASSERT_TRUE(class1.save());
+
+    CorporateActionsAuditLog class3(state_dir.string(), db, "EQUITY_MR_PORTFOLIO",
+                                    "LIVE_EQUITY_MEAN_REVERSION", "EQUITY_MEAN_REVERSION");
+    class3.set_run_date("2026-04-07",
+                        CorporateActionsAuditLog::RunDateCheck::StampOnly);
+    auto loaded = class3.load();
+    ASSERT_FALSE(loaded.is_error())
+        << "the same run's own rows must not be mistaken for a later pass's";
+
+    // Enforce on the same state is the failing case -- which is what proves the
+    // mode is doing something rather than being decoration.
+    CorporateActionsAuditLog enforcing(state_dir.string(), db, "EQUITY_MR_PORTFOLIO",
+                                       "LIVE_EQUITY_MEAN_REVERSION", "EQUITY_MEAN_REVERSION");
+    enforcing.set_run_date("2026-04-07");
+    EXPECT_TRUE(enforcing.load().is_error());
+
+    std::filesystem::remove_all(state_dir);
+}
+
+TEST(CorpActionRunDateGuard, AnUnstampedRunNeitherStampsNorChecks) {
+    // Pre-005 behaviour is preserved exactly for any caller that sets no run date:
+    // rows are written with no stamp and no load is ever refused. This is what the
+    // file-backed tests and every other caller rely on.
+    const auto state_dir = make_temp_state_dir("rundate_none");
+    auto db = std::make_shared<FakeDedupDatabase>();
+
+    CorporateActionsAuditLog stamped(state_dir.string(), db, "EQUITY_MR_PORTFOLIO",
+                                     "LIVE_EQUITY_MEAN_REVERSION", "EQUITY_MEAN_REVERSION");
+    stamped.set_run_date("2026-04-07");
+    ASSERT_FALSE(stamped.load().is_error());
+    stamped.record(split_adjustment("BKNG", "2026-04-06", 25.0));
+    ASSERT_TRUE(stamped.save());
+
+    CorporateActionsAuditLog unstamped(state_dir.string(), db, "EQUITY_MR_PORTFOLIO",
+                                       "LIVE_EQUITY_MEAN_REVERSION", "EQUITY_MEAN_REVERSION");
+    auto loaded = unstamped.load();
+    EXPECT_FALSE(loaded.is_error())
+        << "a caller that sets no run date must behave exactly as it did before 005";
+    EXPECT_TRUE(unstamped.is_applied("BKNG", "2026-04-06", CorpActionType::SPLIT));
+
+    std::filesystem::remove_all(state_dir);
+}
+
+}  // namespace audit_run_date

--- a/tests/live/corp_actions/test_audit_log.cpp
+++ b/tests/live/corp_actions/test_audit_log.cpp
@@ -819,3 +819,90 @@ TEST(CorpActionsUltrareviewFixes, AtomicSaveOverwritesStaleTempFile) {
 }
 
 }  // namespace audit_ex_date_cash
+
+// ──────────────────────────────────────────────────────────────────────────
+// E2-F39 / BA-15 -- the legacy state-file import must key dividend detail on
+// the ACTION TYPE too, not just (symbol, ex_date).
+//
+// The file records applied events as (symbol, ex_date, action_type) but carries
+// dividend detail as (symbol, ex_date) only -- DividendEvent has no type field,
+// because everything in that list IS a dividend. The import matched on the pair
+// alone, so a SPLIT sharing an ex-date with a DIVIDEND inherited the dividend's
+// qty_held / dividend_per_share / total_cash. The same cash then shows up twice
+// in cumulative dividend income: on the dividend row that paid it and on the
+// split row that paid nothing.
+//
+// Same-day split-and-dividend is not exotic: a company declaring a split
+// commonly sets its ex-date to a dividend ex-date so the two settle together.
+// ──────────────────────────────────────────────────────────────────────────
+
+using trade_ngin::CorpActionType;
+using trade_ngin::CorporateActionsAuditLog;
+using DividendEvent = CorporateActionsAuditLog::DividendEvent;
+
+TEST(LegacyImportDividendDetail, ASplitSharingAnExDateDoesNotInheritTheDividendCash) {
+    const std::vector<DividendEvent> events{
+        {"AAPL", "2026-08-10", /*qty*/ 250.0, /*dps*/ 0.24, /*cash*/ 60.0}};
+
+    // The dividend gets its detail.
+    const auto* div = CorporateActionsAuditLog::dividend_detail_for(
+        "AAPL", "2026-08-10", CorpActionType::DIVIDEND, events);
+    ASSERT_NE(div, nullptr) << "a dividend must still receive its own detail";
+    EXPECT_DOUBLE_EQ(div->total_cash, 60.0);
+    EXPECT_DOUBLE_EQ(div->qty_held, 250.0);
+    EXPECT_DOUBLE_EQ(div->dividend_per_share, 0.24);
+
+    // The split on the SAME symbol and SAME ex-date gets nothing.
+    EXPECT_EQ(CorporateActionsAuditLog::dividend_detail_for(
+                  "AAPL", "2026-08-10", CorpActionType::SPLIT, events),
+              nullptr)
+        << "a split pays no dividend; inheriting 60.0 here double-counts the cash";
+
+    // Neither do the other non-paying classes.
+    EXPECT_EQ(CorporateActionsAuditLog::dividend_detail_for(
+                  "AAPL", "2026-08-10", CorpActionType::ADR_SPLIT, events),
+              nullptr);
+    EXPECT_EQ(CorporateActionsAuditLog::dividend_detail_for(
+                  "AAPL", "2026-08-10", CorpActionType::TERMINATION, events),
+              nullptr);
+    EXPECT_EQ(CorporateActionsAuditLog::dividend_detail_for(
+                  "AAPL", "2026-08-10", CorpActionType::UNKNOWN, events),
+              nullptr);
+}
+
+TEST(LegacyImportDividendDetail, DetailStillMatchesOnSymbolAndExDate) {
+    const std::vector<DividendEvent> events{
+        {"AAPL", "2026-08-10", 250.0, 0.24, 60.0},
+        {"MSFT", "2026-08-10", 80.0, 0.75, 60.0},   // same cash, different symbol
+        {"AAPL", "2026-05-11", 250.0, 0.24, 60.0},  // same symbol, different date
+    };
+
+    const auto* a = CorporateActionsAuditLog::dividend_detail_for(
+        "AAPL", "2026-08-10", CorpActionType::DIVIDEND, events);
+    ASSERT_NE(a, nullptr);
+    EXPECT_EQ(a->symbol, "AAPL");
+    EXPECT_EQ(a->ex_date, "2026-08-10");
+    EXPECT_DOUBLE_EQ(a->qty_held, 250.0);
+
+    const auto* m = CorporateActionsAuditLog::dividend_detail_for(
+        "MSFT", "2026-08-10", CorpActionType::DIVIDEND, events);
+    ASSERT_NE(m, nullptr);
+    EXPECT_DOUBLE_EQ(m->dividend_per_share, 0.75) << "the right row, not the first one";
+
+    // A dividend with no detail in the file is not an error -- it simply carries none.
+    EXPECT_EQ(CorporateActionsAuditLog::dividend_detail_for(
+                  "TMUS", "2026-08-10", CorpActionType::DIVIDEND, events),
+              nullptr);
+    EXPECT_EQ(CorporateActionsAuditLog::dividend_detail_for(
+                  "AAPL", "2026-08-11", CorpActionType::DIVIDEND, events),
+              nullptr);
+}
+
+TEST(LegacyImportDividendDetail, AnEmptyDetailListYieldsNothingForAnyType) {
+    const std::vector<DividendEvent> none;
+    for (auto t : {CorpActionType::DIVIDEND, CorpActionType::SPLIT,
+                   CorpActionType::ADR_SPLIT, CorpActionType::TERMINATION}) {
+        EXPECT_EQ(CorporateActionsAuditLog::dividend_detail_for("AAPL", "2026-08-10", t, none),
+                  nullptr);
+    }
+}

--- a/tests/live/corp_actions/test_corp_action_query_bounds_db.cpp
+++ b/tests/live/corp_actions/test_corp_action_query_bounds_db.cpp
@@ -456,3 +456,55 @@ TEST_F(CorpActionQueryBoundsDbTest, AMissingBarOnAClass1DateIsOnlyEverADividend)
     // "No price history exists for held symbol(s)" ERROR is load-bearing.
     RecordProperty("missing_bar_dividends", static_cast<int>(missing_bar_dividends));
 }
+
+// ──────────────────────────────────────────────────────────────────────────
+// E4 item 3 -- against the real table.
+//
+// The pure tests in test_effect_classes.cpp pin what the status says for a given
+// measurement. This one pins that a measurement HAPPENS: the reported date has
+// to equal what the server holds, which a literal cannot do once the feed moves.
+// ──────────────────────────────────────────────────────────────────────────
+
+#include "trade_ngin/live/corp_action_feed_status.hpp"
+
+TEST_F(CorpActionQueryBoundsDbTest, FrozenAfterDateIsMeasuredNotHardcoded) {
+    const std::string as_of = "2026-09-03";
+
+    auto measured = db_->get_corp_action_feed_last_date(as_of);
+    ASSERT_TRUE(measured.is_ok()) << measured.error()->what();
+
+    // Independently derived, not read back from the same accessor.
+    pqxx::connection c(conn_string_);
+    pqxx::work w(c);
+    const std::string expected =
+        w.exec_params("SELECT COALESCE(max(date), '') FROM equities_data.corporate_action "
+                      "WHERE date <= $1",
+                      as_of)[0][0]
+            .c_str();
+    w.commit();
+
+    ASSERT_FALSE(expected.empty()) << "the table is empty; this proves nothing";
+    EXPECT_EQ(measured.value(), expected)
+        << "the reported last-row date is not what the table holds -- a literal cannot "
+           "track a revived feed";
+
+    // The audit's assertion: it is at least as new as the compiled-in date, and
+    // the accessor is the thing that would move if the feed were backfilled.
+    EXPECT_GE(measured.value(), std::string(kCorpActionTableFrozenAfter))
+        << "the feed appears to have LOST rows since " << kCorpActionTableFrozenAfter
+        << "; that is a data incident, not a code defect";
+
+    const auto status = assess_corp_action_feed(measured.value(), as_of);
+    EXPECT_TRUE(status.measured);
+    EXPECT_EQ(status.frozen, expected < as_of);
+
+    // The upper bound matters: the table carries tickerchange placeholders dated
+    // 2027-07-18, and an unbounded max() would report a feed running ahead of the
+    // run -- which would make `frozen` false and the WARN text nonsense.
+    auto unbounded = db_->get_corp_action_feed_last_date();
+    ASSERT_TRUE(unbounded.is_ok()) << unbounded.error()->what();
+    EXPECT_GT(unbounded.value(), measured.value())
+        << "the future-dated rows are what the as-of bound exists to exclude";
+    EXPECT_FALSE(assess_corp_action_feed(unbounded.value(), as_of).frozen)
+        << "and this is the wrong answer the bound prevents";
+}

--- a/tests/live/corp_actions/test_corp_action_query_bounds_db.cpp
+++ b/tests/live/corp_actions/test_corp_action_query_bounds_db.cpp
@@ -1,0 +1,187 @@
+// tests/live/corp_actions/test_corp_action_query_bounds_db.cpp
+//
+// E3 G6-4 / G6-5 / V4-1 -- the three things that can go wrong at the BOUNDARY of
+// equities_data.corporate_action, all of which need the real table to show anything:
+//
+//   G6-4  `date` is TEXT. The reader used `date::date BETWEEN $3::date AND $4::date`,
+//         which casts every row in the scan and dies on the first value that is not a
+//         parseable date. ISO-8601 strings sort lexicographically, so a plain text
+//         comparison selects exactly the same rows with no cast at all -- and it is
+//         index-native on (ticker, date).
+//   G6-5  Future-dated rows exist (SBDS 2027-07-18). The upper bound is what keeps them
+//         out of a 2026 run; nothing pinned that it was actually applied.
+//   V4-1  A class-1 row can exist in this table with NO corresponding move on the bar.
+//         Class-1 effects are sourced PER BAR, so the applier is a silent no-op on such
+//         a row: LEN's 2025-02-07 Millrose spinoff is in corporate_action with ratio 0.5
+//         while the LEN bar that day carries split_factor 1 and div_cash 0.
+//
+// Read-only. Nothing here writes.
+//
+// Reachability gate matches tests/live/corp_actions/test_denominator_range_db.cpp:
+//   * TRADE_NGIN_REQUIRE_DB=1 -- unreachable database FAILS rather than skips.
+//   * unset -- skip (local dev without a server).
+
+#include <gtest/gtest.h>
+#include <pqxx/pqxx>
+
+#include <algorithm>
+#include <cstdlib>
+#include <filesystem>
+#include <fstream>
+#include <memory>
+#include <nlohmann/json.hpp>
+#include <set>
+#include <string>
+#include <vector>
+
+#include "trade_ngin/data/postgres_database.hpp"
+#include "trade_ngin/live/corporate_actions_classification.hpp"
+
+using namespace trade_ngin;
+
+namespace {
+
+std::string discover_connection_string() {
+    namespace fs = std::filesystem;
+    fs::path dir = fs::current_path();
+    for (int i = 0; i < 8 && !dir.empty(); ++i) {
+        fs::path candidate = dir / "config" / "defaults.json";
+        if (fs::exists(candidate)) {
+            try {
+                std::ifstream in(candidate);
+                nlohmann::json j = nlohmann::json::parse(in);
+                const auto& d = j.at("database");
+                return "postgresql://" + d.at("username").get<std::string>() + ":" +
+                       d.at("password").get<std::string>() + "@" +
+                       d.at("host").get<std::string>() + ":" + d.at("port").get<std::string>() +
+                       "/" + d.at("name").get<std::string>();
+            } catch (const std::exception&) {
+                return {};
+            }
+        }
+        dir = dir.parent_path();
+    }
+    return {};
+}
+
+}  // namespace
+
+class CorpActionQueryBoundsDbTest : public ::testing::Test {
+protected:
+    void SetUp() override {
+        const bool require_db = [] {
+            const char* v = std::getenv("TRADE_NGIN_REQUIRE_DB");
+            return v && std::string(v) == "1";
+        }();
+
+        conn_string_ = discover_connection_string();
+        if (conn_string_.empty()) {
+            if (require_db) {
+                FAIL() << "TRADE_NGIN_REQUIRE_DB=1 but config/defaults.json is not reachable, "
+                          "so the corporate_action query bounds go unverified";
+            }
+            GTEST_SKIP() << "config/defaults.json not reachable; no database to exercise";
+        }
+        db_ = std::make_shared<PostgresDatabase>(conn_string_);
+        auto connected = db_->connect();
+        if (connected.is_error() || !db_->is_connected()) {
+            if (require_db) {
+                FAIL() << "TRADE_NGIN_REQUIRE_DB=1 but the database is unreachable, so the "
+                          "corporate_action query bounds go unverified";
+            }
+            GTEST_SKIP() << "database unreachable; these bounds need the real table";
+        }
+    }
+
+    void TearDown() override {
+        if (db_ && db_->is_connected()) db_->disconnect();
+    }
+
+    std::string conn_string_;
+    std::shared_ptr<PostgresDatabase> db_;
+};
+
+// ──────────────────────────────────────────────────────────────────────────
+// G6-4
+// ──────────────────────────────────────────────────────────────────────────
+
+// The precondition the text comparison rests on. Every value in the column is a
+// 10-character ISO date, so `>=` / `<=` on text orders identically to a date
+// comparison. If a single row ever arrives in another shape this fails, and the
+// text comparison silently starts selecting the wrong set -- which is exactly
+// the day someone needs to know.
+TEST_F(CorpActionQueryBoundsDbTest, EveryDateValueIsISO8601) {
+    pqxx::connection c(conn_string_);
+    pqxx::work w(c);
+    const auto total =
+        w.exec("SELECT count(*) FROM equities_data.corporate_action")[0][0].as<long>();
+    const auto non_iso =
+        w.exec("SELECT count(*) FROM equities_data.corporate_action "
+               "WHERE date !~ '^[0-9]{4}-[0-9]{2}-[0-9]{2}$'")[0][0]
+            .as<long>();
+    w.commit();
+
+    ASSERT_GT(total, 100000) << "the table is not loaded; this proves nothing about it";
+    EXPECT_EQ(non_iso, 0)
+        << "a non-ISO value in a TEXT date column breaks BOTH readings: the old "
+           "`date::date` cast errors on it, and a lexicographic comparison misplaces it";
+}
+
+// The row that motivated the change: it must still come back, verbatim, through
+// the production accessor. A range whose ends do not straddle the row proves the
+// bound is a bound and not an accident.
+TEST_F(CorpActionQueryBoundsDbTest, TextRangeReturnsTheLenSpinoffRow) {
+    auto in_range = db_->get_corporate_actions({"LEN"}, "2025-02-01", "2025-02-28", {"spinoff"});
+    ASSERT_TRUE(in_range.is_ok()) << in_range.error()->what();
+    ASSERT_EQ(in_range.value().size(), 1u)
+        << "LEN's 2025-02-07 Millrose spinoff is the row this range exists to select";
+    EXPECT_EQ(in_range.value()[0].date_str, "2025-02-07");
+    EXPECT_EQ(in_range.value()[0].action, "spinoff");
+    EXPECT_EQ(in_range.value()[0].ticker, "LEN");
+    EXPECT_EQ(in_range.value()[0].contra_ticker, "MRP");
+    EXPECT_DOUBLE_EQ(in_range.value()[0].value, 0.5);
+
+    // Both ends are INCLUSIVE, and one day inside either end excludes the row.
+    auto on_both_bounds =
+        db_->get_corporate_actions({"LEN"}, "2025-02-07", "2025-02-07", {"spinoff"});
+    ASSERT_TRUE(on_both_bounds.is_ok()) << on_both_bounds.error()->what();
+    EXPECT_EQ(on_both_bounds.value().size(), 1u) << "the bounds are inclusive at both ends";
+
+    auto after_start = db_->get_corporate_actions({"LEN"}, "2025-02-08", "2025-02-28", {"spinoff"});
+    ASSERT_TRUE(after_start.is_ok()) << after_start.error()->what();
+    EXPECT_TRUE(after_start.value().empty()) << "start bound is not applied";
+
+    auto before_end = db_->get_corporate_actions({"LEN"}, "2025-02-01", "2025-02-06", {"spinoff"});
+    ASSERT_TRUE(before_end.is_ok()) << before_end.error()->what();
+    EXPECT_TRUE(before_end.value().empty()) << "end bound is not applied";
+}
+
+// Lexicographic and calendar ordering must agree across the shapes that break
+// naive string comparison elsewhere: a year boundary, a month boundary, and the
+// zero-padded single-digit month/day that make ISO-8601 sortable in the first
+// place.
+TEST_F(CorpActionQueryBoundsDbTest, TextComparisonSelectsTheSameSetACastWould) {
+    pqxx::connection c(conn_string_);
+    pqxx::work w(c);
+    // The two readings, side by side, over a window that spans a year end.
+    auto cast_rows = w.exec(
+        "SELECT ticker, date, action FROM equities_data.corporate_action "
+        "WHERE ticker = ANY(ARRAY['AAPL','MSFT','LEN','SBDS','DD']) "
+        "  AND date::date BETWEEN DATE '2024-12-15' AND DATE '2025-03-15' "
+        "ORDER BY date, ticker, action");
+    auto text_rows = w.exec(
+        "SELECT ticker, date, action FROM equities_data.corporate_action "
+        "WHERE ticker = ANY(ARRAY['AAPL','MSFT','LEN','SBDS','DD']) "
+        "  AND date >= '2024-12-15' AND date <= '2025-03-15' "
+        "ORDER BY date, ticker, action");
+    w.commit();
+
+    ASSERT_GT(cast_rows.size(), 0u) << "an empty window compares two empty sets";
+    ASSERT_EQ(cast_rows.size(), text_rows.size())
+        << "the text comparison changed WHICH rows the reader sees";
+    for (size_t i = 0; i < cast_rows.size(); ++i) {
+        EXPECT_EQ(std::string(cast_rows[i][0].c_str()), std::string(text_rows[i][0].c_str()));
+        EXPECT_EQ(std::string(cast_rows[i][1].c_str()), std::string(text_rows[i][1].c_str()));
+        EXPECT_EQ(std::string(cast_rows[i][2].c_str()), std::string(text_rows[i][2].c_str()));
+    }
+}

--- a/tests/live/corp_actions/test_corp_action_query_bounds_db.cpp
+++ b/tests/live/corp_actions/test_corp_action_query_bounds_db.cpp
@@ -246,3 +246,213 @@ TEST_F(CorpActionQueryBoundsDbTest, TheFutureRowsExistAndAreDatedBeyondAnyRun) {
         << "only the tickerchange placeholders are future-dated; if a real event ever is, "
            "every reader's as-of bound becomes load-bearing for more than renames";
 }
+
+
+// ──────────────────────────────────────────────────────────────────────────
+// V4-1 -- the LEN/Millrose hole.
+//
+// Class-1 (price-restating) effects are sourced PER BAR: the applier reads
+// ohlcv_1d.split_factor and ohlcv_1d.div_cash via get_per_bar_corporate_actions,
+// never corporate_action.value. equities_data.corporate_action is consulted only
+// for class-2 renames and class-3 deal terms. So a class-1 row whose bar carries
+// no move is applied by NOTHING -- no error, no WARN, no dedup row, no deferral.
+// The position carries an unrestated cost basis across a real event, forever.
+//
+// LEN 2025-02-07 is that shape: corporate_action holds `spinoff` MRP 0.5 and
+// `spinoffdividend` 11.495, while the LEN bar for that day carries split_factor 1
+// and div_cash 0 -- and the close fell 127.25 -> 121.94.
+//
+// Two distinct shapes come out of the same join and must not be conflated:
+//
+//   (a) a bar EXISTS on the ex-date and is flat  -- V4-1. Nothing downstream can
+//       ever notice, because the applier only sees bars and this bar says
+//       "nothing happened". This is the failing assertion below.
+//   (b) NO bar exists on the ex-date -- the applier has no input and the runner
+//       already says so out loud ("No price history exists for held symbol(s)")
+//       and leaves the event unapplied for a later run to pick up. Not silent,
+//       and not this test's subject; what IS pinned is that this shape only ever
+//       happens to dividends. A missing bar on a split or spinoff date would mean
+//       a share count that never adjusts.
+// ──────────────────────────────────────────────────────────────────────────
+
+namespace {
+
+// Bars carry split_factor/div_cash reliably over the era a live book can reach
+// (this book's positions start 2026-04-01). Before 2020 the rows are dominated
+// by ticker-reuse artefacts -- DD's 2018-19 dividends belong to DowDuPont, whose
+// history now lives under DD1 -- which say nothing about the applier.
+constexpr const char* kBarEraFloor = "2020-01-01";
+
+// (ticker, date, action) triples KNOWN to be silent and accepted. The allowlist
+// is the point of the test: a corporate action nothing applies is tolerable only
+// once somebody has looked at it and written down why.
+const std::set<std::vector<std::string>>& allowlisted_silent_class1() {
+    static const std::set<std::vector<std::string>> a = {
+        // The Millrose (MRP) spin-off. Tiingo encoded it in neither split_factor
+        // nor div_cash on the LEN bar, so the class-1 applier cannot see it at
+        // all. Receipt of the child is E4 NEW-5(B); until that lands, LEN is not
+        // in the traded universe and this row is inert. Both vendor labels for
+        // the one event are listed -- corporate_action carries a `spinoff` row
+        // (ratio 0.5) and a `spinoffdividend` row (11.495) for the same date.
+        {"LEN", "2025-02-07", "spinoff"},
+        {"LEN", "2025-02-07", "spinoffdividend"},
+    };
+    return a;
+}
+
+// The symbols a live equity run can reach: every symbol named by an equity
+// portfolio config on this machine, plus the symbols this tripwire exists to
+// keep watching. LEN is not in the configured book -- it is here because it is
+// the proven instance of the failure, and dropping it would make the test
+// green by looking away.
+std::vector<std::string> tripwire_universe() {
+    namespace fs = std::filesystem;
+    std::set<std::string> symbols = {"LEN"};
+
+    fs::path dir = fs::current_path();
+    for (int i = 0; i < 8 && !dir.empty(); ++i) {
+        bool found_any = false;
+        for (const char* rel : {"config/portfolios/equity_mr/portfolio.json",
+                                "config_template/portfolios/equity_mr/portfolio.json"}) {
+            fs::path candidate = dir / rel;
+            if (!fs::exists(candidate)) continue;
+            found_any = true;
+            try {
+                std::ifstream in(candidate);
+                nlohmann::json j = nlohmann::json::parse(in);
+                for (const auto& [name, def] : j.at("strategies").items()) {
+                    (void)name;
+                    if (!def.contains("symbols")) continue;
+                    for (const auto& s : def.at("symbols")) symbols.insert(s.get<std::string>());
+                }
+            } catch (const std::exception&) {
+                // A malformed config must not silently shrink the scan set; the
+                // size assertion in the test catches that.
+            }
+        }
+        if (found_any) break;
+        dir = dir.parent_path();
+    }
+    return std::vector<std::string>(symbols.begin(), symbols.end());
+}
+
+struct SilentClass1Row {
+    std::string ticker, date, action;
+    bool has_bar = false;
+    double split_factor = 1.0;
+    double div_cash = 0.0;
+};
+
+std::vector<SilentClass1Row> scan_silent_class1(const std::string& conn,
+                                                const std::vector<std::string>& universe) {
+    pqxx::connection c(conn);
+    pqxx::work w(c);
+    auto rows = w.exec(
+        "SELECT ca.ticker, ca.date, ca.action, "
+        "       (b.symbol IS NOT NULL) AS has_bar, "
+        "       COALESCE(b.split_factor, 1) AS split_factor, "
+        "       COALESCE(b.div_cash, 0) AS div_cash "
+        "FROM equities_data.corporate_action ca "
+        "LEFT JOIN equities_data.ohlcv_1d b "
+        "       ON b.symbol = ca.ticker AND b.time::date = ca.date::date "
+        "WHERE ca.ticker = ANY($1) AND ca.action = ANY($2) AND ca.date >= $3 "
+        "ORDER BY ca.date, ca.ticker, ca.action",
+        pqxx::params{universe, vendor_labels_for_class(CorpActionClass::PRICE_RESTATING),
+                     std::string(kBarEraFloor)});
+    w.commit();
+
+    std::vector<SilentClass1Row> out;
+    for (const auto& r : rows) {
+        SilentClass1Row s;
+        s.ticker = r["ticker"].c_str();
+        s.date = r["date"].c_str();
+        s.action = r["action"].c_str();
+        s.has_bar = r["has_bar"].as<bool>();
+        s.split_factor = r["split_factor"].as<double>();
+        s.div_cash = r["div_cash"].as<double>();
+        if (s.has_bar && (s.split_factor != 1.0 || s.div_cash != 0.0)) continue;  // applied
+        out.push_back(std::move(s));
+    }
+    return out;
+}
+
+}  // namespace
+
+// (a) The silent no-op. A bar exists, the applier reads it, and it says nothing
+// happened.
+TEST_F(CorpActionQueryBoundsDbTest, NoSilentlyUnappliedClass1RowInTheLiveUniverse) {
+    const auto universe = tripwire_universe();
+    ASSERT_GE(universe.size(), 5u)
+        << "no equity portfolio config was found; scanning one symbol proves nothing";
+
+    const auto silent = scan_silent_class1(conn_string_, universe);
+
+    std::vector<std::string> unexplained;
+    for (const auto& s : silent) {
+        if (!s.has_bar) continue;  // shape (b), pinned by the next test
+        if (allowlisted_silent_class1().count({s.ticker, s.date, s.action})) continue;
+        unexplained.push_back(s.ticker + " " + s.date + " " + s.action +
+                              " (bar present, split_factor=" + std::to_string(s.split_factor) +
+                              " div_cash=" + std::to_string(s.div_cash) + ")");
+    }
+
+    std::string detail;
+    for (const auto& u : unexplained) detail += "\n    " + u;
+    EXPECT_TRUE(unexplained.empty())
+        << unexplained.size()
+        << " class-1 corporate_action row(s) have a bar on the ex-date that carries no "
+           "move, so the applier is a silent no-op and the cost basis is never restated:"
+        << detail
+        << "\n  Either the bar data is wrong (fix the feed) or the row is genuinely "
+           "inapplicable (add it to allowlisted_silent_class1 with the reason).";
+}
+
+// The allowlist must never become a rubber stamp: every entry has to name a row
+// that is really there and really silent. An entry that stops matching means the
+// data moved and the exemption is now hiding something else.
+TEST_F(CorpActionQueryBoundsDbTest, EveryAllowlistedSilentRowStillExistsAndIsStillSilent) {
+    ASSERT_FALSE(allowlisted_silent_class1().empty())
+        << "an empty allowlist makes the tripwire above prove nothing about LEN";
+
+    const auto silent = scan_silent_class1(conn_string_, tripwire_universe());
+    std::set<std::vector<std::string>> observed;
+    for (const auto& s : silent) {
+        if (s.has_bar) observed.insert({s.ticker, s.date, s.action});
+    }
+    for (const auto& entry : allowlisted_silent_class1()) {
+        EXPECT_EQ(observed.count(entry), 1u)
+            << "allowlisted " << entry[0] << " " << entry[1] << " " << entry[2]
+            << " is no longer a silent class-1 row -- remove the exemption rather than "
+               "leaving it to cover a future one";
+    }
+}
+
+// (b) The other shape: no bar at all on the ex-date. The runner is loud about
+// this one and retries it, so it is not V4-1 -- but it must stay confined to
+// dividends. A split or spinoff whose ex-date has no bar means a share count
+// that never adjusts, which no later run can repair.
+TEST_F(CorpActionQueryBoundsDbTest, AMissingBarOnAClass1DateIsOnlyEverADividend) {
+    const auto silent = scan_silent_class1(conn_string_, tripwire_universe());
+
+    std::vector<std::string> quantity_changing;
+    size_t missing_bar_dividends = 0;
+    for (const auto& s : silent) {
+        if (s.has_bar) continue;
+        if (s.action == "dividend") {
+            ++missing_bar_dividends;
+            continue;
+        }
+        quantity_changing.push_back(s.ticker + " " + s.date + " " + s.action);
+    }
+
+    std::string detail;
+    for (const auto& q : quantity_changing) detail += "\n    " + q;
+    EXPECT_TRUE(quantity_changing.empty())
+        << "a quantity-changing class-1 event has no bar on its ex-date, so the share "
+           "count is never adjusted and no later run can repair it:"
+        << detail;
+
+    // Recorded, not asserted to be zero: these are real and are why the runner's
+    // "No price history exists for held symbol(s)" ERROR is load-bearing.
+    RecordProperty("missing_bar_dividends", static_cast<int>(missing_bar_dividends));
+}

--- a/tests/live/corp_actions/test_corp_action_query_bounds_db.cpp
+++ b/tests/live/corp_actions/test_corp_action_query_bounds_db.cpp
@@ -185,3 +185,64 @@ TEST_F(CorpActionQueryBoundsDbTest, TextComparisonSelectsTheSameSetACastWould) {
         EXPECT_EQ(std::string(cast_rows[i][2].c_str()), std::string(text_rows[i][2].c_str()));
     }
 }
+
+// ──────────────────────────────────────────────────────────────────────────
+// G6-5 -- the UPPER bound is what keeps future-dated rows out of a run.
+//
+// equities_data.corporate_action carries rows dated in the future: SBDS has a
+// tickerchangeto/from pair on 2027-07-18 (contra DTCB), placeholders the vendor
+// emits ahead of an announced change. Every reader passes the run's as-of date
+// as the end bound, so they are invisible today. Nothing pinned that. If the
+// end bound is ever widened -- a "load everything, filter later" refactor, a
+// bulk backfill -- a 2026 run would act on a 2027 rename.
+// ──────────────────────────────────────────────────────────────────────────
+
+TEST_F(CorpActionQueryBoundsDbTest, FutureDatedRowsAreExcludedByTheEndBound) {
+    const auto tickerchange = vendor_labels_for_class(CorpActionClass::SERIES_CONTINUITY);
+    ASSERT_FALSE(tickerchange.empty());
+
+    // A run bounded at its own as-of date sees nothing.
+    auto bounded = db_->get_corporate_actions({"SBDS"}, "2020-01-01", "2026-09-03", tickerchange);
+    ASSERT_TRUE(bounded.is_ok()) << bounded.error()->what();
+    for (const auto& r : bounded.value()) {
+        EXPECT_LE(r.date_str, "2026-09-03")
+            << "a row dated after the run leaked past the end bound: " << r.ticker << " "
+            << r.date_str << " " << r.action;
+    }
+
+    // The rows are really there -- widening the bound returns them, which is what
+    // makes the assertion above a bound and not an empty table.
+    auto widened = db_->get_corporate_actions({"SBDS"}, "2020-01-01", "2027-12-31", tickerchange);
+    ASSERT_TRUE(widened.is_ok()) << widened.error()->what();
+    size_t future_rows = 0;
+    for (const auto& r : widened.value()) {
+        if (r.date_str > "2026-09-03") ++future_rows;
+    }
+    EXPECT_EQ(future_rows, 2u)
+        << "SBDS's 2027-07-18 tickerchangeto/from pair is the fixture this pin rests on; "
+           "if the data changed, re-pick a future-dated symbol rather than deleting the test";
+    EXPECT_GT(widened.value().size(), bounded.value().size())
+        << "the two bounds must not return the same set, or the bound is doing nothing";
+}
+
+// The same statement one layer down, independent of the accessor: the bound is a
+// property of the query, and a lexicographic upper bound on ISO text orders the
+// same way a date bound does across the year boundary the future rows sit past.
+TEST_F(CorpActionQueryBoundsDbTest, TheFutureRowsExistAndAreDatedBeyondAnyRun) {
+    pqxx::connection c(conn_string_);
+    pqxx::work w(c);
+    auto rows = w.exec(
+        "SELECT date, action FROM equities_data.corporate_action "
+        "WHERE ticker = 'SBDS' AND date > '2026-12-31' ORDER BY date, action");
+    const auto max_real = w.exec(
+        "SELECT max(date) FROM equities_data.corporate_action "
+        "WHERE action NOT IN ('tickerchangeto','tickerchangefrom')")[0][0].c_str();
+    w.commit();
+
+    ASSERT_EQ(rows.size(), 2u);
+    EXPECT_EQ(std::string(rows[0][0].c_str()), "2027-07-18");
+    EXPECT_EQ(std::string(rows[1][0].c_str()), "2027-07-18");
+    EXPECT_LT(std::string(max_real), "2027-01-01")
+        << "only the tickerchange placeholders are future-dated; if a real event ever is, "
+           "every reader's as-of bound becomes load-bearing for more than renames";
+}

--- a/tests/live/corp_actions/test_denominator_range_db.cpp
+++ b/tests/live/corp_actions/test_denominator_range_db.cpp
@@ -183,3 +183,58 @@ TEST_F(DenominatorRangeDbTest, EqualEndpointsReturnAtMostOneDay) {
         EXPECT_LE(by_date.size(), 1u);
     }
 }
+
+// ──────────────────────────────────────────────────────────────────────────
+// BA-8 / C-1 D12 -- get_delisting_dates must not hand a 2026 run a 2008 row.
+//
+// delisting_date is keyed on the TICKER and the reader takes max() over the
+// symbol's entire history, so a reused ticker inherits the dead company's
+// delisting. The runner's bars-contradict guard needs a bar to contradict with:
+// delisting_is_stale() is false when last_bar_date is empty, which is exactly
+// the symbol that stopped printing. The floor closes it at the source.
+//
+// Read-only against real rows. HPC and MER are real delistings in this database
+// (2008-11-24 and 2008-12-31), which is what makes the bound worth asserting.
+// ──────────────────────────────────────────────────────────────────────────
+class DelistingFloorDbTest : public DenominatorRangeDbTest {};
+
+TEST_F(DelistingFloorDbTest, DateFloorExcludesADecadeOldDelisting) {
+    const std::vector<std::string> tickers{"HPC", "MER"};
+
+    // No floor: the historical rows come back, which is the pre-BA-8 behaviour
+    // and the input the runner used to act on.
+    auto unbounded = db_->get_delisting_dates(tickers);
+    ASSERT_TRUE(unbounded.is_ok()) << unbounded.error()->what();
+    ASSERT_EQ(unbounded.value().size(), 2u)
+        << "both tickers must actually carry a delisting row, or this test proves nothing";
+    EXPECT_EQ(unbounded.value().at("HPC"), "2008-11-24");
+    EXPECT_EQ(unbounded.value().at("MER"), "2008-12-31");
+
+    // With a floor a 2026 run cannot see them at all.
+    auto bounded = db_->get_delisting_dates(tickers, "2026-06-01");
+    ASSERT_TRUE(bounded.is_ok()) << bounded.error()->what();
+    EXPECT_TRUE(bounded.value().empty())
+        << "a delisting 18 years before the run date must not reach a live book";
+
+    // The floor is INCLUSIVE, so a delisting exactly on the bound survives.
+    auto on_bound = db_->get_delisting_dates({"HPC"}, "2008-11-24");
+    ASSERT_TRUE(on_bound.is_ok()) << on_bound.error()->what();
+    ASSERT_EQ(on_bound.value().size(), 1u) << "the bound is inclusive";
+    EXPECT_EQ(on_bound.value().at("HPC"), "2008-11-24");
+
+    // One day later excludes it, pinning the boundary rather than the direction only.
+    auto past_bound = db_->get_delisting_dates({"HPC"}, "2008-11-25");
+    ASSERT_TRUE(past_bound.is_ok()) << past_bound.error()->what();
+    EXPECT_TRUE(past_bound.value().empty());
+}
+
+TEST_F(DelistingFloorDbTest, EmptyFloorPreservesTheUnboundedRead) {
+    // The default argument must be behaviour-preserving: any caller that passes
+    // nothing gets exactly what it got before.
+    auto with_empty = db_->get_delisting_dates({"MER"}, "");
+    auto defaulted = db_->get_delisting_dates({"MER"});
+    ASSERT_TRUE(with_empty.is_ok() && defaulted.is_ok());
+    EXPECT_EQ(with_empty.value(), defaulted.value());
+    ASSERT_EQ(defaulted.value().size(), 1u);
+    EXPECT_EQ(defaulted.value().at("MER"), "2008-12-31");
+}

--- a/tests/live/corp_actions/test_effect_classes.cpp
+++ b/tests/live/corp_actions/test_effect_classes.cpp
@@ -452,3 +452,88 @@ TEST(CorpActionTypeRoundTrip, ApplierSkipsTerminationRatherThanRestatingPrice) {
         << "The applier mutated a position on a TERMINATION event.";
     EXPECT_DOUBLE_EQ(static_cast<double>(positions["DEAD"].average_price), 100.0);
 }
+
+// ──────────────────────────────────────────────────────────────────────────
+// E4 item 3 -- the deal-terms feed's stop date is MEASURED, not compiled in.
+//
+// kCorpActionTableFrozenAfter used to be quoted verbatim in every "no deal
+// terms" WARN as though it were current fact. It is a fact about the DATABASE:
+// the day the vendor subscription restarts and the ACTIONS ingest backfills,
+// the constant is wrong and the log keeps asserting it until somebody rebuilds
+// -- and nobody is told that the dormant rollover path just went live.
+// ──────────────────────────────────────────────────────────────────────────
+
+#include "trade_ngin/live/corp_action_feed_status.hpp"
+
+TEST(CorpActionFeedStatus, AMeasuredDateReplacesTheConstant) {
+    // A feed that has been backfilled past the build-time constant.
+    const auto s = assess_corp_action_feed("2026-08-31", "2026-09-03");
+    EXPECT_TRUE(s.measured);
+    EXPECT_EQ(s.last_row_date, "2026-08-31");
+    EXPECT_NE(s.last_row_date, std::string(kCorpActionTableFrozenAfter))
+        << "the reported date must come from the database, not from the binary";
+    EXPECT_TRUE(s.revived_since_build)
+        << "a feed with rows after the build-time date has been revived, and the "
+           "operator has to be told before the deal-terms path starts acting";
+    EXPECT_TRUE(s.frozen) << "still short of the run date, so 'frozen' is still true";
+    EXPECT_NE(describe_corp_action_feed(s).find("2026-08-31"), std::string::npos);
+    EXPECT_NE(describe_corp_action_feed(s).find("REVIVED"), std::string::npos);
+}
+
+TEST(CorpActionFeedStatus, TodaysMeasurementReproducesTheConstantWithoutBeingIt) {
+    // What the live table says today. Same value as the constant -- and that is
+    // the point: it is reported because it was read, not because it was typed.
+    const auto s = assess_corp_action_feed("2025-08-29", "2026-09-03");
+    EXPECT_TRUE(s.measured);
+    EXPECT_FALSE(s.revived_since_build);
+    EXPECT_TRUE(s.frozen);
+    EXPECT_EQ(describe_corp_action_feed(s),
+              "deal-terms feed last row 2025-08-29, frozen: yes");
+}
+
+TEST(CorpActionFeedStatus, AFeedCurrentToTheRunDateIsNotFrozen) {
+    const auto s = assess_corp_action_feed("2026-09-03", "2026-09-03");
+    EXPECT_TRUE(s.measured);
+    EXPECT_FALSE(s.frozen) << "a row on the run date means the feed has not stopped";
+    EXPECT_EQ(describe_corp_action_feed(s).find("frozen: no") == std::string::npos, false);
+}
+
+TEST(CorpActionFeedStatus, AFailedMeasurementFallsBackAndSaysSo) {
+    const auto s = assess_corp_action_feed("", "2026-09-03");
+    EXPECT_FALSE(s.measured);
+    EXPECT_EQ(s.last_row_date, std::string(kCorpActionTableFrozenAfter))
+        << "an unreadable table must degrade to the old behaviour, not to a blank date";
+    EXPECT_FALSE(s.revived_since_build);
+    EXPECT_NE(describe_corp_action_feed(s).find("NOT MEASURED"), std::string::npos)
+        << "a fallen-back date must not be presented as a measurement";
+}
+
+// The WARN text the handler emits now carries the measured date. Passing it is
+// what makes the message true; passing nothing preserves the old text exactly,
+// so a caller that could not measure is no worse off than before.
+TEST(CorpActionClass3, TerminationWarnsQuoteTheMeasuredFeedDate) {
+    std::unordered_map<std::string, Position> positions;
+    positions["GONE"] = make_position("GONE", 40.0, 25.0);
+    std::unordered_map<std::string, double> final_closes = {{"GONE", 20.0}};
+
+    auto log = CorporateActionsLifecycle::apply_terminations(
+        positions, {termination("GONE", "2026-04-09", "delisted")}, final_closes,
+        "2026-08-31");
+
+    // The measured date changes only the message, never the arithmetic: the exit
+    // is still at the final close and the realized delta is unchanged.
+    ASSERT_EQ(log.size(), 1u);
+    EXPECT_EQ(log[0].outcome, LifecycleOutcome::EXITED_AT_FINAL_CLOSE);
+    EXPECT_DOUBLE_EQ(log[0].exit_price, 20.0);
+    EXPECT_DOUBLE_EQ(log[0].realized_delta, (20.0 - 25.0) * 40.0);
+    EXPECT_DOUBLE_EQ(positions["GONE"].quantity.as_double(), 0.0);
+
+    // And the default argument leaves every existing caller byte-identical.
+    std::unordered_map<std::string, Position> same;
+    same["GONE"] = make_position("GONE", 40.0, 25.0);
+    auto log_default = CorporateActionsLifecycle::apply_terminations(
+        same, {termination("GONE", "2026-04-09", "delisted")}, final_closes);
+    ASSERT_EQ(log_default.size(), 1u);
+    EXPECT_EQ(log_default[0].outcome, log[0].outcome);
+    EXPECT_DOUBLE_EQ(log_default[0].realized_delta, log[0].realized_delta);
+}

--- a/tests/live/corp_actions/test_window.cpp
+++ b/tests/live/corp_actions/test_window.cpp
@@ -216,3 +216,99 @@ TEST(CorpActionWindowDerivation, DeepHoldingIsReportedAsTheSource) {
     ASSERT_EQ(w.deep_symbols.size(), 1u);
     EXPECT_EQ(w.deep_symbols[0], "OLD");
 }
+
+// ──────────────────────────────────────────────────────────────────────────
+// BA-9 / C-1 D13 -- an inception read that SUCCEEDS but does not answer for a
+// held symbol.
+//
+// Only is_error() used to widen the window. A successful read that returned no
+// row for a held symbol (or for none of them) fell straight through, contributed
+// nothing to the derivation, and left the window at its 14-day floor -- the same
+// silent narrowing this whole derivation exists to prevent, reached by a
+// different route. Class 1 fails WIDE by design: an unknown inception must reach
+// the bulk edge, because under-applying a price rescale is the permanent error.
+// ──────────────────────────────────────────────────────────────────────────
+
+TEST(CorpActionInceptionUnknowns, HeldSymbolWithNoRowGetsTheBulkEdgeNotTheFloor) {
+    const std::string bulk_start = "2024-09-01";
+    const std::vector<std::string> held{"AAPL", "MSFT"};
+    // The read answered for AAPL only -- MSFT is held but unexplained.
+    const std::unordered_map<std::string, std::string> read{{"AAPL", "2026-08-29"}};
+
+    const auto filled = inception_with_unknowns_widened(held, read, bulk_start);
+
+    ASSERT_EQ(filled.size(), 2u) << "every held symbol must carry a date";
+    EXPECT_EQ(filled.at("AAPL"), "2026-08-29") << "a real answer is never overwritten";
+    EXPECT_EQ(filled.at("MSFT"), bulk_start)
+        << "unknown inception fails WIDE: an unexplained holding reaches the bulk edge";
+
+    // And the window that follows must actually be widened by it.
+    const std::time_t today = parse_ymd_utc("2026-08-31");
+    const auto w = derive_corp_action_window(today, 14, 730, filled);
+    EXPECT_EQ(w.source, CorpActionWindowSource::Inception)
+        << "a held symbol with no inception row must not leave the window at the floor";
+    EXPECT_EQ(w.source_symbol, "MSFT");
+    EXPECT_EQ(w.start, parse_ymd_utc(bulk_start));
+}
+
+TEST(CorpActionInceptionUnknowns, EmptyReadWithHeldSymbolsWidensEveryOneOfThem) {
+    const std::string bulk_start = "2024-09-01";
+    const std::vector<std::string> held{"AAPL", "MSFT", "TMUS"};
+    const std::unordered_map<std::string, std::string> read;  // ok, but zero rows
+
+    const auto filled = inception_with_unknowns_widened(held, read, bulk_start);
+
+    ASSERT_EQ(filled.size(), 3u);
+    for (const auto& sym : held) {
+        EXPECT_EQ(filled.at(sym), bulk_start) << sym << " is held and unexplained";
+    }
+    EXPECT_EQ(held_symbols_without_inception(held, read).size(), 3u);
+}
+
+// A malformed date is indistinguishable from no answer: derive_corp_action_window
+// skips anything that will not parse, so leaving it in place would narrow the
+// window exactly as a missing row does.
+TEST(CorpActionInceptionUnknowns, UnparseableDateIsTreatedAsUnknown) {
+    const std::string bulk_start = "2024-09-01";
+    const std::vector<std::string> held{"AAPL"};
+    const std::unordered_map<std::string, std::string> read{{"AAPL", "not-a-date"}};
+
+    const auto filled = inception_with_unknowns_widened(held, read, bulk_start);
+
+    EXPECT_EQ(filled.at("AAPL"), bulk_start);
+    const auto missing = held_symbols_without_inception(held, read);
+    ASSERT_EQ(missing.size(), 1u);
+    EXPECT_EQ(missing[0], "AAPL");
+}
+
+// Nothing held is not an anomaly -- the floor is the right answer, and no
+// symbol should be invented.
+TEST(CorpActionInceptionUnknowns, NoHoldingsLeavesTheWindowAtTheFloor) {
+    const std::vector<std::string> held;
+    const std::unordered_map<std::string, std::string> read;
+
+    const auto filled = inception_with_unknowns_widened(held, read, "2024-09-01");
+    EXPECT_TRUE(filled.empty());
+    EXPECT_TRUE(held_symbols_without_inception(held, read).empty());
+
+    const std::time_t today = parse_ymd_utc("2026-08-31");
+    const auto w = derive_corp_action_window(today, 14, 730, filled);
+    EXPECT_EQ(w.source, CorpActionWindowSource::Floor);
+}
+
+// The read's own answers are authoritative when present: this must not become a
+// blanket widening that discards real inception dates.
+TEST(CorpActionInceptionUnknowns, FullyAnsweredReadIsPassedThroughUnchanged) {
+    const std::vector<std::string> held{"AAPL", "MSFT"};
+    const std::unordered_map<std::string, std::string> read{
+        {"AAPL", "2026-08-29"}, {"MSFT", "2026-08-30"}};
+
+    const auto filled = inception_with_unknowns_widened(held, read, "2024-09-01");
+    EXPECT_EQ(filled.at("AAPL"), "2026-08-29");
+    EXPECT_EQ(filled.at("MSFT"), "2026-08-30");
+    EXPECT_TRUE(held_symbols_without_inception(held, read).empty());
+
+    const std::time_t today = parse_ymd_utc("2026-08-31");
+    const auto w = derive_corp_action_window(today, 14, 730, filled);
+    EXPECT_EQ(w.source, CorpActionWindowSource::Floor) << "both holdings are inside the floor";
+}

--- a/tests/live/test_effective_universe.cpp
+++ b/tests/live/test_effective_universe.cpp
@@ -1,0 +1,246 @@
+// tests/live/test_effective_universe.cpp
+//
+// E2-F34 / E3 F-4 -- the tradeable universe must be finalized AFTER the book is known,
+// and BA-2 / C-3 D1 -- the era test that decides which renames count must be asked
+// about the CURRENT holding, not the lifetime of the ticker.
+//
+// The failure shape these pin, end to end: the runner fixed `symbols` from config,
+// registered instruments, loaded bars and built trading_params from it, and only then
+// -- about 1,500 lines later -- ran apply_renames. A held position whose successor was
+// not in config was re-keyed onto a symbol the run had no bars, no instrument, no cost
+// config and no target for. The day-T pass logged "Missing T-1 price for symbol with a
+// non-zero position", execute_day_t rule 3 rolled the target back to the carried
+// quantity, and the next session did the same thing again: an unpriceable zombie,
+// persisted under the new key, that re-running does not clear.
+//
+// LiveDailyCycle::effective_universe is the pure part of the reordering: given the book
+// and the alias table, which extra tickers must this run be able to price?
+
+#include <gtest/gtest.h>
+
+#include <algorithm>
+#include <string>
+#include <unordered_map>
+#include <vector>
+
+#include "trade_ngin/core/types.hpp"
+#include "trade_ngin/live/live_daily_cycle.hpp"
+
+using namespace trade_ngin;
+
+namespace {
+
+constexpr const char* kToday = "2026-09-03";
+
+Position held(const std::string& symbol, double qty) {
+    Position p;
+    p.symbol = symbol;
+    p.quantity = Quantity(qty);
+    p.average_price = Decimal(100.0);
+    p.last_update = std::chrono::system_clock::now();
+    return p;
+}
+
+bool contains(const std::vector<std::string>& v, const std::string& s) {
+    return std::find(v.begin(), v.end(), s) != v.end();
+}
+
+}  // namespace
+
+// ---------------------------------------------------------------------------
+// E2-F34 / F-4
+// ---------------------------------------------------------------------------
+
+// The regression. FB is held, FB -> META closed on 2022-06-09, the holding was
+// established inside that era, and META is NOT configured. apply_renames WILL move
+// the position onto META later in the run, so the run has to be able to price META.
+TEST(EffectiveUniverse, SuccessorOfAHeldRenamedTickerJoinsTheUniverse) {
+    const std::vector<std::string> config{"AAPL", "MSFT"};
+    std::unordered_map<std::string, Position> book{{"FB", held("FB", 100.0)}};
+    const std::vector<TickerAlias> aliases{{"FB", "META", "2022-06-09", "rename"}};
+    const std::unordered_map<std::string, std::string> holding_start{{"FB", "2021-03-01"}};
+
+    const auto universe =
+        LiveDailyCycle::effective_universe(config, book, aliases, kToday, holding_start);
+
+    EXPECT_TRUE(contains(universe, "META"))
+        << "the successor apply_renames will re-key onto has no bars, no instrument and "
+           "no target unless the universe carries it";
+    EXPECT_TRUE(contains(universe, "AAPL"));
+    EXPECT_TRUE(contains(universe, "MSFT"));
+    EXPECT_EQ(universe.size(), 3u);
+}
+
+// Config order is preserved and additions are appended, so the universe is
+// deterministic run to run (the symbol list drives query text and log ordering).
+TEST(EffectiveUniverse, ConfigOrderIsPreservedAndAdditionsAppendedSorted) {
+    const std::vector<std::string> config{"ZTS", "AAPL"};
+    std::unordered_map<std::string, Position> book{{"FB", held("FB", 10.0)},
+                                                   {"TWTR", held("TWTR", 5.0)}};
+    const std::vector<TickerAlias> aliases{{"FB", "META", "2022-06-09", ""},
+                                           {"TWTR", "X", "2023-07-24", ""}};
+    const std::unordered_map<std::string, std::string> holding_start{{"FB", "2021-03-01"},
+                                                                    {"TWTR", "2022-01-04"}};
+
+    const auto universe =
+        LiveDailyCycle::effective_universe(config, book, aliases, kToday, holding_start);
+
+    ASSERT_EQ(universe.size(), 4u);
+    EXPECT_EQ(universe[0], "ZTS");
+    EXPECT_EQ(universe[1], "AAPL");
+    EXPECT_EQ(universe[2], "META");
+    EXPECT_EQ(universe[3], "X");
+}
+
+// An alias that maps a ticker we do not hold contributes nothing: the universe grows
+// only for positions the run actually has to carry.
+TEST(EffectiveUniverse, UnrelatedAliasAddsNothing) {
+    const std::vector<std::string> config{"AAPL"};
+    std::unordered_map<std::string, Position> book{{"AAPL", held("AAPL", 10.0)}};
+    const std::vector<TickerAlias> aliases{{"FB", "META", "2022-06-09", ""}};
+    const std::unordered_map<std::string, std::string> holding_start{{"AAPL", "2026-01-05"}};
+
+    const auto universe =
+        LiveDailyCycle::effective_universe(config, book, aliases, kToday, holding_start);
+
+    EXPECT_EQ(universe, config);
+}
+
+// A flat row is not a holding. Closed rows exist to carry realized P&L on the day
+// they closed (E2-F19) and nothing re-keys them, so they must not widen the universe.
+TEST(EffectiveUniverse, AFlatRowDoesNotWidenTheUniverse) {
+    const std::vector<std::string> config{"AAPL"};
+    std::unordered_map<std::string, Position> book{{"FB", held("FB", 0.0)}};
+    const std::vector<TickerAlias> aliases{{"FB", "META", "2022-06-09", ""}};
+    const std::unordered_map<std::string, std::string> holding_start{{"FB", "2021-03-01"}};
+
+    const auto universe =
+        LiveDailyCycle::effective_universe(config, book, aliases, kToday, holding_start);
+
+    EXPECT_EQ(universe, config);
+}
+
+// A successor already in config is not duplicated -- the symbol list is passed straight
+// to get_market_data and to the per-symbol config loops.
+TEST(EffectiveUniverse, AlreadyConfiguredSuccessorIsNotDuplicated) {
+    const std::vector<std::string> config{"AAPL", "META"};
+    std::unordered_map<std::string, Position> book{{"FB", held("FB", 100.0)}};
+    const std::vector<TickerAlias> aliases{{"FB", "META", "2022-06-09", ""}};
+    const std::unordered_map<std::string, std::string> holding_start{{"FB", "2021-03-01"}};
+
+    const auto universe =
+        LiveDailyCycle::effective_universe(config, book, aliases, kToday, holding_start);
+
+    EXPECT_EQ(universe, config);
+}
+
+// The universe must not admit a rename apply_renames will refuse. Its as-of guard is
+// `as_of_date > effective_until`; on or before the boundary the rename has not happened
+// yet and the position keeps its own ticker.
+TEST(EffectiveUniverse, ARenameThatHasNotHappenedYetIsNotInTheUniverse) {
+    const std::vector<std::string> config{"AAPL"};
+    std::unordered_map<std::string, Position> book{{"FB", held("FB", 100.0)}};
+    const std::vector<TickerAlias> aliases{{"FB", "META", "2026-12-31", ""}};
+    const std::unordered_map<std::string, std::string> holding_start{{"FB", "2021-03-01"}};
+
+    const auto universe =
+        LiveDailyCycle::effective_universe(config, book, aliases, kToday, holding_start);
+
+    EXPECT_EQ(universe, config);
+
+    // ... and the re-keying agrees, which is the property that matters: one rename map,
+    // one era test, shared by both.
+    auto positions = book;
+    auto log = CorporateActionsLifecycle::apply_renames(positions, aliases, kToday,
+                                                        holding_start);
+    EXPECT_TRUE(log.empty());
+    EXPECT_EQ(positions.count("FB"), 1u);
+}
+
+// A chain A -> B -> C is followed at the same era, so every hop is priceable.
+TEST(EffectiveUniverse, EveryHopOfARenameChainJoinsTheUniverse) {
+    const std::vector<std::string> config{"AAPL"};
+    std::unordered_map<std::string, Position> book{{"A", held("A", 10.0)}};
+    const std::vector<TickerAlias> aliases{{"A", "B", "2023-01-31", ""},
+                                           {"B", "C", "2024-01-31", ""}};
+    const std::unordered_map<std::string, std::string> holding_start{{"A", "2022-06-01"}};
+
+    const auto universe =
+        LiveDailyCycle::effective_universe(config, book, aliases, kToday, holding_start);
+
+    EXPECT_TRUE(contains(universe, "B"));
+    EXPECT_TRUE(contains(universe, "C"));
+    EXPECT_EQ(universe.size(), 3u);
+}
+
+// A symbol with no era date is skipped, not guessed at: class 2 fails narrow, and so
+// must the universe derived from it, or the run would load bars for a rename that is
+// never applied.
+TEST(EffectiveUniverse, NoHoldingStartMeansNoAddition) {
+    const std::vector<std::string> config{"AAPL"};
+    std::unordered_map<std::string, Position> book{{"FB", held("FB", 100.0)}};
+    const std::vector<TickerAlias> aliases{{"FB", "META", "2022-06-09", ""}};
+
+    const auto universe = LiveDailyCycle::effective_universe(config, book, aliases, kToday, {});
+
+    EXPECT_EQ(universe, config);
+}
+
+// ---------------------------------------------------------------------------
+// BA-2 / C-3 D1 -- which date the era test is asked about
+// ---------------------------------------------------------------------------
+
+// The two inputs, side by side, on one book. `get_position_inception_dates` answers
+// min(date) over ALL history and is deliberately fail-wide for the class-1 price
+// window; feeding that answer to class 2 re-keys a live holding onto a dead symbol.
+// `get_current_holding_start_dates` answers "when did the holding we hold now begin",
+// and the same alias then correctly does nothing.
+//
+// The live shape this is drawn from, measured 2026-09-03 on EQUITY_MR_PORTFOLIO:
+// META's lifetime inception is 2026-06-11, its current holding began 2026-07-31 (the
+// position was closed and re-opened in between).
+TEST(RenameEraInput, LifetimeInceptionRekeysAReopenedTickerAndTheHoldingStartDoesNot) {
+    const std::vector<TickerAlias> aliases{{"META", "METV", "2022-01-31", "backfill"}};
+
+    // Held 2021-11-01 .. 2021-12-15 (Facebook), closed, re-bought 2026-08-20 (Meta
+    // Platforms) and still held.
+    const std::unordered_map<std::string, std::string> lifetime{{"META", "2021-11-01"}};
+    const std::unordered_map<std::string, std::string> current_holding{{"META", "2026-08-20"}};
+
+    {
+        std::unordered_map<std::string, Position> positions{{"META", held("META", 100.0)}};
+        auto log = CorporateActionsLifecycle::apply_renames(positions, aliases, kToday, lifetime);
+        ASSERT_EQ(log.size(), 1u) << "characterizing the defect: the lifetime date is inside "
+                                     "the alias era, so the rename fires";
+        EXPECT_EQ(positions.count("META"), 0u);
+        EXPECT_EQ(positions.count("METV"), 1u)
+            << "a live 100-share holding was moved onto a symbol with no bars";
+    }
+    {
+        std::unordered_map<std::string, Position> positions{{"META", held("META", 100.0)}};
+        auto log = CorporateActionsLifecycle::apply_renames(positions, aliases, kToday,
+                                                            current_holding);
+        EXPECT_TRUE(log.empty());
+        ASSERT_EQ(positions.count("META"), 1u)
+            << "the holding we actually hold began four years after the alias era closed";
+        EXPECT_EQ(positions.count("METV"), 0u);
+        EXPECT_DOUBLE_EQ(positions.at("META").quantity.as_double(), 100.0);
+    }
+}
+
+// The same distinction, seen from the universe: class 1's answer makes the run load
+// bars for a dead ticker; class 2's answer leaves the universe alone.
+TEST(RenameEraInput, LifetimeInceptionWidensTheUniverseOntoADeadTicker) {
+    const std::vector<std::string> config{"META"};
+    std::unordered_map<std::string, Position> book{{"META", held("META", 100.0)}};
+    const std::vector<TickerAlias> aliases{{"META", "METV", "2022-01-31", "backfill"}};
+
+    const auto with_lifetime = LiveDailyCycle::effective_universe(
+        config, book, aliases, kToday, {{"META", "2021-11-01"}});
+    EXPECT_TRUE(contains(with_lifetime, "METV"))
+        << "characterizing the defect: class 1's fail-wide date drags a dead symbol in";
+
+    const auto with_holding_start = LiveDailyCycle::effective_universe(
+        config, book, aliases, kToday, {{"META", "2026-08-20"}});
+    EXPECT_EQ(with_holding_start, config);
+}

--- a/tests/live/test_execution_manager.cpp
+++ b/tests/live/test_execution_manager.cpp
@@ -324,3 +324,84 @@ TEST_F(ExecutionManagerTest, SellSideCarriesRegulatoryFeesWhenConfigured) {
                     buy.value()[0].total_transaction_costs.as_double(),
                 sec_fee + taf, 1e-9);
 }
+
+// ──────────────────────────────────────────────────────────────────────────
+// E2-F46 -- the order-id date must be the RUN date, in the run date's frame.
+//
+// generate_date_string formatted the run timestamp with std::localtime while
+// the equity runner passes UTC midnight (95679ea2) and stamps every other
+// artefact of the same run with gmtime. On a negative-offset host that is the
+// previous evening locally, so the id took the previous calendar day: the
+// 2026-06-15 run wrote DAILY_AAPL_20260614. The id is what
+// delete_stale_executions matches on and what a broker statement is
+// reconciled against, so an id naming the wrong day is not cosmetic.
+//
+// Both frames are pinned: UTC midnight is what the equity runner passes, local
+// midnight is what live_portfolio*.cpp:60 still passes (E2-F42). Both must
+// produce the run date's own YYYYMMDD, or fixing equities would move futures.
+// ──────────────────────────────────────────────────────────────────────────
+
+namespace {
+
+class OrderIdDateFrameTest : public ::testing::Test {
+protected:
+    void SetUp() override {
+        if (const char* tz = std::getenv("TZ")) {
+            had_tz_ = true;
+            saved_tz_ = tz;
+        }
+        setenv("TZ", "America/New_York", 1);
+        tzset();
+    }
+    void TearDown() override {
+        if (had_tz_) {
+            setenv("TZ", saved_tz_.c_str(), 1);
+        } else {
+            unsetenv("TZ");
+        }
+        tzset();
+    }
+    static Timestamp utc_midnight(int y, int m, int d) {
+        std::tm tm{};
+        tm.tm_year = y - 1900;
+        tm.tm_mon = m - 1;
+        tm.tm_mday = d;
+        return std::chrono::system_clock::from_time_t(timegm(&tm));
+    }
+    static Timestamp local_midnight(int y, int m, int d) {
+        std::tm tm{};
+        tm.tm_year = y - 1900;
+        tm.tm_mon = m - 1;
+        tm.tm_mday = d;
+        tm.tm_isdst = -1;
+        return std::chrono::system_clock::from_time_t(std::mktime(&tm));
+    }
+    bool had_tz_ = false;
+    std::string saved_tz_;
+};
+
+}  // namespace
+
+TEST_F(OrderIdDateFrameTest, UtcMidnightRunDateStampsItsOwnDay) {
+    EXPECT_EQ(ExecutionManager::generate_date_string(utc_midnight(2026, 6, 15)), "20260615")
+        << "the 2026-06-15 run wrote DAILY_<SYM>_20260614";
+    EXPECT_EQ(ExecutionManager::generate_date_string(utc_midnight(2026, 1, 1)), "20260101")
+        << "a year boundary is where the off-by-one is most expensive";
+}
+
+// Futures preservation: a local-midnight run date lands at 04:00/05:00Z on the
+// same calendar day, so reading it in UTC gives the same YYYYMMDD it always did.
+TEST_F(OrderIdDateFrameTest, LocalMidnightRunDateStampsTheSameDay) {
+    EXPECT_EQ(ExecutionManager::generate_date_string(local_midnight(2026, 6, 15)), "20260615");
+    EXPECT_EQ(ExecutionManager::generate_date_string(local_midnight(2026, 1, 1)), "20260101");
+}
+
+// The whole point of the id: two runs on different days must not collide, and a
+// run's id must match the date its rows are keyed on.
+TEST_F(OrderIdDateFrameTest, ConsecutiveRunDatesProduceDistinctStamps) {
+    const auto a = ExecutionManager::generate_date_string(utc_midnight(2026, 6, 15));
+    const auto b = ExecutionManager::generate_date_string(utc_midnight(2026, 6, 16));
+    EXPECT_EQ(a, "20260615");
+    EXPECT_EQ(b, "20260616");
+    EXPECT_NE(a, b);
+}

--- a/tests/live/test_execution_manager.cpp
+++ b/tests/live/test_execution_manager.cpp
@@ -279,3 +279,48 @@ TEST_F(ExecutionManagerTest, DefaultPolicyIsMarkFallbackSoFuturesCallersAreUnaff
     EXPECT_DOUBLE_EQ(defaulted.value()[0].fill_price.as_double(),
                      explicit_mark.value()[0].fill_price.as_double());
 }
+
+// ============================================================================
+// E2-F29: SEC/TAF regulatory fees must reach a SELL fill.
+//
+// TransactionCostManager gates the fees on `quantity < 0`; the live caller passed
+// |quantity| for both sides, so on a config with apply_regulatory_fees the sell
+// side was charged exactly what the buy side was. SELL cost - BUY cost must equal
+// sec_fee + taf for the same clip.
+// ============================================================================
+TEST_F(ExecutionManagerTest, SellSideCarriesRegulatoryFeesWhenConfigured) {
+    ExecutionManager em;
+    transaction_cost::AssetCostConfig cfg;
+    cfg.symbol = "TIERD";
+    cfg.asset_type = AssetType::EQUITY;
+    cfg.commission_per_unit = 0.0035;
+    cfg.min_commission_per_order = 0.35;
+    cfg.max_commission_per_order = 1e9;
+    cfg.apply_regulatory_fees = true;
+    cfg.sec_fee_per_million = 20.60;
+    cfg.finra_taf_per_share = 0.000195;
+    cfg.finra_taf_cap_per_trade = 9.79;
+    em.get_transaction_cost_manager().register_asset_config(cfg);
+
+    const double qty = 1000.0, px = 50.0;
+    std::unordered_map<std::string, double> prices{{"TIERD", px}};
+    std::unordered_map<std::string, Position> flat;
+    std::unordered_map<std::string, Position> held{{"TIERD", make_position("TIERD", qty, px)}};
+
+    auto buy = em.generate_daily_executions(held, flat, prices, std::chrono::system_clock::now());
+    auto sell = em.generate_daily_executions(flat, held, prices, std::chrono::system_clock::now());
+    ASSERT_TRUE(buy.is_ok() && sell.is_ok());
+    ASSERT_EQ(buy.value().size(), 1u);
+    ASSERT_EQ(sell.value().size(), 1u);
+    ASSERT_EQ(buy.value()[0].side, Side::BUY);
+    ASSERT_EQ(sell.value()[0].side, Side::SELL);
+
+    const double sec_fee = (qty * px / 1e6) * cfg.sec_fee_per_million;   // 1.03
+    const double taf = std::min(qty * cfg.finra_taf_per_share, cfg.finra_taf_cap_per_trade);  // 0.195
+    EXPECT_NEAR(sell.value()[0].commissions_fees.as_double() - buy.value()[0].commissions_fees.as_double(),
+                sec_fee + taf, 1e-9)
+        << "SELL must carry SEC + TAF on top of the BUY-side commission";
+    EXPECT_NEAR(sell.value()[0].total_transaction_costs.as_double() -
+                    buy.value()[0].total_transaction_costs.as_double(),
+                sec_fee + taf, 1e-9);
+}

--- a/tests/live/test_live_daily_cycle_carry_forward.cpp
+++ b/tests/live/test_live_daily_cycle_carry_forward.cpp
@@ -1,0 +1,172 @@
+// tests/live/test_live_daily_cycle_carry_forward.cpp
+//
+// T-OR.3 -- the closed-day path.
+//
+// The equity runner has processed weekends and holidays as CARRY-FORWARD days since
+// `eaa292d1`: the book, live_results and equity_curve are written from the previous
+// session while signal generation and execution are skipped. That behaviour was
+// implemented as five inline copies of `dow == 0 || dow == 6 || is_holiday(...)` inside
+// main(), and nothing anywhere covered the predicate or the carry decision -- `grep
+// is_holiday tests/live tests/strategy` returned nothing. A closed day that silently
+// starts trading, or a carried book that silently gains a realized figure, would be
+// invisible until it showed up in the P&L.
+//
+// The two decisions now live in LiveDailyCycle, and this is their test.
+
+#include <gtest/gtest.h>
+
+#include <chrono>
+#include <ctime>
+#include <filesystem>
+#include <string>
+#include <unordered_map>
+#include <vector>
+
+#include "trade_ngin/core/holiday_checker.hpp"
+#include "trade_ngin/core/types.hpp"
+#include "trade_ngin/live/live_daily_cycle.hpp"
+
+using namespace trade_ngin;
+
+namespace {
+
+std::tm utc_tm_for(const std::string& ymd) {
+    std::tm t{};
+    t.tm_year = std::stoi(ymd.substr(0, 4)) - 1900;
+    t.tm_mon = std::stoi(ymd.substr(5, 2)) - 1;
+    t.tm_mday = std::stoi(ymd.substr(8, 2));
+    t.tm_hour = 12;
+    // tm_wday is what the weekend test reads, and the runner gets it from gmtime_r.
+    // timegm/gmtime_r round-trip populates it the same way here.
+    std::time_t as_utc = timegm(&t);
+    std::tm out{};
+    gmtime_r(&as_utc, &out);
+    return out;
+}
+
+Position held(const std::string& symbol, double qty, double basis, double unrealized,
+              double realized) {
+    Position p;
+    p.symbol = symbol;
+    p.quantity = Quantity(qty);
+    p.average_price = Decimal(basis);
+    p.unrealized_pnl = Decimal(unrealized);
+    p.realized_pnl = Decimal(realized);
+    p.last_update = std::chrono::system_clock::now();
+    return p;
+}
+
+// The shipped calendar, found from wherever the test binary was launched. Same walk the
+// suite's other calendar tests use: ctest runs from build/, a direct invocation may run
+// from the source root.
+std::string shipped_calendar_path() {
+    for (const auto* p : {"include/trade_ngin/core/holidays.json",
+                          "../include/trade_ngin/core/holidays.json",
+                          "../../include/trade_ngin/core/holidays.json"}) {
+        if (std::filesystem::exists(p)) return p;
+    }
+    return "";
+}
+
+}  // namespace
+
+class LiveDailyCycleCarryForwardTest : public ::testing::Test {
+protected:
+    void SetUp() override {
+        const std::string path = shipped_calendar_path();
+        if (path.empty()) {
+            GTEST_SKIP() << "shipped holidays.json not reachable from cwd";
+        }
+        holidays_ = std::make_unique<HolidayChecker>(path);
+        ASSERT_TRUE(holidays_->loaded())
+            << "the calendar is the input under test; without it every date reports open";
+        ASSERT_TRUE(holidays_->covers_date("2026-08-03"))
+            << "calendar does not cover 2026, so these assertions would prove nothing";
+    }
+
+    std::unique_ptr<HolidayChecker> holidays_;
+};
+
+// ---------------------------------------------------------------------------
+// the predicate
+// ---------------------------------------------------------------------------
+
+TEST_F(LiveDailyCycleCarryForwardTest, SaturdayAndSundayAreNonTrading) {
+    EXPECT_TRUE(LiveDailyCycle::is_non_trading_day(utc_tm_for("2026-08-01"), *holidays_))
+        << "2026-08-01 is a Saturday";
+    EXPECT_TRUE(LiveDailyCycle::is_non_trading_day(utc_tm_for("2026-08-02"), *holidays_))
+        << "2026-08-02 is a Sunday";
+}
+
+TEST_F(LiveDailyCycleCarryForwardTest, AWeekdayHolidayIsNonTrading) {
+    ASSERT_TRUE(holidays_->is_holiday("2026-07-03"))
+        << "fixture precondition: the observed Independence Day holiday is in the calendar";
+    EXPECT_TRUE(LiveDailyCycle::is_non_trading_day(utc_tm_for("2026-07-03"), *holidays_));
+}
+
+TEST_F(LiveDailyCycleCarryForwardTest, AnOrdinaryWeekdayIsATradingDay) {
+    EXPECT_FALSE(LiveDailyCycle::is_non_trading_day(utc_tm_for("2026-08-03"), *holidays_))
+        << "2026-08-03 is a Monday and not a holiday";
+    EXPECT_FALSE(LiveDailyCycle::is_non_trading_day(utc_tm_for("2026-08-06"), *holidays_))
+        << "2026-08-06 is a Thursday and not a holiday";
+}
+
+// A holiday that lands on a weekend is still non-trading -- the weekend test short
+// circuits before the calendar is consulted, so the two rules cannot disagree.
+TEST_F(LiveDailyCycleCarryForwardTest, AHolidayThatIsAlsoAWeekendIsNonTrading) {
+    EXPECT_TRUE(LiveDailyCycle::is_non_trading_day(utc_tm_for("2026-07-04"), *holidays_))
+        << "2026-07-04 is a Saturday; the observed holiday is 07-03";
+}
+
+// ---------------------------------------------------------------------------
+// the carry decision
+// ---------------------------------------------------------------------------
+
+// The carried book IS the previous book on everything that describes the holding, and
+// carries no flow. Nothing traded, so nothing was realized; nothing printed, so nothing
+// was re-marked.
+TEST_F(LiveDailyCycleCarryForwardTest, CarriedBookKeepsQuantityBasisAndMarkAndRealizesNothing) {
+    std::unordered_map<std::string, Position> previous;
+    previous["AAPL"] = held("AAPL", 100.0, 150.25, 375.0, 42.5);
+    previous["MSFT"] = held("MSFT", -0.0, 0.0, 0.0, -17.0);  // a closed row's residue
+
+    const auto carried = LiveDailyCycle::carry_forward(previous);
+
+    ASSERT_EQ(carried.size(), previous.size());
+    for (const auto& [symbol, before] : previous) {
+        auto it = carried.find(symbol);
+        ASSERT_NE(it, carried.end()) << symbol << " was dropped from the carried book";
+        EXPECT_DOUBLE_EQ(it->second.quantity.as_double(), before.quantity.as_double());
+        EXPECT_DOUBLE_EQ(it->second.average_price.as_double(), before.average_price.as_double())
+            << "a carried holding's cost basis is not re-derived on a closed day";
+        EXPECT_DOUBLE_EQ(it->second.unrealized_pnl.as_double(),
+                         before.unrealized_pnl.as_double())
+            << "no bar closed, so the mark is the previous session's";
+        EXPECT_DOUBLE_EQ(it->second.realized_pnl.as_double(), 0.0)
+            << "daily_realized_pnl is a FLOW; carrying yesterday's makes it a running total";
+    }
+
+    // The source book is not mutated -- it is still needed as the T-1 snapshot.
+    EXPECT_DOUBLE_EQ(previous.at("AAPL").realized_pnl.as_double(), 42.5);
+}
+
+// A carried book generates no executions: every delta against the previous book is
+// zero. This is the property the runner's closed-day skip relies on, asserted rather
+// than assumed.
+TEST_F(LiveDailyCycleCarryForwardTest, CarriedBookHasNoDeltaAgainstThePreviousBook) {
+    std::unordered_map<std::string, Position> previous;
+    previous["AAPL"] = held("AAPL", 100.0, 150.25, 375.0, 42.5);
+    previous["MSFT"] = held("MSFT", 40.0, 300.0, -120.0, 0.0);
+
+    const auto carried = LiveDailyCycle::carry_forward(previous);
+
+    for (const auto& [symbol, after] : carried) {
+        const double delta =
+            after.quantity.as_double() - previous.at(symbol).quantity.as_double();
+        EXPECT_DOUBLE_EQ(delta, 0.0) << symbol << " would have traded on a closed day";
+    }
+}
+
+TEST_F(LiveDailyCycleCarryForwardTest, AnEmptyBookCarriesForwardAsAnEmptyBook) {
+    EXPECT_TRUE(LiveDailyCycle::carry_forward({}).empty());
+}

--- a/tests/live/test_live_data_loader.cpp
+++ b/tests/live/test_live_data_loader.cpp
@@ -78,3 +78,96 @@ TEST_F(LiveDataLoaderTest, LoadDailyPnLHistoryDisconnectedErrors) {
     LiveDataLoader l(make_disconnected_db(), "trading");
     ASSERT_DB_ERROR(l.load_daily_pnl_history("S", "P", now()));
 }
+
+// ──────────────────────────────────────────────────────────────────────────
+// BA-5 / C-1 D2 -- a real pin for 43dfefb7.
+//
+// That commit's headline fix was load_commissions_by_symbol's column name:
+// <schema>.executions stores realised commissions in `commissions_fees`, never
+// `commission`, so the old query FAILED at runtime and every caller silently
+// degraded to a WARN with an empty map. C-1 found the fix had no test anywhere
+// at HEAD -- the one test the commit added covers an unrelated dividend
+// contract, so the column name could be reverted and the suite stays green.
+//
+// The query is built as a string and handed to execute_query, so its SHAPE is
+// observable: capture it and assert the column. Note `commission` is a
+// SUBSTRING of `commissions_fees`, so the assertion has to name the full
+// aggregate expression or it would pass on the broken query too.
+// ──────────────────────────────────────────────────────────────────────────
+namespace {
+
+class QueryCapturingDb : public PostgresDatabase {
+public:
+    QueryCapturingDb() : PostgresDatabase("mock://capture") {}
+
+    Result<void> connect() override {
+        connected_ = true;
+        return Result<void>();
+    }
+    void disconnect() override { connected_ = false; }
+    bool is_connected() const override { return connected_; }
+
+    Result<std::shared_ptr<arrow::Table>> execute_query(const std::string& query) override {
+        last_query = query;
+        // A null table is the documented "no rows" path in the caller.
+        return Result<std::shared_ptr<arrow::Table>>(nullptr);
+    }
+
+    std::string last_query;
+
+private:
+    bool connected_{true};
+};
+
+}  // namespace
+
+TEST_F(LiveDataLoaderTest, CommissionsQueryNamesTheCommissionsFeesColumn) {
+    auto db = std::make_shared<QueryCapturingDb>();
+    ASSERT_TRUE(db->connect().is_ok());
+    LiveDataLoader loader(db, "trading");
+
+    // 2026-08-06 00:00:00 UTC, a date inside the equity book's window.
+    std::tm utc{};
+    utc.tm_year = 126;
+    utc.tm_mon = 7;
+    utc.tm_mday = 6;
+    const Timestamp when = std::chrono::system_clock::from_time_t(timegm(&utc));
+
+    auto r = loader.load_commissions_by_symbol("EQUITY_MR_PORTFOLIO", when);
+    ASSERT_TRUE(r.is_ok()) << r.error()->what();
+    ASSERT_FALSE(db->last_query.empty()) << "the loader must have issued a query";
+
+    // The column. Asserting the whole aggregate expression matters: "commission"
+    // alone is a substring of "commissions_fees" and would match the broken query.
+    EXPECT_NE(db->last_query.find("SUM(commissions_fees)"), std::string::npos)
+        << "realised commissions live in commissions_fees; SUM(commission) fails at "
+           "runtime and the caller degrades to an empty map. Query was:\n"
+        << db->last_query;
+    EXPECT_EQ(db->last_query.find("SUM(commission)"), std::string::npos)
+        << "the pre-fix column name must not come back";
+
+    // The rest of the query's shape, so a rewrite cannot quietly change what is
+    // being aggregated or over what.
+    EXPECT_NE(db->last_query.find("trading.executions"), std::string::npos);
+    EXPECT_NE(db->last_query.find("GROUP BY symbol"), std::string::npos);
+
+    // Portfolio id and date are quoted literals, not bare concatenation -- the
+    // other half of what 43dfefb7 changed.
+    EXPECT_NE(db->last_query.find("'EQUITY_MR_PORTFOLIO'"), std::string::npos);
+    EXPECT_NE(db->last_query.find("'2026-08-06'"), std::string::npos)
+        << "the date key must be the UTC date, quoted. Query was:\n"
+        << db->last_query;
+}
+
+// A portfolio id containing a quote must not break out of the literal.
+TEST_F(LiveDataLoaderTest, CommissionsQueryEscapesAQuoteInThePortfolioId) {
+    auto db = std::make_shared<QueryCapturingDb>();
+    ASSERT_TRUE(db->connect().is_ok());
+    LiveDataLoader loader(db, "trading");
+
+    auto r = loader.load_commissions_by_symbol("O'BRIEN", std::chrono::system_clock::now());
+    ASSERT_TRUE(r.is_ok());
+    EXPECT_NE(db->last_query.find("'O''BRIEN'"), std::string::npos)
+        << "an embedded quote must be doubled. Query was:\n"
+        << db->last_query;
+}

--- a/tests/live/test_live_pnl_manager.cpp
+++ b/tests/live/test_live_pnl_manager.cpp
@@ -205,6 +205,37 @@ TEST_F(LivePnLManagerTest, GetPointValueStripsVariantSuffix) {
     EXPECT_DOUBLE_EQ(mgr.get_point_value("ES.v.0"), 50.0);
 }
 
+// E2-F38 / BA-7: the fallback table is matched by SUBSTRING over futures contract
+// codes, so an unregistered EQUITY ticker that happens to contain one inherits a
+// futures multiplier. These are all real US tickers, and the multipliers below are
+// what the table actually returns for them today.
+TEST_F(LivePnLManagerTest, UnregisteredEquityDoesNotInheritAFuturesMultiplier) {
+    LivePnLManager mgr(500000.0, InstrumentRegistry::instance());
+    mgr.set_asset_type(AssetType::EQUITY);
+
+    // LEN is the spinoff parent in this campaign's own corp-action work (LEN/Millrose).
+    EXPECT_DOUBLE_EQ(mgr.get_point_value("LEN"), 1.0) << "matches \"LE\", live cattle, 40000";
+    EXPECT_DOUBLE_EQ(mgr.get_point_value("ZM"), 1.0) << "Zoom matches \"ZM\", soybean meal, 100";
+    EXPECT_DOUBLE_EQ(mgr.get_point_value("UBER"), 1.0) << "matches \"UB\", ultra T-bond, 1000";
+    EXPECT_DOUBLE_EQ(mgr.get_point_value("HES"), 1.0) << "Hess matches \"ES\", E-mini S&P, 5";
+    EXPECT_DOUBLE_EQ(mgr.get_point_value("SIRI"), 1.0) << "matches \"SI\", silver, 5000";
+    EXPECT_DOUBLE_EQ(mgr.get_point_value("PLD"), 1.0) << "Prologis matches \"PL\", platinum, 50";
+
+    // A share is a share: every equity point value is 1.0, registered or not.
+    EXPECT_DOUBLE_EQ(mgr.get_point_value("AAPL"), 1.0);
+}
+
+// The futures default is untouched: a manager that says nothing behaves exactly as
+// it does today, which is what keeps this change inert for both futures runners.
+TEST_F(LivePnLManagerTest, DefaultAssetTypeKeepsTheFuturesFallbackTable) {
+    LivePnLManager mgr(500000.0, InstrumentRegistry::instance());
+    EXPECT_EQ(mgr.asset_type(), AssetType::FUTURE) << "silent callers stay on futures";
+    EXPECT_DOUBLE_EQ(mgr.get_point_value("CL"), 1000.0);
+    EXPECT_DOUBLE_EQ(mgr.get_point_value("GC"), 1000.0);
+    EXPECT_DOUBLE_EQ(mgr.get_point_value("ZM"), 100.0) << "as futures, ZM IS soybean meal";
+    EXPECT_DOUBLE_EQ(mgr.get_point_value("UNKNOWN_XYZ"), 1.0) << "no match, still 1.0";
+}
+
 // ===== reset_daily_tracking =====
 
 TEST_F(LivePnLManagerTest, ResetDailyTrackingClearsAccumulators) {

--- a/tests/live/test_trading_days_anchor.cpp
+++ b/tests/live/test_trading_days_anchor.cpp
@@ -1,0 +1,116 @@
+// tests/live/test_trading_days_anchor.cpp
+//
+// E2-F32 -- the annualization anchor that contradicts the book it annualizes.
+//
+// `trading.get_trading_days(strategy, target, portfolio)` reads
+// strategy_trading_days_metadata.live_start_date and only falls back to MIN(date)
+// over live_results when no row exists. So a metadata row dated AFTER the book's
+// first day is worse than no row at all, and the function cannot tell -- it stops
+// looking as soon as it finds one.
+//
+// Measured on the live database 2026-09-03:
+//   EQUITY_MR_PORTFOLIO / LIVE_EQUITY_MEAN_REVERSION
+//     live_start_date  2026-07-24   (seeded by hand on 2026-09-01 for a 10-day window)
+//     live_results     2026-04-01 .. 2026-08-04, 126 rows
+//   -> every date before 07-24 gets 1 trading day, so total_annualized_return
+//      collapses onto total_cumulative_return on 115 rows; 07-27 gets 4 days and
+//      a -3.5 % cumulative return annualizes to -1674 %.
+//
+// Pure: no database, no I/O.
+
+#include <gtest/gtest.h>
+
+#include <string>
+
+#include "trade_ngin/live/trading_days_anchor.hpp"
+
+using namespace trade_ngin;
+
+// The live defect, stated as data.
+TEST(TradingDaysAnchor, AMetadataRowLaterThanTheBookIsCaught) {
+    const auto a = assess_trading_days_anchor("2026-07-24", "2026-04-01");
+
+    ASSERT_TRUE(a.has_metadata);
+    EXPECT_TRUE(a.anchor_is_late)
+        << "an anchor 114 days after the book's first day is the E2-F32 shape";
+    EXPECT_EQ(a.effective_anchor, "2026-04-01")
+        << "annualization must anchor to the book, not to a hand-seeded row";
+
+    // What the DB function returns today vs what it should: on 2026-07-27 the
+    // stored anchor gives 4 days, which is what produced -1674 %.
+    EXPECT_EQ(trading_days_from_anchor(a.metadata_anchor, "2026-07-27"), 4);
+    EXPECT_EQ(trading_days_from_anchor(a.effective_anchor, "2026-07-27"), 118);
+
+    // And on any date before the stored anchor the function floors at 1, which is
+    // why 115 rows show annualized == cumulative rather than an obvious error.
+    EXPECT_EQ(trading_days_from_anchor(a.metadata_anchor, "2026-05-01"), 1);
+    EXPECT_EQ(trading_days_from_anchor(a.effective_anchor, "2026-05-01"), 31);
+}
+
+// The sound case must stay silent, or the check is noise on every futures run.
+TEST(TradingDaysAnchor, AnAnchorOnTheBooksFirstDayIsNotFlagged) {
+    // LIVE_TREND_FOLLOWING / CONSERVATIVE_PORTFOLIO as of 2026-09-03: anchor and
+    // first live_results row are both 2025-10-05.
+    const auto a = assess_trading_days_anchor("2025-10-05", "2025-10-05");
+    EXPECT_TRUE(a.has_metadata);
+    EXPECT_FALSE(a.anchor_is_late) << "equal dates are the correct, seeded shape";
+    EXPECT_EQ(a.effective_anchor, "2025-10-05");
+}
+
+// An anchor EARLIER than the first result is normal -- a book seeded before its
+// first run -- and annualizes conservatively. Flagging it would train operators
+// to ignore the warning.
+TEST(TradingDaysAnchor, AnAnchorBeforeTheBookIsAcceptedAsSeeded) {
+    const auto a = assess_trading_days_anchor("2025-10-01", "2025-10-05");
+    EXPECT_FALSE(a.anchor_is_late);
+    EXPECT_EQ(a.effective_anchor, "2025-10-01")
+        << "the seeded date wins: it says when the strategy went live, which is the "
+           "quantity being annualized over";
+}
+
+// No metadata row: the DB function's own MIN(date) fallback is already right, so
+// the check must not invent an override.
+TEST(TradingDaysAnchor, NoMetadataRowDefersToTheBook) {
+    const auto a = assess_trading_days_anchor("", "2026-04-01");
+    EXPECT_FALSE(a.has_metadata);
+    EXPECT_FALSE(a.anchor_is_late);
+    EXPECT_EQ(a.effective_anchor, "2026-04-01");
+}
+
+// A genuine first run: a seeded anchor and no history at all. There is nothing to
+// contradict, and calling that a defect would fire on every new strategy.
+TEST(TradingDaysAnchor, AFirstRunWithNoHistoryTrustsTheSeededAnchor) {
+    const auto a = assess_trading_days_anchor("2026-09-01", "");
+    EXPECT_TRUE(a.has_metadata);
+    EXPECT_FALSE(a.anchor_is_late);
+    EXPECT_EQ(a.effective_anchor, "2026-09-01");
+}
+
+// Neither source: the function returns 1 and so must this, rather than a zero or
+// a negative that would divide badly downstream.
+TEST(TradingDaysAnchor, NothingKnownYieldsOneDay) {
+    const auto a = assess_trading_days_anchor("", "");
+    EXPECT_TRUE(a.effective_anchor.empty());
+    EXPECT_EQ(trading_days_from_anchor(a.effective_anchor, "2026-09-03"), 1);
+}
+
+// The count must be the SAME quantity the SQL computes, or an override would
+// silently redefine the denominator instead of correcting its anchor.
+// SQL: GREATEST(1, (p_target_date - v_start_date) + 1), whole calendar days.
+TEST(TradingDaysAnchor, TheCountReproducesTheSqlExactly) {
+    EXPECT_EQ(trading_days_from_anchor("2026-09-03", "2026-09-03"), 1) << "same day is 1";
+    EXPECT_EQ(trading_days_from_anchor("2026-09-02", "2026-09-03"), 2) << "inclusive of both ends";
+    EXPECT_EQ(trading_days_from_anchor("2025-10-05", "2026-05-03"), 211)
+        << "the futures figure migration 004's verification block pins";
+    // Calendar days, so weekends and holidays count -- exactly like date subtraction.
+    EXPECT_EQ(trading_days_from_anchor("2026-08-07", "2026-08-10"), 4) << "Fri to Mon";
+    // Leap year handled by the same UTC arithmetic the freshness check uses.
+    EXPECT_EQ(trading_days_from_anchor("2024-02-28", "2024-03-01"), 3);
+    EXPECT_EQ(trading_days_from_anchor("2026-02-28", "2026-03-01"), 2);
+    // A target BEFORE the anchor floors at 1, matching GREATEST(1, ...), rather
+    // than going negative and inverting the sign of every annualized return.
+    EXPECT_EQ(trading_days_from_anchor("2026-09-03", "2026-01-01"), 1);
+    // Malformed input is the function's "I do not know" answer, not a huge count.
+    EXPECT_EQ(trading_days_from_anchor("garbage", "2026-09-03"), 1);
+    EXPECT_EQ(trading_days_from_anchor("2026-09-03", ""), 1);
+}

--- a/tests/live/test_unrealized_cost_basis.cpp
+++ b/tests/live/test_unrealized_cost_basis.cpp
@@ -14,6 +14,7 @@
 
 #include <gtest/gtest.h>
 #include <memory>
+#include <type_traits>
 #include <unordered_map>
 #include <vector>
 
@@ -77,10 +78,21 @@ TEST(UnrealizedCostBasis, AHeldPositionDoesNotMeasureAsZero) {
 }
 
 TEST(UnrealizedCostBasis, RowAndAggregateAgreeOnTheSameInputs) {
-    // The invariant F-D restores: what the runner writes per row equals what the manager
-    // reports in the aggregate, because they are the same function on the same fields.
+    // The invariant F-D restores: what the runner writes per row equals what the MANAGER
+    // reports in its aggregate.
+    //
+    // BA-3 / C-3 D2(b): this test used to accumulate BOTH sides from
+    // unrealized_from_cost_basis itself, differing only by point_value defaulted versus
+    // passed as 1.0. That is a tautology -- it compared the helper to itself and never
+    // read a single manager output, so it would have passed even if the aggregate had
+    // stopped using the helper entirely, which is the exact drift the commit claims to
+    // prevent. It now reads get_current_snapshot(), and pins both sides against an
+    // independently computed figure so they cannot drift TOGETHER either.
     auto& registry = InstrumentRegistry::instance();
     LivePnLManager mgr(500000.0, registry);
+    // An equity book: one share is one unit. Stated explicitly because the manager's
+    // default is FUTURE, where an unregistered AAPL would pick up a contract multiplier.
+    mgr.set_asset_type(AssetType::EQUITY);
 
     std::vector<Position> positions = {at_basis("AAPL", 250.0, 188.25),
                                        at_basis("MSFT", -80.0, 410.00)};
@@ -89,28 +101,73 @@ TEST(UnrealizedCostBasis, RowAndAggregateAgreeOnTheSameInputs) {
 
     ASSERT_TRUE(mgr.calculate_position_pnls(positions, current, previous).is_ok());
 
+    // Computed here from the position fields alone, with no reference to the code under
+    // test. If the row rule and the aggregate rule both changed in the same direction,
+    // this is what still catches it.
+    const double expected = 250.0 * (194.10 - 188.25) + (-80.0) * (402.50 - 410.00);
+    ASSERT_NE(expected, 0.0) << "the fixture must have real unrealized P&L to compare";
+
+    // Side 1: the manager's OWN aggregate, the number live_results carries.
+    auto snapshot = mgr.get_current_snapshot();
+    ASSERT_TRUE(snapshot.is_ok());
+    const double aggregate = snapshot.value().unrealized_pnl;
+
+    // Side 2: what the equity runner persists per row, at the point value the manager
+    // itself resolved for each symbol -- not a hard-coded 1.0 standing in for it.
     double row_total = 0.0;
     for (const auto& p : positions) {
-        // Exactly what the equity runner now persists per row.
         row_total += LivePnLManager::unrealized_from_cost_basis(
-            p.quantity.as_double(), static_cast<double>(p.average_price), current.at(p.symbol));
+            p.quantity.as_double(), static_cast<double>(p.average_price),
+            current.at(p.symbol), mgr.get_point_value(p.symbol));
     }
-    EXPECT_NE(row_total, 0.0) << "the fixture must actually have unrealized P&L to compare";
 
-    double aggregate = 0.0;
-    for (const auto& p : positions) {
-        aggregate += LivePnLManager::unrealized_from_cost_basis(
-            p.quantity.as_double(), static_cast<double>(p.average_price), current.at(p.symbol),
-            /*point_value=*/1.0);
-    }
-    EXPECT_NEAR(row_total, aggregate, 1e-9);
+    EXPECT_NEAR(aggregate, expected, 1e-9)
+        << "the manager's aggregate must be the cost-basis measurement, not something else";
+    EXPECT_NEAR(row_total, expected, 1e-9) << "so must the per-row figure";
+    EXPECT_NEAR(aggregate, row_total, 1e-9)
+        << "row and aggregate are the same measurement on the same inputs (F-D)";
 }
 
+// BA-3 / C-3 D2(a): an ACTUAL compile-time pin on the struct's shape.
+//
+// This test used to claim "if a member named entry_price comes back, this file stops
+// compiling at the line above" while its body only asserted that two unrelated members
+// were 0.0. Nothing referenced entry_price, so nothing could stop compiling: restoring
+// the field AND reverting the runner to the always-zero persistence left the file
+// building and the suite green. The claim is now enforced by a detector rather than
+// asserted in a comment.
+namespace {
+
+template <typename T, typename = void>
+struct has_entry_price : std::false_type {};
+
+template <typename T>
+struct has_entry_price<T, std::void_t<decltype(std::declval<T&>().entry_price)>>
+    : std::true_type {};
+
+// The pin. Reintroducing MeanReversionInstrumentData::entry_price fails the BUILD here,
+// which is the only place that can catch it before it silently reports 0 again: the
+// field had no writer anywhere in the tree, so every persisted row read 0 while the
+// aggregate reported otherwise.
+static_assert(!has_entry_price<MeanReversionInstrumentData>::value,
+              "MeanReversionInstrumentData::entry_price is back. It is a cost-basis field "
+              "on per-instrument scratch data with no writer, which is what made every "
+              "persisted trading.positions.unrealized_pnl 0 while live_results disagreed "
+              "(F-D). Cost basis lives on Position::average_price, whose sole writer is "
+              "BaseStrategy::on_execution -- see docs/AVERAGE_PRICE_LIFECYCLE.md.");
+
+}  // namespace
+
 TEST(UnrealizedCostBasis, InstrumentDataCarriesNoCostBasisField) {
-    // Guards the regression's root: cost basis must not be reintroduced onto the
-    // strategy's per-instrument scratch data, where nothing writes it. If a member named
-    // entry_price comes back, this file stops compiling at the line above rather than
-    // silently reporting 0 again.
+    // The static_assert above is the real guard; this makes the intent visible in the
+    // test log and fails loudly rather than only at build time.
+    EXPECT_FALSE(has_entry_price<MeanReversionInstrumentData>::value)
+        << "cost basis must not be reintroduced onto the strategy's scratch data";
+
+    // A cost basis has exactly one home, and it is not here.
+    EXPECT_TRUE(has_entry_price<Position>::value == false)
+        << "Position carries average_price, never entry_price";
+
     MeanReversionInstrumentData d;
     EXPECT_DOUBLE_EQ(d.target_position, 0.0);
     EXPECT_DOUBLE_EQ(d.current_price, 0.0);

--- a/tests/storage/test_backtest_results_manager.cpp
+++ b/tests/storage/test_backtest_results_manager.cpp
@@ -189,17 +189,6 @@ TEST_F(BacktestResultsManagerTest, SaveSignalsBatchInvokesStoreBacktestSignalsPe
     EXPECT_GT(db_->call_count("store_backtest_signals"), 0);
 }
 
-// ===== save_metadata =====
-
-TEST_F(BacktestResultsManagerTest, SaveMetadataInvokesStoreBacktestMetadata) {
-    mgr_->set_metadata(date_at(2026, 1, 1), date_at(2026, 1, 5),
-                        nlohmann::json{{"key", "val"}}, "Run name", "Run desc");
-    db_->reset_call_counts();
-    auto r = mgr_->save_metadata("RUN_1");
-    EXPECT_TRUE(r.is_ok());
-    EXPECT_EQ(db_->call_count("store_backtest_metadata"), 1);
-}
-
 // ===== save_strategy_positions / save_strategy_executions =====
 
 TEST_F(BacktestResultsManagerTest, SaveStrategyPositionsInvokesPerStrategyDbCall) {

--- a/tests/strategy/test_base_strategy.cpp
+++ b/tests/strategy/test_base_strategy.cpp
@@ -537,3 +537,63 @@ TEST_F(PnLAccountingBranchTest, AccessorIsStableAcrossCalls) {
 }
 
 }  // namespace pnl_accounting_branch_detail
+
+// ============================================================================
+// E2-F27 / T-OR.4: a fill that crosses zero realizes on the CLOSED quantity only.
+//
+// Long 100 @ 150, SELL 150 @ 170: 100 shares close (realized 100 x 20 = 2000)
+// and the remaining 50 open a new short at the fill price. Realizing on the
+// full 150 (3000) books P&L on 50 shares that were never held. Mirror for the
+// short side. TF/TFF/TFS override on_execution; MR and any non-overriding
+// strategy hit this path on an optimizer-driven flip.
+// ============================================================================
+TEST_F(BaseStrategyTest, OnExecution_FlipRealizesOnlyTheClosedQuantity_Long) {
+    auto db = std::make_shared<MockPostgresDatabase>();
+    StrategyConfig config;
+    auto strategy = createRunningStrategy(config, db);
+
+    ASSERT_TRUE(strategy->on_execution(createExecution(Side::BUY, "AAPL", 100, 150.0)).is_ok());
+    ASSERT_TRUE(strategy->on_execution(createExecution(Side::SELL, "AAPL", 150, 170.0)).is_ok());
+
+    const auto& pos = strategy->get_positions().at("AAPL");
+    EXPECT_DOUBLE_EQ(pos.realized_pnl.as_double(), 2000.0)
+        << "realized must be (170-150) x the 100 shares that closed, not x 150";
+    EXPECT_DOUBLE_EQ(strategy->get_metrics().realized_pnl, 2000.0);
+    EXPECT_DOUBLE_EQ(pos.quantity.as_double(), -50.0);
+    EXPECT_DOUBLE_EQ(pos.average_price.as_double(), 170.0)
+        << "the 50-share remainder opens at the fill price";
+}
+
+TEST_F(BaseStrategyTest, OnExecution_FlipRealizesOnlyTheClosedQuantity_Short) {
+    auto db = std::make_shared<MockPostgresDatabase>();
+    StrategyConfig config;
+    auto strategy = createRunningStrategy(config, db);
+
+    ASSERT_TRUE(strategy->on_execution(createExecution(Side::SELL, "AAPL", 100, 150.0)).is_ok());
+    ASSERT_TRUE(strategy->on_execution(createExecution(Side::BUY, "AAPL", 150, 130.0)).is_ok());
+
+    const auto& pos = strategy->get_positions().at("AAPL");
+    EXPECT_DOUBLE_EQ(pos.realized_pnl.as_double(), 2000.0)
+        << "realized must be (150-130) x the 100 shares that covered, not x 150";
+    EXPECT_DOUBLE_EQ(strategy->get_metrics().realized_pnl, 2000.0);
+    EXPECT_DOUBLE_EQ(pos.quantity.as_double(), 50.0);
+    EXPECT_DOUBLE_EQ(pos.average_price.as_double(), 130.0)
+        << "the 50-share remainder opens at the fill price";
+}
+
+// An exact close (qty == fill) and a partial close are unchanged by the fix.
+TEST_F(BaseStrategyTest, OnExecution_ExactAndPartialCloseRealizeOnTheFill) {
+    auto db = std::make_shared<MockPostgresDatabase>();
+    StrategyConfig config;
+    auto strategy = createRunningStrategy(config, db);
+
+    ASSERT_TRUE(strategy->on_execution(createExecution(Side::BUY, "AAPL", 100, 150.0)).is_ok());
+    ASSERT_TRUE(strategy->on_execution(createExecution(Side::SELL, "AAPL", 40, 160.0)).is_ok());
+    EXPECT_DOUBLE_EQ(strategy->get_positions().at("AAPL").realized_pnl.as_double(), 400.0);
+    EXPECT_DOUBLE_EQ(strategy->get_positions().at("AAPL").quantity.as_double(), 60.0);
+    EXPECT_DOUBLE_EQ(strategy->get_positions().at("AAPL").average_price.as_double(), 150.0);
+
+    ASSERT_TRUE(strategy->on_execution(createExecution(Side::SELL, "AAPL", 60, 170.0)).is_ok());
+    EXPECT_DOUBLE_EQ(strategy->get_positions().at("AAPL").realized_pnl.as_double(), 400.0 + 1200.0);
+    EXPECT_DOUBLE_EQ(strategy->get_positions().at("AAPL").quantity.as_double(), 0.0);
+}

--- a/tests/strategy/test_live_bt_signal_consistency.cpp
+++ b/tests/strategy/test_live_bt_signal_consistency.cpp
@@ -10,17 +10,39 @@
 
 #include "../core/test_base.hpp"
 #include "../data/test_db_utils.hpp"
+#include "trade_ngin/live/live_daily_cycle.hpp"
 #include "trade_ngin/strategy/equity_strategy_builder.hpp"
 #include "trade_ngin/strategy/mean_reversion.hpp"
 
 using namespace trade_ngin;
 using namespace trade_ngin::testing;
 
-// Review T-OR.5: the backtest and live equity runners must produce identical signals
-// from identical bars. Both runners now build the MeanReversionConfig via the shared
-// build_mean_reversion_config() helper (review T2.6); this test pins that two
-// strategies constructed that way agree bar-for-bar. It is the regression tripwire
-// for any future change that lets the two runners' construction drift apart.
+// NEW-6(a) / T-OR.5 -- the backtest and the live runner must reach the same state from
+// the same bars.
+//
+// This file used to feed BOTH sides the same vector in the same call and assert they
+// agreed, which is a tautology: it proved that one function is deterministic. It could
+// not see the difference that actually existed, because the two runners do not stage
+// their data the same way.
+//
+//   BACKTEST  BacktestCoordinator walks the history and calls on_data() once per day
+//             with that day's bars (backtest_coordinator.cpp:393, :587), then reads
+//             get_target_positions().
+//   LIVE      LiveDailyCycle::prepare_strategy_for_signals() seeds the previous day's
+//             book, then PortfolioManager::process_market_data() calls on_data() once
+//             with the whole loaded window (portfolio_manager.cpp:217) and reads
+//             get_target_positions().
+//
+// Until E2-F28 the live path fed that window TWICE -- prepare_strategy_for_signals()
+// called on_data() itself and then the portfolio manager called it again. MeanReversion
+// appends per bar, so the live strategy's volatility window, ADV EMA and warm-up counter
+// were all computed over a series twice as long as the one that traded, and the two
+// runners silently disagreed on the same data.
+//
+// So the test drives the two SEQUENCES and compares the state each arrives at. The
+// window is deliberately shorter than vol_lookback: that is where the doubling changes
+// the answer rather than merely the bookkeeping, because the volatility window then
+// spans the seam between the two copies and the warm-up gate flips.
 
 class LiveBtSignalConsistencyTest : public TestBase {
 protected:
@@ -54,8 +76,18 @@ protected:
         TestBase::TearDown();
     }
 
-    // Deterministic mean-reverting series (fixed seed); the *same* vector is fed to
-    // both strategies, so input is identical by construction.
+    // The config block both runners read from portfolio.json, through the shared builder
+    // (review T2.6). vol_lookback exceeds the window on purpose -- see the file header.
+    static nlohmann::json config_json() {
+        return {{"lookback_period", 20},  {"entry_threshold", 2.0},
+                {"exit_threshold", 0.5},  {"risk_target", 0.15},
+                {"position_size", 0.1},   {"vol_lookback", 40},
+                {"use_stop_loss", true},  {"stop_loss_pct", 0.05},
+                {"allow_fractional_shares", true}};
+    }
+
+    // Deterministic mean-reverting series with a VOLUME LEVEL SHIFT, so the ADV EMA is a
+    // function of how many times the series was fed and not just of its last value.
     std::vector<Bar> make_bars(const std::string& symbol, int n, double start,
                                unsigned seed) const {
         std::vector<Bar> data;
@@ -75,7 +107,7 @@ protected:
             bar.open = price;
             bar.high = price * 1.01;
             bar.low = price * 0.99;
-            bar.volume = 1000000.0;  // constant -> no rand() nondeterminism
+            bar.volume = (i < n / 2) ? 5000000.0 : 120000.0;
             data.push_back(bar);
         }
         return data;
@@ -90,49 +122,154 @@ protected:
         return s;
     }
 
+    // A held book, so generate_signal() takes its EXIT branch and the stop-loss has a
+    // basis to measure from. A fresh flat strategy never executes either, which is why
+    // the previous version of this test could not reach the branches that matter.
+    std::unordered_map<std::string, Position> held_book() const {
+        std::unordered_map<std::string, Position> book;
+        for (const auto& symbol : symbols_) {
+            Position p;
+            p.symbol = symbol;
+            p.quantity = Quantity(25.0);
+            p.average_price = Decimal(148.0);
+            p.last_update = std::chrono::system_clock::now();
+            book[symbol] = p;
+        }
+        return book;
+    }
+
+    // BacktestCoordinator's staging: one on_data() per day, in date order.
+    static void feed_backtest_sequence(BaseStrategy& strategy,
+                                       const std::vector<Bar>& bars) {
+        for (const auto& bar : bars) {
+            ASSERT_TRUE(strategy.on_data({bar}).is_ok());
+        }
+    }
+
+    // The live runner's staging: seed the book, then ONE feed of the loaded window by
+    // PortfolioManager::process_market_data.
+    static void feed_live_sequence(BaseStrategy& strategy,
+                                   const std::unordered_map<std::string, Position>& book,
+                                   const std::vector<Bar>& bars) {
+        ASSERT_TRUE(LiveDailyCycle::prepare_strategy_for_signals(strategy, book).is_ok());
+        ASSERT_TRUE(strategy.on_data(bars).is_ok());
+    }
+
     std::shared_ptr<MockPostgresDatabase> db_;
     StrategyConfig base_config_;
     RiskLimits risk_limits_;
     std::vector<std::string> symbols_{"AAPL", "MSFT", "GOOGL"};
+    static constexpr int kBars = 30;  // shorter than vol_lookback, on purpose
 };
 
-TEST_F(LiveBtSignalConsistencyTest, SharedBuilderYieldsIdenticalSignals) {
-    // The same JSON "config" block both runners read from portfolio.json.
-    nlohmann::json cfg = {{"lookback_period", 20},  {"entry_threshold", 2.0},
-                          {"exit_threshold", 0.5},  {"risk_target", 0.15},
-                          {"position_size", 0.1},   {"vol_lookback", 20},
-                          {"use_stop_loss", true},  {"stop_loss_pct", 0.05},
-                          {"allow_fractional_shares", true}};
+// The real parity claim: run the two staging sequences over the same bars with the same
+// held book and compare everything the strategy carries into its targets.
+TEST_F(LiveBtSignalConsistencyTest, BacktestAndLiveStagingReachTheSameState) {
+    auto mr_bt = apps::build_mean_reversion_config(config_json());
+    auto mr_live = apps::build_mean_reversion_config(config_json());
+    ASSERT_EQ(mr_bt.vol_lookback, 40);
+    ASSERT_GT(mr_bt.vol_lookback, kBars)
+        << "the window must be shorter than vol_lookback or a doubled feed is invisible";
 
-    // Both runners construct via the shared builder -> identical MeanReversionConfig.
-    auto mr_bt = apps::build_mean_reversion_config(cfg);
-    auto mr_live = apps::build_mean_reversion_config(cfg);
-
-    // Distinct ids (StateManager keys by id); behavior must still be identical.
     auto bt_strat = make_strategy("BT_PARITY", mr_bt);
     auto live_strat = make_strategy("LIVE_PARITY", mr_live);
 
+    const auto book = held_book();
+    // The backtest reaches a held book through on_execution over its own history; here
+    // both sides are handed the same book so the comparison isolates the STAGING.
+    ASSERT_TRUE(bt_strat->seed_positions(book).is_ok());
+
     for (const auto& symbol : symbols_) {
-        auto bars = make_bars(symbol, 60, 150.0, 42);  // identical vector to both
-        ASSERT_TRUE(bt_strat->on_data(bars).is_ok());
-        ASSERT_TRUE(live_strat->on_data(bars).is_ok());
+        const auto bars = make_bars(symbol, kBars, 150.0, 42);  // identical vector to both
+        feed_backtest_sequence(*bt_strat, bars);
+        feed_live_sequence(*live_strat, book, bars);
     }
 
-    const auto& sig_bt = bt_strat->get_last_signals();
-    const auto& sig_live = live_strat->get_last_signals();
+    for (const auto& symbol : symbols_) {
+        const auto* bt = bt_strat->get_instrument_data(symbol);
+        const auto* live = live_strat->get_instrument_data(symbol);
+        ASSERT_NE(bt, nullptr);
+        ASSERT_NE(live, nullptr);
 
-    ASSERT_EQ(sig_bt.size(), sig_live.size());
-    for (const auto& [symbol, value] : sig_bt) {
-        auto it = sig_live.find(symbol);
-        ASSERT_NE(it, sig_live.end()) << "live missing signal for " << symbol;
-        EXPECT_DOUBLE_EQ(value, it->second) << "signal mismatch for " << symbol;
+        EXPECT_EQ(live->price_history.size(), bt->price_history.size())
+            << symbol << ": the live staging saw a different number of closes";
+        EXPECT_EQ(live->volume_sample_count, bt->volume_sample_count)
+            << symbol << ": the ADV warm-up counter drives fractional-share eligibility";
+        EXPECT_DOUBLE_EQ(live->avg_daily_volume, bt->avg_daily_volume)
+            << symbol << ": the ADV EMA advanced a different number of times";
+        EXPECT_DOUBLE_EQ(live->current_volatility, bt->current_volatility)
+            << symbol << ": volatility sizes the position";
+        EXPECT_DOUBLE_EQ(live->moving_average, bt->moving_average) << symbol;
+        EXPECT_DOUBLE_EQ(live->std_deviation, bt->std_deviation) << symbol;
     }
 
-    // Cross-check via the per-symbol z-score accessor as well.
+    // z-scores and the signals derived from them.
     for (const auto& symbol : symbols_) {
-        EXPECT_DOUBLE_EQ(bt_strat->get_z_score(symbol), live_strat->get_z_score(symbol));
+        EXPECT_DOUBLE_EQ(bt_strat->get_z_score(symbol), live_strat->get_z_score(symbol))
+            << symbol;
+    }
+    // NOT compared here: get_last_signals(). It is filled by BaseStrategy::on_signal(),
+    // which only the three trend strategies call; MeanReversionStrategy::on_data() keeps
+    // its signals in a local and never publishes them, so the map is empty on BOTH sides
+    // and comparing it asserts 0 == 0. The previous version of this test did exactly
+    // that. The signal is observed through the z-score and the target instead, which are
+    // what it is computed from and what it produces.
+    EXPECT_TRUE(bt_strat->get_last_signals().empty())
+        << "if MeanReversion starts publishing signals, compare them here too";
+
+    // The output the runners actually act on.
+    const auto targets_bt = bt_strat->get_target_positions();
+    const auto targets_live = live_strat->get_target_positions();
+    ASSERT_EQ(targets_bt.size(), targets_live.size());
+    for (const auto& [symbol, position] : targets_bt) {
+        auto it = targets_live.find(symbol);
+        ASSERT_NE(it, targets_live.end()) << "live missing target for " << symbol;
+        EXPECT_DOUBLE_EQ(position.quantity.as_double(), it->second.quantity.as_double())
+            << "target mismatch for " << symbol;
     }
 
     bt_strat->stop();
     live_strat->stop();
+}
+
+// The seeded book must survive the live staging: seeding is what lets generate_signal()
+// take the exit branch and lets the stop-loss measure from a basis (F-B). A staging
+// change that quietly dropped it would make every held position look flat again.
+TEST_F(LiveBtSignalConsistencyTest, LiveStagingKeepsTheSeededBook) {
+    auto mr = apps::build_mean_reversion_config(config_json());
+    auto strat = make_strategy("LIVE_SEED_SURVIVES", mr);
+
+    const auto book = held_book();
+    for (const auto& symbol : symbols_) {
+        feed_live_sequence(*strat, book, make_bars(symbol, kBars, 150.0, 42));
+    }
+
+    const auto positions = strat->get_positions();
+    for (const auto& symbol : symbols_) {
+        ASSERT_EQ(positions.count(symbol), 1u) << symbol << " lost its seeded holding";
+        EXPECT_DOUBLE_EQ(positions.at(symbol).quantity.as_double(), 25.0);
+        EXPECT_DOUBLE_EQ(positions.at(symbol).average_price.as_double(), 148.0)
+            << "a rename-free staging pass must not restate the cost basis";
+        EXPECT_DOUBLE_EQ(positions.at(symbol).realized_pnl.as_double(), 0.0)
+            << "seeding zeroes realized: the column is a daily flow (E2-F19)";
+    }
+
+    strat->stop();
+}
+
+// The shared builder still has to produce one config from one JSON block -- the property
+// the previous version of this file was really testing. Kept, stated as what it is.
+TEST_F(LiveBtSignalConsistencyTest, SharedBuilderIsDeterministic) {
+    const auto a = apps::build_mean_reversion_config(config_json());
+    const auto b = apps::build_mean_reversion_config(config_json());
+
+    EXPECT_EQ(a.lookback_period, b.lookback_period);
+    EXPECT_DOUBLE_EQ(a.entry_threshold, b.entry_threshold);
+    EXPECT_DOUBLE_EQ(a.exit_threshold, b.exit_threshold);
+    EXPECT_DOUBLE_EQ(a.risk_target, b.risk_target);
+    EXPECT_DOUBLE_EQ(a.position_size, b.position_size);
+    EXPECT_EQ(a.vol_lookback, b.vol_lookback);
+    EXPECT_EQ(a.use_stop_loss, b.use_stop_loss);
+    EXPECT_DOUBLE_EQ(a.stop_loss_pct, b.stop_loss_pct);
+    EXPECT_EQ(a.allow_fractional_shares, b.allow_fractional_shares);
 }

--- a/tests/strategy/test_live_daily_cycle_seeding.cpp
+++ b/tests/strategy/test_live_daily_cycle_seeding.cpp
@@ -699,3 +699,84 @@ TEST_F(LiveDailyCycleSeedingTest, LiveDayFeedsEachBarExactlyOnce) {
         << "ADV EMA advanced " << data->volume_sample_count << " times for "
         << bars.size() << " bars";
 }
+
+// ---------------------------------------------------------------------------
+// E2-F35 / BA-4 -- the row and the aggregate mark from ONE map
+// ---------------------------------------------------------------------------
+
+// The regression, stated as the two sides of the identity. THIN has no T-1 close;
+// execute_day_t widens to an older real session and both fills and marks it there.
+// The aggregate (summed over `positions` after resolve_and_apply_basis) therefore
+// carries THIN's mark, while the day-T row loop used to recompute from the T-1 close
+// map -- which does not contain THIN at all -- and wrote 0. Same book, two answers.
+TEST_F(LiveDailyCycleSeedingTest, RowAndAggregateMarkAWidenedSymbolIdentically) {
+    const auto now = std::chrono::system_clock::now();
+
+    // T-1 closes: AAPL printed, THIN did not.
+    const std::unordered_map<std::string, double> t1_closes{{"AAPL", 110.0}};
+    // What execute_day_t actually priced with: the T-1 closes plus THIN's widened close.
+    const std::unordered_map<std::string, double> execution_prices{{"AAPL", 110.0},
+                                                                   {"THIN", 50.0}};
+
+    std::unordered_map<std::string, Position> previous;
+    previous["AAPL"] = held_long("AAPL", 10.0, 100.0);
+    previous["THIN"] = held_long("THIN", 20.0, 40.0);
+    auto positions = previous;
+
+    LiveDailyCycle::resolve_and_apply_basis(positions, {}, previous, execution_prices);
+
+    double aggregate = 0.0;
+    for (const auto& [symbol, pos] : positions) aggregate += pos.unrealized_pnl.as_double();
+    EXPECT_NEAR(aggregate, 10.0 * (110.0 - 100.0) + 20.0 * (50.0 - 40.0), 1e-9);
+
+    // What the day-T row loop writes, marked from the map the fix hands it.
+    const auto marks = LiveDailyCycle::day_t_mark_prices(t1_closes, execution_prices);
+    double rows = 0.0;
+    for (const auto& [symbol, pos] : positions) {
+        auto mark = marks.find(symbol);
+        const double price = mark != marks.end() ? mark->second : 0.0;
+        if (price > 0.0) {
+            rows += LivePnLManager::unrealized_from_cost_basis(
+                pos.quantity.as_double(), pos.average_price.as_double(), price);
+        }
+    }
+    EXPECT_NEAR(rows, aggregate, 1e-9)
+        << "the row sum and the aggregate must mark from the same map (E2-F35)";
+
+    // And the shape of the defect, for the record: the un-widened map drops THIN's mark.
+    double rows_from_t1_only = 0.0;
+    for (const auto& [symbol, pos] : positions) {
+        auto mark = t1_closes.find(symbol);
+        if (mark != t1_closes.end() && mark->second > 0.0) {
+            rows_from_t1_only += LivePnLManager::unrealized_from_cost_basis(
+                pos.quantity.as_double(), pos.average_price.as_double(), mark->second);
+        }
+    }
+    EXPECT_NEAR(aggregate - rows_from_t1_only, 200.0, 1e-9)
+        << "characterizing E2-F35: a widened symbol's row was 0 while the aggregate "
+           "carried its mark";
+}
+
+// The closed-day path must be untouched. execute_day_t is skipped on a non-trading day,
+// so execution_prices is empty and the marks are exactly the T-1 closes.
+TEST_F(LiveDailyCycleSeedingTest, EmptyExecutionPricesLeaveTheT1CloseMapAlone) {
+    const std::unordered_map<std::string, double> t1_closes{{"AAPL", 110.0}, {"MSFT", 300.0}};
+    EXPECT_EQ(LiveDailyCycle::day_t_mark_prices(t1_closes, {}), t1_closes);
+}
+
+// A present T-1 close is not overwritten by a different value unless the execution
+// path actually priced there -- and when it did, the execution price is the truth,
+// because that is what the fill was struck at.
+TEST_F(LiveDailyCycleSeedingTest, ExecutionPriceWinsAndNonPositiveSubstitutesAreIgnored) {
+    const std::unordered_map<std::string, double> t1_closes{{"AAPL", 110.0}, {"MSFT", 300.0}};
+    const std::unordered_map<std::string, double> execution_prices{
+        {"AAPL", 111.5}, {"DEAD", 0.0}, {"NEG", -3.0}};
+
+    const auto marks = LiveDailyCycle::day_t_mark_prices(t1_closes, execution_prices);
+
+    EXPECT_DOUBLE_EQ(marks.at("AAPL"), 111.5);
+    EXPECT_DOUBLE_EQ(marks.at("MSFT"), 300.0);
+    EXPECT_EQ(marks.count("DEAD"), 0u)
+        << "a zero mark books the whole notional as a gain; absent is the right answer";
+    EXPECT_EQ(marks.count("NEG"), 0u);
+}

--- a/tests/strategy/test_live_daily_cycle_seeding.cpp
+++ b/tests/strategy/test_live_daily_cycle_seeding.cpp
@@ -17,6 +17,19 @@
 using namespace trade_ngin;
 using namespace trade_ngin::testing;
 
+// The live sequence exactly as apps/strategies/live_equity_mean_reversion.cpp
+// performs it: LiveDailyCycle hands the previous day's book back, then
+// PortfolioManager::process_market_data feeds the day's bars (portfolio_manager.cpp
+// calls strategy->on_data(data) itself). Written as one helper so a test cannot
+// accidentally exercise a sequence the runner does not.
+static Result<void> live_sequence(BaseStrategy& strategy,
+                                  const std::unordered_map<std::string, Position>& previous,
+                                  const std::vector<Bar>& bars) {
+    auto seeded = LiveDailyCycle::prepare_strategy_for_signals(strategy, previous);
+    if (seeded.is_error()) return seeded;
+    return strategy.on_data(bars);  // the portfolio manager's one and only feed
+}
+
 // Wave 2 regression tests.
 //
 // F-B: the live equity runner never seeded the strategy's positions_ from the
@@ -144,7 +157,7 @@ TEST_F(LiveDailyCycleSeedingTest, SeededLongIsHeldInsideTheHoldBand) {
     auto bars = hold_band_series("AAPL");
 
     auto flat = create_strategy();
-    ASSERT_TRUE(LiveDailyCycle::prepare_strategy_for_signals(*flat, {}, bars).is_ok());
+    ASSERT_TRUE(live_sequence(*flat, {}, bars).is_ok());
 
     const double z = flat->get_z_score("AAPL");
     ASSERT_LT(z, -mr_config_.exit_threshold)
@@ -160,7 +173,7 @@ TEST_F(LiveDailyCycleSeedingTest, SeededLongIsHeldInsideTheHoldBand) {
     std::unordered_map<std::string, Position> previous{
         {"AAPL", held_long("AAPL", 100.0, 98.0)}};
     ASSERT_TRUE(
-        LiveDailyCycle::prepare_strategy_for_signals(*seeded, previous, bars).is_ok());
+        live_sequence(*seeded, previous, bars).is_ok());
 
     EXPECT_GT(seeded->get_position("AAPL"), 0.0)
         << "a held long inside the hold band must be kept, not liquidated at the "
@@ -177,7 +190,7 @@ TEST_F(LiveDailyCycleSeedingTest, SeededLongExitsOnlyOnceInsideTheExitThreshold)
     std::unordered_map<std::string, Position> previous{
         {"AAPL", held_long("AAPL", 100.0, 98.0)}};
     ASSERT_TRUE(
-        LiveDailyCycle::prepare_strategy_for_signals(*seeded, previous, bars).is_ok());
+        live_sequence(*seeded, previous, bars).is_ok());
 
     ASSERT_LT(std::abs(seeded->get_z_score("AAPL")), mr_config_.exit_threshold)
         << "series precondition: z must be inside the exit threshold";
@@ -195,7 +208,7 @@ TEST_F(LiveDailyCycleSeedingTest, StopLossFiresFromTheSeededCostBasis) {
     std::unordered_map<std::string, Position> previous{
         {"AAPL", held_long("AAPL", 100.0, 200.0)}};
     ASSERT_TRUE(
-        LiveDailyCycle::prepare_strategy_for_signals(*seeded, previous, bars).is_ok());
+        live_sequence(*seeded, previous, bars).is_ok());
 
     EXPECT_DOUBLE_EQ(seeded->get_position("AAPL"), 0.0)
         << "a position 50% underwater must be stopped out";
@@ -207,7 +220,7 @@ TEST_F(LiveDailyCycleSeedingTest, StopLossFiresFromTheSeededCostBasis) {
     std::unordered_map<std::string, Position> healthy_book{
         {"AAPL", held_long("AAPL", 100.0, 99.0)}};
     ASSERT_TRUE(
-        LiveDailyCycle::prepare_strategy_for_signals(*healthy, healthy_book, bars).is_ok());
+        live_sequence(*healthy, healthy_book, bars).is_ok());
 
     EXPECT_GT(healthy->get_position("AAPL"), 0.0)
         << "a position 0.5% underwater is inside the 5% stop and must be held";
@@ -230,7 +243,7 @@ TEST_F(LiveDailyCycleSeedingTest, StopLossMeasuresFromRetainedBasisNotPreviousCl
     std::unordered_map<std::string, Position> reanchored_book{
         {"AAPL", held_long("AAPL", 100.0, kPreviousClose)}};
     ASSERT_TRUE(
-        LiveDailyCycle::prepare_strategy_for_signals(*reanchored, reanchored_book, bars)
+        live_sequence(*reanchored, reanchored_book, bars)
             .is_ok());
     ASSERT_GT(reanchored->get_position("AAPL"), 0.0)
         << "sanity: against a re-anchored basis the stop cannot fire -- this is the "
@@ -241,7 +254,7 @@ TEST_F(LiveDailyCycleSeedingTest, StopLossMeasuresFromRetainedBasisNotPreviousCl
     std::unordered_map<std::string, Position> retained_book{
         {"AAPL", held_long("AAPL", 100.0, kTrueBasis)}};
     ASSERT_TRUE(
-        LiveDailyCycle::prepare_strategy_for_signals(*retained, retained_book, bars)
+        live_sequence(*retained, retained_book, bars)
             .is_ok());
     EXPECT_DOUBLE_EQ(retained->get_position("AAPL"), 0.0)
         << "the stop must measure from the retained cost basis";
@@ -309,7 +322,7 @@ TEST_F(LiveDailyCycleSeedingTest, EmptyBookIsInert) {
 
     auto seeded_empty = create_strategy();
     ASSERT_TRUE(
-        LiveDailyCycle::prepare_strategy_for_signals(*seeded_empty, {}, bars).is_ok());
+        live_sequence(*seeded_empty, {}, bars).is_ok());
 
     EXPECT_DOUBLE_EQ(seeded_empty->get_position("AAPL"), unseeded->get_position("AAPL"));
     EXPECT_DOUBLE_EQ(seeded_empty->get_z_score("AAPL"), unseeded->get_z_score("AAPL"));
@@ -328,7 +341,7 @@ TEST_F(LiveDailyCycleSeedingTest, FlatSymbolIsUnaffectedByAnotherSymbolsSeed) {
     std::unordered_map<std::string, Position> previous{
         {"AAPL", held_long("AAPL", 100.0, 98.0)}};
     ASSERT_TRUE(
-        LiveDailyCycle::prepare_strategy_for_signals(*seeded, previous, bars).is_ok());
+        live_sequence(*seeded, previous, bars).is_ok());
 
     EXPECT_DOUBLE_EQ(seeded->get_position("MSFT"), unseeded->get_position("MSFT"))
         << "MSFT was not seeded and must be unchanged";
@@ -343,7 +356,7 @@ TEST_F(LiveDailyCycleSeedingTest, EntrySignalStillOpensANewPosition) {
     auto bars = hold_band_series("AAPL", 94.0);
 
     auto seeded = create_strategy();
-    ASSERT_TRUE(LiveDailyCycle::prepare_strategy_for_signals(*seeded, {}, bars).is_ok());
+    ASSERT_TRUE(live_sequence(*seeded, {}, bars).is_ok());
 
     ASSERT_LT(seeded->get_z_score("AAPL"), -mr_config_.entry_threshold)
         << "series precondition: z must be beyond the entry threshold";
@@ -440,7 +453,7 @@ TEST_F(LiveDailyCycleSeedingTest, SeedZeroesRealizedAndKeepsBasisAndMark) {
         {"AAPL", held_with_pnl("AAPL", 100.0, 98.0, /*realized*/ -466.969196,
                                /*unrealized*/ 12.34)}};
     ASSERT_TRUE(
-        LiveDailyCycle::prepare_strategy_for_signals(*seeded, previous, bars).is_ok());
+        live_sequence(*seeded, previous, bars).is_ok());
 
     const auto& positions = seeded->get_positions();
     auto it = positions.find("AAPL");
@@ -476,7 +489,7 @@ TEST_F(LiveDailyCycleSeedingTest, SeededRealizedDoesNotLeakIntoTheDaysFill) {
     std::unordered_map<std::string, Position> previous{
         {"TMUS", held_with_pnl("TMUS", qty, basis, /*realized*/ -466.969196, 0.0)}};
     ASSERT_TRUE(
-        LiveDailyCycle::prepare_strategy_for_signals(*seeded, previous, bars).is_ok());
+        live_sequence(*seeded, previous, bars).is_ok());
 
     ASSERT_TRUE(seeded->on_execution(fill("TMUS", Side::SELL, qty, exit)).is_ok());
 
@@ -533,7 +546,7 @@ TEST_F(LiveDailyCycleSeedingTest, ThreeDayFlowWithInterposedFinalization) {
                        double target_qty, double t1_close) {
         auto strat = create_strategy();
         EXPECT_TRUE(
-            LiveDailyCycle::prepare_strategy_for_signals(*strat, loaded, bars).is_ok());
+            live_sequence(*strat, loaded, bars).is_ok());
 
         std::unordered_map<std::string, Position> positions;
         Position target;
@@ -606,7 +619,7 @@ TEST_F(LiveDailyCycleSeedingTest, CloseOutOfAConfiguredSymbolKeepsItsRow) {
     auto strat = create_strategy();
     std::unordered_map<std::string, Position> previous{
         {"MSFT", held_with_pnl("MSFT", 10.0, 100.0, 0.0, 0.0)}};
-    ASSERT_TRUE(LiveDailyCycle::prepare_strategy_for_signals(*strat, previous, bars).is_ok());
+    ASSERT_TRUE(live_sequence(*strat, previous, bars).is_ok());
 
     std::unordered_map<std::string, Position> positions;
     Position target;
@@ -635,7 +648,7 @@ TEST_F(LiveDailyCycleSeedingTest, CloseOutOfAnUnconfiguredSymbolGetsARow) {
     auto strat = create_strategy();
     std::unordered_map<std::string, Position> previous{
         {"MSFT", held_with_pnl("MSFT", 10.0, 100.0, 0.0, 0.0)}};
-    ASSERT_TRUE(LiveDailyCycle::prepare_strategy_for_signals(*strat, previous, bars).is_ok());
+    ASSERT_TRUE(live_sequence(*strat, previous, bars).is_ok());
 
     // MSFT has left the universe: no target entry at all.
     std::unordered_map<std::string, Position> positions;
@@ -658,4 +671,31 @@ TEST_F(LiveDailyCycleSeedingTest, CloseOutOfAnUnconfiguredSymbolGetsARow) {
     EXPECT_NEAR(positions.at("MSFT").realized_pnl.as_double(), 100.0, 1e-6);
     EXPECT_DOUBLE_EQ(positions.at("MSFT").quantity.as_double(), 0.0);
     EXPECT_FALSE(LiveDailyCycle::is_dead_row(positions.at("MSFT")));
+}
+
+// ---------------------------------------------------------------------------
+// E2-F28 -- the live day feeds the strategy ONCE
+// ---------------------------------------------------------------------------
+
+// E2-F28: prepare_strategy_for_signals used to call on_data() itself, and the
+// portfolio manager called it again on the same vector a few lines later. MeanReversion
+// appends unconditionally (mean_reversion.cpp: price_history.push_back per bar,
+// volume_sample_count++ per bar), so every live session saw each bar twice: the history
+// ran to the trim cap instead of the bar count and the ADV EMA advanced over a series
+// that never traded. Backtests feed once, so the two paths could not agree.
+TEST_F(LiveDailyCycleSeedingTest, LiveDayFeedsEachBarExactlyOnce) {
+    auto bars = hold_band_series("AAPL");
+    ASSERT_EQ(bars.size(), 31u) << "fixture precondition";
+
+    auto strat = create_strategy();
+    ASSERT_TRUE(live_sequence(*strat, {}, bars).is_ok());
+
+    const auto* data = strat->get_instrument_data("AAPL");
+    ASSERT_NE(data, nullptr);
+    EXPECT_EQ(data->price_history.size(), bars.size())
+        << "the live day fed the strategy more than once: history holds "
+        << data->price_history.size() << " closes for " << bars.size() << " bars";
+    EXPECT_EQ(data->volume_sample_count, bars.size())
+        << "ADV EMA advanced " << data->volume_sample_count << " times for "
+        << bars.size() << " bars";
 }

--- a/tests/strategy/test_penny_stock_lifecycle.cpp
+++ b/tests/strategy/test_penny_stock_lifecycle.cpp
@@ -1,0 +1,352 @@
+// tests/strategy/test_penny_stock_lifecycle.cpp
+//
+// T-OR.2 -- a sub-dollar name, end to end: sizing -> cost registration -> cost
+// calculation -> fill -> P&L.
+//
+// The only coverage a penny stock had was one lookup of get_tiered_equity_config(0.50,
+// 50000) in test_equity_pnl_accounting.cpp -- a table read, not a lifecycle. Everything
+// downstream of it is live: register_equity_costs_from_bars is called by the live runner,
+// the backtest coordinator and PortfolioManager, and the sizing gates that keep a $0.25
+// name out of fractional shares sit in MeanReversionStrategy::calculate_position_size.
+//
+// A sub-dollar stock is where four rules meet that never meet on a $150 stock:
+//   * fractional shares are refused below `fractional_min_price`, so the target floors;
+//   * the position limit binds in SHARES, and $10k of a $0.25 stock is 40,000 of them;
+//   * SEC Rule 612 makes the tick 0.0001 rather than 0.01, so the spread model prices
+//     off a different grid;
+//   * the commission is $0.005/share against a 1% cap on trade value, and below $0.50 a
+//     share the CAP is the binding term -- the case E2-C2 reordered the expression for.
+//
+// Scenario pin: no red is expected today. It exists so a change to any of those four
+// rules that is harmless at $150 cannot pass unnoticed at $0.25.
+
+#include <gtest/gtest.h>
+
+#include <chrono>
+#include <cmath>
+#include <memory>
+#include <string>
+#include <unordered_map>
+#include <vector>
+
+#include "../core/test_base.hpp"
+#include "../data/test_db_utils.hpp"
+#include "trade_ngin/strategy/mean_reversion.hpp"
+#include "trade_ngin/transaction_cost/asset_cost_config.hpp"
+#include "trade_ngin/transaction_cost/transaction_cost_manager.hpp"
+
+using namespace trade_ngin;
+using namespace trade_ngin::testing;
+using trade_ngin::transaction_cost::TransactionCostManager;
+
+class PennyStockLifecycleTest : public TestBase {
+protected:
+    void SetUp() override {
+        TestBase::SetUp();
+        StateManager::reset_instance();
+
+        db_ = std::make_shared<MockPostgresDatabase>("mock://testdb");
+        ASSERT_TRUE(db_->connect().is_ok());
+
+        strategy_config_.capital_allocation = 100000.0;
+        strategy_config_.max_leverage = 1.0;
+        strategy_config_.asset_classes = {AssetClass::EQUITIES};
+        strategy_config_.frequencies = {DataFrequency::DAILY};
+        for (const auto& symbol : {kPenny, kSubDollar, kNormal}) {
+            strategy_config_.trading_params[symbol] = 1.0;
+            // $10,000 of a $0.25 stock is 40,000 shares; the limit is in SHARES.
+            strategy_config_.position_limits[symbol] = 40000.0;
+        }
+
+        mr_config_.lookback_period = 20;
+        mr_config_.vol_lookback = 20;
+        mr_config_.entry_threshold = 2.0;
+        mr_config_.exit_threshold = 0.5;
+        mr_config_.risk_target = 0.15;
+        mr_config_.position_size = 0.1;
+        mr_config_.use_stop_loss = false;
+        mr_config_.allow_fractional_shares = true;
+        mr_config_.fractional_min_price = 1.0;
+        mr_config_.fractional_min_adv = 50000.0;
+
+        risk_limits_.max_position_size = 1e9;
+        risk_limits_.max_notional_value = 1e9;
+        risk_limits_.max_drawdown = 0.9;
+        risk_limits_.max_leverage = 10.0;
+    }
+
+    void TearDown() override {
+        if (db_) {
+            db_->disconnect();
+            db_.reset();
+        }
+        TestBase::TearDown();
+    }
+
+    std::unique_ptr<MeanReversionStrategy> create_strategy() {
+        static int id = 0;
+        auto strategy = std::make_unique<MeanReversionStrategy>(
+            "TEST_PENNY_" + std::to_string(++id), strategy_config_, mr_config_, db_);
+        EXPECT_TRUE(strategy->initialize().is_ok());
+        EXPECT_TRUE(strategy->update_risk_limits(risk_limits_).is_ok());
+        EXPECT_TRUE(strategy->start().is_ok());
+        return strategy;
+    }
+
+    // 60 bars oscillating around `level`, closing well below the mean so the entry
+    // branch fires long. Volume is constant so ADV is exactly `volume`.
+    std::vector<Bar> series(const std::string& symbol, double level, double volume) const {
+        std::vector<Bar> bars;
+        const auto now = std::chrono::system_clock::now();
+        for (int i = 0; i < 59; ++i) {
+            const double close = (i % 2 == 0) ? level * 0.98 : level * 1.02;
+            bars.push_back(bar(symbol, close, volume, now - std::chrono::hours(24 * (60 - i))));
+        }
+        bars.push_back(bar(symbol, level * 0.90, volume, now));  // well below the mean
+        return bars;
+    }
+
+    Bar bar(const std::string& symbol, double close, double volume, Timestamp ts) const {
+        Bar b;
+        b.symbol = symbol;
+        b.timestamp = ts;
+        b.open = close;
+        b.high = close;
+        b.low = close;
+        b.close = close;
+        b.volume = volume;
+        return b;
+    }
+
+    static constexpr const char* kPenny = "PENNYA";      // $0.25
+    static constexpr const char* kSubDollar = "PENNYB";  // $0.50
+    static constexpr const char* kNormal = "NORMAL";     // $150, the control
+
+    std::shared_ptr<MockPostgresDatabase> db_;
+    StrategyConfig strategy_config_;
+    RiskLimits risk_limits_;
+    MeanReversionConfig mr_config_;
+};
+
+// ---------------------------------------------------------------------------
+// sizing
+// ---------------------------------------------------------------------------
+
+// Below fractional_min_price the target is a whole number of shares, however large.
+// Fractional sizing on a $0.25 name is not a rounding nicety: brokers do not fill it,
+// so a fractional target would be a position the book claims and does not have.
+TEST_F(PennyStockLifecycleTest, SubDollarTargetsAreWholeShares) {
+    auto strategy = create_strategy();
+    for (const auto& symbol : {kPenny, kSubDollar}) {
+        ASSERT_TRUE(strategy->on_data(series(symbol, symbol == std::string(kPenny) ? 0.25 : 0.50,
+                                             500000.0))
+                        .is_ok());
+    }
+    ASSERT_TRUE(strategy->on_data(series(kNormal, 150.0, 500000.0)).is_ok());
+
+    for (const auto& symbol : {kPenny, kSubDollar}) {
+        const double target = strategy->get_position(symbol);
+        ASSERT_NE(target, 0.0) << symbol << " did not open; the scenario proves nothing";
+        EXPECT_DOUBLE_EQ(target, std::floor(target))
+            << symbol << " priced below fractional_min_price must size in whole shares";
+    }
+
+    // The control: the same code path leaves a $150 name free to hold a fraction, so the
+    // assertion above is about the price gate and not about rounding everywhere.
+    const double normal_target = strategy->get_position(kNormal);
+    ASSERT_NE(normal_target, 0.0);
+    EXPECT_NE(normal_target, std::floor(normal_target))
+        << "a $150 name with ADV above the floor is fractional-eligible";
+}
+
+// ADV below fractional_min_adv fails CLOSED even above the price floor: an unreliable
+// liquidity estimate is not a licence to place an order the venue may not accept.
+TEST_F(PennyStockLifecycleTest, ThinADVForcesWholeSharesEvenAboveThePriceFloor) {
+    auto strategy = create_strategy();
+    ASSERT_TRUE(strategy->on_data(series(kNormal, 150.0, 10000.0)).is_ok());  // ADV 10k < 50k
+
+    const double target = strategy->get_position(kNormal);
+    ASSERT_NE(target, 0.0);
+    EXPECT_DOUBLE_EQ(target, std::floor(target));
+}
+
+// `position_limits` is expressed in SHARES, and a share count means something very
+// different at $0.25 than at $150: the live config's 500-share live limit is $75,000 of
+// a $150 name and $125 of a penny name. This pins that the clamp is applied in share
+// space -- the unclamped volatility-targeted size is measured first, so the assertion
+// cannot pass by the limit happening to sit above it.
+TEST_F(PennyStockLifecycleTest, PositionLimitClampBindsInSharesOnAPennyName) {
+    double unclamped = 0.0;
+    {
+        auto strategy = create_strategy();  // limit 40,000, well above the sized target
+        ASSERT_TRUE(strategy->on_data(series(kPenny, 0.25, 500000.0)).is_ok());
+        unclamped = strategy->get_position(kPenny);
+        ASSERT_GT(unclamped, 0.0);
+        ASSERT_LT(unclamped, strategy_config_.position_limits.at(kPenny))
+            << "fixture precondition: the default limit must NOT bind, or the clamp below "
+               "proves nothing";
+    }
+
+    const double tight = std::floor(unclamped / 2.0);
+    strategy_config_.position_limits[kPenny] = tight;
+    auto strategy = create_strategy();
+    ASSERT_TRUE(strategy->on_data(series(kPenny, 0.25, 500000.0)).is_ok());
+
+    EXPECT_DOUBLE_EQ(strategy->get_position(kPenny), tight)
+        << "the share-count clamp must cut the target, not the notional";
+}
+
+// ---------------------------------------------------------------------------
+// cost registration
+// ---------------------------------------------------------------------------
+
+// The tier a penny name gets comes from its own bars, not from a default. SEC Rule 612
+// puts sub-dollar quotes on a 0.0001 grid, and the spread model prices in ticks, so the
+// tick size is the whole difference between a plausible spread and a 100x one.
+TEST_F(PennyStockLifecycleTest, RegisterEquityCostsFromBarsGivesAPennyNameThePennyTier) {
+    TransactionCostManager tcm;
+    std::unordered_map<std::string, std::vector<Bar>> bars_by_symbol;
+    bars_by_symbol[kPenny] = series(kPenny, 0.25, 50000.0);
+    bars_by_symbol[kNormal] = series(kNormal, 150.0, 50000000.0);
+
+    const int registered = tcm.register_equity_costs_from_bars(
+        {kPenny, kNormal}, bars_by_symbol);
+    ASSERT_EQ(registered, 2);
+
+    const auto penny = tcm.get_asset_config(kPenny);
+    EXPECT_EQ(penny.asset_type, AssetType::EQUITY)
+        << "an unregistered equity resolves as a FUTURE: $1.50/share and point_value 100";
+    EXPECT_DOUBLE_EQ(penny.tick_size, 0.0001) << "SEC Rule 612 sub-dollar tick";
+    EXPECT_DOUBLE_EQ(penny.point_value, 1.0);
+    EXPECT_DOUBLE_EQ(penny.baseline_spread_ticks, 10.0) << "penny / illiquid tier";
+    EXPECT_DOUBLE_EQ(penny.max_total_implicit_bps, 500.0);
+
+    const auto normal = tcm.get_asset_config(kNormal);
+    EXPECT_DOUBLE_EQ(normal.tick_size, 0.01);
+    EXPECT_DOUBLE_EQ(normal.baseline_spread_ticks, 1.0) << "mega-cap tier from ADV 50m";
+}
+
+// ---------------------------------------------------------------------------
+// cost calculation
+// ---------------------------------------------------------------------------
+
+// The 1%-of-trade-value CAP is the binding commission term on a penny clip, and it must
+// win over the $1.00 per-order floor. 40,000 shares at $0.25 is $10,000 of value: raw
+// per-share commission is $200, the cap is $100. Getting the order of these two wrong is
+// exactly E2-C2, which over-charged the smallest clips by 21%.
+TEST_F(PennyStockLifecycleTest, OnePercentCapBindsOnAPennyClipAndBeatsTheFloor) {
+    TransactionCostManager tcm;
+    std::unordered_map<std::string, std::vector<Bar>> bars_by_symbol;
+    bars_by_symbol[kPenny] = series(kPenny, 0.25, 50000.0);
+    ASSERT_EQ(tcm.register_equity_costs_from_bars({kPenny}, bars_by_symbol), 1);
+
+    const double qty = 40000.0;
+    const double price = 0.25;
+    const auto cost = tcm.calculate_costs(kPenny, qty, price, 50000.0, 1.0, AssetType::EQUITY);
+
+    EXPECT_DOUBLE_EQ(cost.commissions_fees, 0.01 * qty * price)
+        << "raw per-share commission is $" << qty * 0.005 << "; the 1% cap is $"
+        << 0.01 * qty * price << " and a cap that a floor can exceed is not a cap";
+    EXPECT_LT(cost.commissions_fees, qty * 0.005);
+
+    // The other side of the same expression: a tiny clip is capped BELOW the $1.00 floor.
+    const auto tiny = tcm.calculate_costs(kPenny, 100.0, price, 50000.0, 1.0,
+                                          AssetType::EQUITY);
+    EXPECT_DOUBLE_EQ(tiny.commissions_fees, 0.01 * 100.0 * price);
+    EXPECT_LT(tiny.commissions_fees, 1.00) << "the floor must not override the cap";
+}
+
+// Implicit cost is bounded by the tier's max_total_implicit_bps even when a large clip
+// meets a thin book -- 40,000 shares against ADV 50,000 is 80% of a day's volume.
+TEST_F(PennyStockLifecycleTest, ImplicitCostOnAPennyNameIsBoundedByItsTier) {
+    TransactionCostManager tcm;
+    std::unordered_map<std::string, std::vector<Bar>> bars_by_symbol;
+    bars_by_symbol[kPenny] = series(kPenny, 0.25, 50000.0);
+    ASSERT_EQ(tcm.register_equity_costs_from_bars({kPenny}, bars_by_symbol), 1);
+
+    const double qty = 40000.0;
+    const double price = 0.25;
+    const auto cost = tcm.calculate_costs(kPenny, qty, price, 50000.0, 1.0, AssetType::EQUITY);
+
+    const double implicit_bps = (cost.implicit_price_impact / price) * 10000.0;
+    EXPECT_GT(implicit_bps, 0.0) << "a penny name trading 80% of ADV is not free";
+    EXPECT_LE(implicit_bps, 500.0 + 1e-9)
+        << "penny tier max_total_implicit_bps is 500 and must actually bind";
+    EXPECT_NEAR(cost.slippage_market_impact, cost.implicit_price_impact * qty * 1.0, 1e-9)
+        << "equities are point_value 1; a futures multiplier here would be 100x";
+    EXPECT_NEAR(cost.total_transaction_costs,
+                cost.commissions_fees + cost.slippage_market_impact, 1e-9);
+}
+
+// ---------------------------------------------------------------------------
+// fill and P&L
+// ---------------------------------------------------------------------------
+
+// The round trip on a penny name: 40,000 shares in at $0.25, out at $0.30, realized
+// $2,000 with no basis left behind. Whole-share quantities and a sub-dollar basis are
+// where a fixed-point rounding mistake would show up first.
+TEST_F(PennyStockLifecycleTest, RoundTripRealizesOnTheWholeShareQuantity) {
+    auto strategy = create_strategy();
+    ASSERT_TRUE(strategy->on_data(series(kPenny, 0.25, 500000.0)).is_ok());
+
+    ExecutionReport buy;
+    buy.symbol = kPenny;
+    buy.order_id = "PENNY_BUY";
+    buy.exec_id = "PENNY_BUY_1";
+    buy.side = Side::BUY;
+    buy.filled_quantity = 40000.0;
+    buy.fill_price = 0.25;
+    buy.fill_time = std::chrono::system_clock::now();
+    ASSERT_TRUE(strategy->on_execution(buy).is_ok());
+
+    auto book = strategy->get_positions();
+    ASSERT_EQ(book.count(kPenny), 1u);
+    EXPECT_DOUBLE_EQ(book.at(kPenny).quantity.as_double(), 40000.0);
+    EXPECT_DOUBLE_EQ(book.at(kPenny).average_price.as_double(), 0.25);
+    EXPECT_DOUBLE_EQ(book.at(kPenny).realized_pnl.as_double(), 0.0);
+
+    ExecutionReport sell = buy;
+    sell.order_id = "PENNY_SELL";
+    sell.exec_id = "PENNY_SELL_1";
+    sell.side = Side::SELL;
+    sell.fill_price = 0.30;
+    ASSERT_TRUE(strategy->on_execution(sell).is_ok());
+
+    book = strategy->get_positions();
+    ASSERT_EQ(book.count(kPenny), 1u);
+    EXPECT_DOUBLE_EQ(book.at(kPenny).quantity.as_double(), 0.0);
+    EXPECT_NEAR(book.at(kPenny).realized_pnl.as_double(), 40000.0 * (0.30 - 0.25), 1e-6);
+}
+
+// A partial exit realizes on the shares that left and keeps the basis on the rest --
+// the E2-F27 rule, exercised where the numbers are small enough that a per-share
+// rounding error would be visible.
+TEST_F(PennyStockLifecycleTest, PartialExitRealizesOnlyTheSharesThatLeft) {
+    auto strategy = create_strategy();
+    ASSERT_TRUE(strategy->on_data(series(kPenny, 0.25, 500000.0)).is_ok());
+
+    ExecutionReport buy;
+    buy.symbol = kPenny;
+    buy.order_id = "P1";
+    buy.exec_id = "P1_1";
+    buy.side = Side::BUY;
+    buy.filled_quantity = 40000.0;
+    buy.fill_price = 0.25;
+    buy.fill_time = std::chrono::system_clock::now();
+    ASSERT_TRUE(strategy->on_execution(buy).is_ok());
+
+    ExecutionReport sell = buy;
+    sell.order_id = "P2";
+    sell.exec_id = "P2_1";
+    sell.side = Side::SELL;
+    sell.filled_quantity = 15000.0;
+    sell.fill_price = 0.31;
+    ASSERT_TRUE(strategy->on_execution(sell).is_ok());
+
+    const auto book = strategy->get_positions();
+    ASSERT_EQ(book.count(kPenny), 1u);
+    EXPECT_DOUBLE_EQ(book.at(kPenny).quantity.as_double(), 25000.0);
+    EXPECT_DOUBLE_EQ(book.at(kPenny).average_price.as_double(), 0.25)
+        << "a partial exit does not restate the basis of what is still held";
+    EXPECT_NEAR(book.at(kPenny).realized_pnl.as_double(), 15000.0 * (0.31 - 0.25), 1e-6);
+}

--- a/tests/transaction_cost/test_transaction_cost_manager.cpp
+++ b/tests/transaction_cost/test_transaction_cost_manager.cpp
@@ -601,3 +601,36 @@ TEST(MarketDataUpdate, ValidPrevCloseRecordsBothVolumeAndReturn) {
     EXPECT_GT(tcm.get_annual_volatility("ZS"), 0.0)
         << "A genuine prior close must still produce a return observation.";
 }
+
+// ──────────────────────────────────────────────────────────────────────────
+// E2-F29: regulatory fees are keyed on the SIGN of quantity. A negative
+// quantity is a sell and carries SEC + TAF; a positive one does not; and the
+// fees stay off entirely on a config that does not enable them (IBKR Fixed).
+// ──────────────────────────────────────────────────────────────────────────
+TEST(RegulatoryFeesTest, NegativeQuantityIsTheSellSideAndCarriesSecAndTaf) {
+    TransactionCostManager tcm{TransactionCostManager::Config{}};
+    AssetCostConfig cfg;
+    cfg.symbol = "TIERD";
+    cfg.asset_type = AssetType::EQUITY;
+    cfg.commission_per_unit = 0.0035;
+    cfg.min_commission_per_order = 0.35;
+    cfg.max_commission_per_order = 1e9;
+    cfg.apply_regulatory_fees = true;
+    tcm.register_asset_config(cfg);
+
+    const double qty = 1000.0, px = 50.0;
+    auto buy = tcm.calculate_costs("TIERD", +qty, px, 1e6, 1.0, AssetType::EQUITY);
+    auto sell = tcm.calculate_costs("TIERD", -qty, px, 1e6, 1.0, AssetType::EQUITY);
+    const double sec_fee = (qty * px / 1e6) * cfg.sec_fee_per_million;
+    const double taf = std::min(qty * cfg.finra_taf_per_share, cfg.finra_taf_cap_per_trade);
+    EXPECT_NEAR(sell.commissions_fees - buy.commissions_fees, sec_fee + taf, 1e-9);
+
+    AssetCostConfig fixed = cfg;
+    fixed.symbol = "FIXED";
+    fixed.apply_regulatory_fees = false;
+    tcm.register_asset_config(fixed);
+    auto fbuy = tcm.calculate_costs("FIXED", +qty, px, 1e6, 1.0, AssetType::EQUITY);
+    auto fsell = tcm.calculate_costs("FIXED", -qty, px, 1e6, 1.0, AssetType::EQUITY);
+    EXPECT_DOUBLE_EQ(fsell.commissions_fees, fbuy.commissions_fees)
+        << "IBKR Fixed is all-inclusive: no separate regulatory fee on either side";
+}


### PR DESCRIPTION
Phase B batches 1-3 of the finishing campaign: flip realized, regulatory-fee sign, holiday partial-load guard, dedup import keying, UTC run date, trading-days anchor, single strategy feed, effective universe for renamed holdings, day-T mark map and the in-run unrealized identity, and the checkpoint fix that moved find_previous_trading_day and the order-id date to the UTC frame (E2-F45/F46). Two equity windows replayed value-identical to the pre-campaign chain.