### PR TITLE
db: identifier guards and a bound large-batch executions insert

### DIFF
--- a/src/data/postgres_database.cpp
+++ b/src/data/postgres_database.cpp
@@ -1,6 +1,7 @@
 // src/data/postgres_database.cpp
 
 #include "trade_ngin/data/postgres_database.hpp"
+#include <algorithm>
 #include <iomanip>
 #include <sstream>
 #include "trade_ngin/core/state_manager.hpp"
@@ -1704,6 +1705,15 @@ Result<void> PostgresDatabase::validate_strategy_id(const std::string& strategy_
         }
     }
 
+    // A single dash is a legitimate separator ("trend-following-1"); two in a
+    // row open a SQL line comment, so refuse them even though each character
+    // passed the allowlist above.
+    if (strategy_id.find("--") != std::string::npos) {
+        return make_error<void>(ErrorCode::INVALID_ARGUMENT,
+                                "Invalid strategy_id: consecutive dashes are not allowed",
+                                "PostgresDatabase");
+    }
+
     return Result<void>();
 }
 
@@ -1850,35 +1860,60 @@ Result<void> PostgresDatabase::store_backtest_executions(
 
         std::string actual_portfolio_id = portfolio_id.empty() ? "BASE_PORTFOLIO" : portfolio_id;
 
+        for (const auto& exec : executions) {
+            auto exec_validation = validate_execution_report(exec);
+            if (exec_validation.is_error()) {
+                return exec_validation;
+            }
+        }
+
         // Use batch insert for better performance with large execution sets
         if (executions.size() > 100) {
-            // Build a single multi-value INSERT for large batches
-            std::string query = "INSERT INTO " + table_name +
-                                " (run_id, portfolio_id, execution_id, order_id, timestamp, "
-                                "symbol, side, quantity, price, commissions_fees, "
-                                "implicit_price_impact, slippage_market_impact, "
-                                "total_transaction_costs, is_partial) VALUES ";
+            // Bind every value: Postgres caps a statement at 65535 parameters,
+            // so insert in chunks of whole rows.
+            constexpr std::size_t kColumns = 14;
+            constexpr std::size_t kMaxRowsPerStatement = 65535 / kColumns;
+            const std::string prefix =
+                "INSERT INTO " + table_name +
+                " (run_id, portfolio_id, execution_id, order_id, timestamp, "
+                "symbol, side, quantity, price, commissions_fees, "
+                "implicit_price_impact, slippage_market_impact, "
+                "total_transaction_costs, is_partial) VALUES ";
 
-            std::vector<std::string> value_strings;
-            value_strings.reserve(executions.size());
-
-            for (const auto& exec : executions) {
-                std::string values = "('" + run_id + "', '" + actual_portfolio_id + "', '" +
-                                     exec.exec_id + "', '" + exec.order_id + "', '" +
-                                     format_timestamp(exec.fill_time) + "', '" + exec.symbol +
-                                     "', '" + side_to_string(exec.side) + "', " +
-                                     std::to_string(static_cast<double>(exec.filled_quantity)) +
-                                     ", " + std::to_string(static_cast<double>(exec.fill_price)) +
-                                     ", " + std::to_string(static_cast<double>(exec.commissions_fees)) +
-                                     ", " + std::to_string(static_cast<double>(exec.implicit_price_impact)) +
-                                     ", " + std::to_string(static_cast<double>(exec.slippage_market_impact)) +
-                                     ", " + std::to_string(static_cast<double>(exec.total_transaction_costs)) +
-                                     ", " + (exec.is_partial ? "true" : "false") + ")";
-                value_strings.push_back(values);
+            for (std::size_t start = 0; start < executions.size(); start += kMaxRowsPerStatement) {
+                const std::size_t end =
+                    std::min(executions.size(), start + kMaxRowsPerStatement);
+                std::string query = prefix;
+                pqxx::params batch;
+                std::size_t next_placeholder = 1;
+                for (std::size_t i = start; i < end; ++i) {
+                    const auto& exec = executions[i];
+                    if (i != start)
+                        query += ",";
+                    query += "(";
+                    for (std::size_t c = 0; c < kColumns; ++c) {
+                        if (c != 0)
+                            query += ",";
+                        query += "$" + std::to_string(next_placeholder++);
+                    }
+                    query += ")";
+                    batch.append(run_id);
+                    batch.append(actual_portfolio_id);
+                    batch.append(exec.exec_id);
+                    batch.append(exec.order_id);
+                    batch.append(format_timestamp(exec.fill_time));
+                    batch.append(exec.symbol);
+                    batch.append(side_to_string(exec.side));
+                    batch.append(static_cast<double>(exec.filled_quantity));
+                    batch.append(static_cast<double>(exec.fill_price));
+                    batch.append(static_cast<double>(exec.commissions_fees));
+                    batch.append(static_cast<double>(exec.implicit_price_impact));
+                    batch.append(static_cast<double>(exec.slippage_market_impact));
+                    batch.append(static_cast<double>(exec.total_transaction_costs));
+                    batch.append(exec.is_partial);
+                }
+                txn.exec(query, batch);
             }
-
-            query += pqxx::separated_list(",", value_strings.begin(), value_strings.end());
-            txn.exec(query);
         } else {
             // Use parameterized queries for smaller batches
             for (const auto& exec : executions) {
@@ -1931,35 +1966,60 @@ Result<void> PostgresDatabase::store_backtest_executions_with_strategy(
 
         std::string actual_portfolio_id = portfolio_id.empty() ? "BASE_PORTFOLIO" : portfolio_id;
 
+        for (const auto& exec : executions) {
+            auto exec_validation = validate_execution_report(exec);
+            if (exec_validation.is_error()) {
+                return exec_validation;
+            }
+        }
+
         // Use batch insert for better performance with large execution sets
         if (executions.size() > 100) {
-            // Build a single multi-value INSERT for large batches with strategy_id
-            std::string query =
+            // Bind every value: Postgres caps a statement at 65535 parameters,
+            // so insert in chunks of whole rows.
+            constexpr std::size_t kColumns = 15;
+            constexpr std::size_t kMaxRowsPerStatement = 65535 / kColumns;
+            const std::string prefix =
                 "INSERT INTO " + table_name +
                 " (run_id, portfolio_id, strategy_id, execution_id, order_id, timestamp, symbol, "
                 "side, quantity, price, commissions_fees, implicit_price_impact, "
                 "slippage_market_impact, total_transaction_costs, is_partial) VALUES ";
 
-            std::vector<std::string> value_strings;
-            value_strings.reserve(executions.size());
-
-            for (const auto& exec : executions) {
-                std::string values = "('" + run_id + "', '" + actual_portfolio_id + "', '" +
-                                     strategy_id + "', '" + exec.exec_id + "', '" + exec.order_id +
-                                     "', '" + format_timestamp(exec.fill_time) + "', '" +
-                                     exec.symbol + "', '" + side_to_string(exec.side) + "', " +
-                                     std::to_string(static_cast<double>(exec.filled_quantity)) +
-                                     ", " + std::to_string(static_cast<double>(exec.fill_price)) +
-                                     ", " + std::to_string(static_cast<double>(exec.commissions_fees)) +
-                                     ", " + std::to_string(static_cast<double>(exec.implicit_price_impact)) +
-                                     ", " + std::to_string(static_cast<double>(exec.slippage_market_impact)) +
-                                     ", " + std::to_string(static_cast<double>(exec.total_transaction_costs)) +
-                                     ", " + (exec.is_partial ? "true" : "false") + ")";
-                value_strings.push_back(values);
+            for (std::size_t start = 0; start < executions.size(); start += kMaxRowsPerStatement) {
+                const std::size_t end =
+                    std::min(executions.size(), start + kMaxRowsPerStatement);
+                std::string query = prefix;
+                pqxx::params batch;
+                std::size_t next_placeholder = 1;
+                for (std::size_t i = start; i < end; ++i) {
+                    const auto& exec = executions[i];
+                    if (i != start)
+                        query += ",";
+                    query += "(";
+                    for (std::size_t c = 0; c < kColumns; ++c) {
+                        if (c != 0)
+                            query += ",";
+                        query += "$" + std::to_string(next_placeholder++);
+                    }
+                    query += ")";
+                    batch.append(run_id);
+                    batch.append(actual_portfolio_id);
+                    batch.append(strategy_id);
+                    batch.append(exec.exec_id);
+                    batch.append(exec.order_id);
+                    batch.append(format_timestamp(exec.fill_time));
+                    batch.append(exec.symbol);
+                    batch.append(side_to_string(exec.side));
+                    batch.append(static_cast<double>(exec.filled_quantity));
+                    batch.append(static_cast<double>(exec.fill_price));
+                    batch.append(static_cast<double>(exec.commissions_fees));
+                    batch.append(static_cast<double>(exec.implicit_price_impact));
+                    batch.append(static_cast<double>(exec.slippage_market_impact));
+                    batch.append(static_cast<double>(exec.total_transaction_costs));
+                    batch.append(exec.is_partial);
+                }
+                txn.exec(query, batch);
             }
-
-            query += pqxx::separated_list(",", value_strings.begin(), value_strings.end());
-            txn.exec(query);
         } else {
             // Use parameterized queries for smaller batches with strategy_id
             for (const auto& exec : executions) {

--- a/src/data/postgres_database_extensions.cpp
+++ b/src/data/postgres_database_extensions.cpp
@@ -478,6 +478,15 @@ Result<void> PostgresDatabase::update_live_results(
     const std::string& table_name) {
     std::lock_guard<std::mutex> lock(mutex_);
 
+    // Column names are concatenated into the statement (Postgres cannot bind
+    // identifiers), so allow-list every key before anything else happens.
+    for (const auto& [column, value] : updates) {
+        auto column_validation = validate_identifier(column);
+        if (column_validation.is_error()) {
+            return column_validation;
+        }
+    }
+
     // Validate connection
     auto validation = validate_connection();
     if (validation.is_error()) {
@@ -690,6 +699,21 @@ Result<void> PostgresDatabase::store_live_results_complete(
     const std::unordered_map<std::string, int>& int_metrics, const nlohmann::json& config,
     const std::string& portfolio_id, const std::string& table_name) {
     std::lock_guard<std::mutex> lock(mutex_);
+
+    // Column names are concatenated into the statement (Postgres cannot bind
+    // identifiers), so allow-list every key before anything else happens.
+    for (const auto& [column, value] : metrics) {
+        auto column_validation = validate_identifier(column);
+        if (column_validation.is_error()) {
+            return column_validation;
+        }
+    }
+    for (const auto& [column, value] : int_metrics) {
+        auto column_validation = validate_identifier(column);
+        if (column_validation.is_error()) {
+            return column_validation;
+        }
+    }
 
     // Validate connection
     auto validation = validate_connection();

--- a/tests/data/test_postgres_param_safety.cpp
+++ b/tests/data/test_postgres_param_safety.cpp
@@ -1,6 +1,9 @@
 #include <gtest/gtest.h>
 
 #include <string>
+#include <unordered_map>
+
+#include <nlohmann/json.hpp>
 
 #include "trade_ngin/core/error.hpp"
 #include "trade_ngin/data/postgres_database.hpp"
@@ -99,4 +102,38 @@ TEST(PostgresParamSafety, ValidateIdentifierRejectsDash) {
     // identifier rules are stricter -- dashes are not valid SQL identifiers.
     auto r = db.validate_identifier("trading-positions");
     ASSERT_TRUE(r.is_error());
+}
+
+// Follow-up to PR #42: a strategy_id is a value, but validate_strategy_id
+// is also the guard on the few places it is still concatenated, so the SQL
+// line-comment opener `--` must not pass even though single dashes do.
+TEST(PostgresParamSafety, StrategyIdRejectsDoubleDash) {
+    PostgresDatabase db = make_offline_db();
+    auto r = db.validate_strategy_id("a--b");
+    ASSERT_TRUE(r.is_error());
+    EXPECT_EQ(r.error()->code(), ErrorCode::INVALID_ARGUMENT);
+    EXPECT_TRUE(db.validate_strategy_id("trend-following-1").is_ok());
+}
+
+// The live-results writers concatenate the metric map's keys as column
+// names. They must be rejected by validate_identifier before the writer
+// ever looks at the connection -- the offline fixture has none, so a
+// CONNECTION_ERROR here would mean the column check ran too late.
+TEST(PostgresParamSafety, UpdateLiveResultsRejectsHostileColumnName) {
+    PostgresDatabase db = make_offline_db();
+    std::unordered_map<std::string, double> updates{{"x; DROP TABLE t", 1.0}};
+    auto r = db.update_live_results("LIVE-EQUITY-MR", Timestamp{}, updates, "BASE_PORTFOLIO",
+                                    "trading.live_results");
+    ASSERT_TRUE(r.is_error());
+    EXPECT_EQ(r.error()->code(), ErrorCode::INVALID_ARGUMENT);
+}
+
+TEST(PostgresParamSafety, StoreLiveResultsCompleteRejectsHostileColumnName) {
+    PostgresDatabase db = make_offline_db();
+    std::unordered_map<std::string, double> metrics{{"sharpe_ratio", 1.2}};
+    std::unordered_map<std::string, int> int_metrics{{"x; DROP TABLE t", 3}};
+    auto r = db.store_live_results_complete("LIVE-EQUITY-MR", Timestamp{}, metrics, int_metrics,
+                                            nlohmann::json(), "BASE_PORTFOLIO", "trading.live_results");
+    ASSERT_TRUE(r.is_error());
+    EXPECT_EQ(r.error()->code(), ErrorCode::INVALID_ARGUMENT);
 }


### PR DESCRIPTION
`update_live_results` and `store_live_results_complete` now run every metric-map key through the existing public `validate_identifier` before touching the connection, so a hostile column name returns `INVALID_ARGUMENT` instead of being concatenated into the statement. `validate_strategy_id` additionally refuses a `--` substring (single dashes stay valid). The >100-row branch of `store_backtest_executions` and `store_backtest_executions_with_strategy` no longer builds a multi-value INSERT by string concatenation: every row is validated with `validate_execution_report`, and values are `$n`-bound in chunks of `65535 / columns` rows so the Postgres parameter cap is respected. The <=100 per-row path is unchanged. Three red-first tests in `tests/data/test_postgres_param_safety.cpp` pin the guards using the file's offline fixture.

This follows up PR #42 by its author. Its positions and identifier work has since been superseded on `main` (`store_positions_in`, `validate_identifier`), but the live-results column names and the large-batch executions path were still concatenated unvalidated. This closes those two remaining gaps with `main`'s existing validators rather than a second allow-list, and without `std::format`. All targets build; ctest runs 1861/1861 green (1858 on `main` + 3).
