### PR TITLE
Database-backed tests connect only through an explicit test DSN

### DIFF
--- a/tests/data/test_current_holding_start_bound_db.cpp
+++ b/tests/data/test_current_holding_start_bound_db.cpp
@@ -49,24 +49,13 @@ constexpr const char* kStrategyName = "EQUITY_MEAN_REVERSION";
 constexpr const char* kPortfolioId = "BA19_HOLDING_BOUND_TEST";  // synthetic, never a real book
 
 std::string discover_connection_string() {
-    namespace fs = std::filesystem;
-    fs::path dir = fs::current_path();
-    for (int i = 0; i < 8 && !dir.empty(); ++i) {
-        fs::path candidate = dir / "config" / "defaults.json";
-        if (fs::exists(candidate)) {
-            try {
-                std::ifstream in(candidate);
-                nlohmann::json j = nlohmann::json::parse(in);
-                const auto& d = j.at("database");
-                return "postgresql://" + d.at("username").get<std::string>() + ":" +
-                       d.at("password").get<std::string>() + "@" +
-                       d.at("host").get<std::string>() + ":" + d.at("port").get<std::string>() +
-                       "/" + d.at("name").get<std::string>();
-            } catch (const std::exception&) {
-                return {};
-            }
-        }
-        dir = dir.parent_path();
+    // Database-backed tests connect ONLY through TRADE_NGIN_TEST_DSN. The previous
+    // behaviour walked up from the working directory looking for config/defaults.json,
+    // which pointed a test run inside any worktree of this checkout at the live
+    // database. Tests must never discover production credentials by accident.
+    const char* dsn = std::getenv("TRADE_NGIN_TEST_DSN");
+    if (dsn && *dsn) {
+        return std::string(dsn);
     }
     return {};
 }
@@ -82,8 +71,8 @@ protected:
         }();
         conn_string_ = discover_connection_string();
         if (conn_string_.empty()) {
-            if (require_db) FAIL() << "TRADE_NGIN_REQUIRE_DB=1 but config/defaults.json is not reachable";
-            GTEST_SKIP() << "config/defaults.json not reachable";
+            if (require_db) FAIL() << "TRADE_NGIN_REQUIRE_DB=1 but TRADE_NGIN_TEST_DSN is not set";
+            GTEST_SKIP() << "TRADE_NGIN_TEST_DSN not set";
         }
         db_ = std::make_shared<PostgresDatabase>(conn_string_);
         auto connected = db_->connect();

--- a/tests/data/test_current_holding_start_db.cpp
+++ b/tests/data/test_current_holding_start_db.cpp
@@ -40,24 +40,13 @@ constexpr const char* kStrategyId = "LIVE_EQUITY_MEAN_REVERSION";
 constexpr const char* kStrategyName = "EQUITY_MEAN_REVERSION";
 
 std::string discover_connection_string() {
-    namespace fs = std::filesystem;
-    fs::path dir = fs::current_path();
-    for (int i = 0; i < 8 && !dir.empty(); ++i) {
-        fs::path candidate = dir / "config" / "defaults.json";
-        if (fs::exists(candidate)) {
-            try {
-                std::ifstream in(candidate);
-                nlohmann::json j = nlohmann::json::parse(in);
-                const auto& d = j.at("database");
-                return "postgresql://" + d.at("username").get<std::string>() + ":" +
-                       d.at("password").get<std::string>() + "@" +
-                       d.at("host").get<std::string>() + ":" + d.at("port").get<std::string>() +
-                       "/" + d.at("name").get<std::string>();
-            } catch (const std::exception&) {
-                return {};
-            }
-        }
-        dir = dir.parent_path();
+    // Database-backed tests connect ONLY through TRADE_NGIN_TEST_DSN. The previous
+    // behaviour walked up from the working directory looking for config/defaults.json,
+    // which pointed a test run inside any worktree of this checkout at the live
+    // database. Tests must never discover production credentials by accident.
+    const char* dsn = std::getenv("TRADE_NGIN_TEST_DSN");
+    if (dsn && *dsn) {
+        return std::string(dsn);
     }
     return {};
 }
@@ -75,10 +64,10 @@ protected:
         conn_string_ = discover_connection_string();
         if (conn_string_.empty()) {
             if (require_db) {
-                FAIL() << "TRADE_NGIN_REQUIRE_DB=1 but config/defaults.json is not reachable, "
+                FAIL() << "TRADE_NGIN_REQUIRE_DB=1 but TRADE_NGIN_TEST_DSN is not set, "
                           "so the class-2 era query goes unverified";
             }
-            GTEST_SKIP() << "config/defaults.json not reachable; no database to exercise";
+            GTEST_SKIP() << "TRADE_NGIN_TEST_DSN not set; no database to exercise";
         }
         db_ = std::make_shared<PostgresDatabase>(conn_string_);
         auto connected = db_->connect();

--- a/tests/data/test_db_transaction_atomicity.cpp
+++ b/tests/data/test_db_transaction_atomicity.cpp
@@ -49,26 +49,15 @@ constexpr const char* kScratchPortfolio = "DBTXN_PROBE_PORTFOLIO";
 constexpr const char* kScratchStrategyId = "DBTXN_PROBE_STRATEGY";
 constexpr const char* kScratchStrategyName = "DBTXN_PROBE_NAME";
 
-/// Connection string from config/defaults.json, empty when it cannot be found.
+/// Connection string from TRADE_NGIN_TEST_DSN, empty when it is not set.
 std::string discover_connection_string() {
-    namespace fs = std::filesystem;
-    fs::path dir = fs::current_path();
-    for (int i = 0; i < 8 && !dir.empty(); ++i) {
-        fs::path candidate = dir / "config" / "defaults.json";
-        if (fs::exists(candidate)) {
-            try {
-                std::ifstream in(candidate);
-                nlohmann::json j = nlohmann::json::parse(in);
-                const auto& d = j.at("database");
-                return "postgresql://" + d.at("username").get<std::string>() + ":" +
-                       d.at("password").get<std::string>() + "@" +
-                       d.at("host").get<std::string>() + ":" + d.at("port").get<std::string>() +
-                       "/" + d.at("name").get<std::string>();
-            } catch (const std::exception&) {
-                return {};
-            }
-        }
-        dir = dir.parent_path();
+    // Database-backed tests connect ONLY through TRADE_NGIN_TEST_DSN. The previous
+    // behaviour walked up from the working directory looking for config/defaults.json,
+    // which pointed a test run inside any worktree of this checkout at the live
+    // database. Tests must never discover production credentials by accident.
+    const char* dsn = std::getenv("TRADE_NGIN_TEST_DSN");
+    if (dsn && *dsn) {
+        return std::string(dsn);
     }
     return {};
 }
@@ -109,10 +98,10 @@ protected:
         const std::string conn = discover_connection_string();
         if (conn.empty()) {
             if (require_db) {
-                FAIL() << "TRADE_NGIN_REQUIRE_DB=1 but config/defaults.json is not "
-                          "reachable, so the atomicity contract cannot be exercised";
+                FAIL() << "TRADE_NGIN_REQUIRE_DB=1 but TRADE_NGIN_TEST_DSN is not "
+                          "set, so the atomicity contract cannot be exercised";
             }
-            GTEST_SKIP() << "config/defaults.json not reachable; no database to exercise";
+            GTEST_SKIP() << "TRADE_NGIN_TEST_DSN not set; no database to exercise";
         }
         db_ = std::make_shared<PostgresDatabase>(conn);
         auto connected = db_->connect();

--- a/tests/data/test_delete_stale_executions_scope_db.cpp
+++ b/tests/data/test_delete_stale_executions_scope_db.cpp
@@ -51,24 +51,13 @@ constexpr const char* kPortfolioB = "F4_SCOPE_PROBE_PORTFOLIO_B";
 constexpr const char* kSharedOrderId = "DAILY_F4PROBE_2026-05-04";
 
 std::string discover_connection_string() {
-    namespace fs = std::filesystem;
-    fs::path dir = fs::current_path();
-    for (int i = 0; i < 8 && !dir.empty(); ++i) {
-        fs::path candidate = dir / "config" / "defaults.json";
-        if (fs::exists(candidate)) {
-            try {
-                std::ifstream in(candidate);
-                nlohmann::json j = nlohmann::json::parse(in);
-                const auto& d = j.at("database");
-                return "postgresql://" + d.at("username").get<std::string>() + ":" +
-                       d.at("password").get<std::string>() + "@" +
-                       d.at("host").get<std::string>() + ":" + d.at("port").get<std::string>() +
-                       "/" + d.at("name").get<std::string>();
-            } catch (const std::exception&) {
-                return {};
-            }
-        }
-        dir = dir.parent_path();
+    // Database-backed tests connect ONLY through TRADE_NGIN_TEST_DSN. The previous
+    // behaviour walked up from the working directory looking for config/defaults.json,
+    // which pointed a test run inside any worktree of this checkout at the live
+    // database. Tests must never discover production credentials by accident.
+    const char* dsn = std::getenv("TRADE_NGIN_TEST_DSN");
+    if (dsn && *dsn) {
+        return std::string(dsn);
     }
     return {};
 }
@@ -112,10 +101,10 @@ protected:
         conn_ = discover_connection_string();
         if (conn_.empty()) {
             if (require_db) {
-                FAIL() << "TRADE_NGIN_REQUIRE_DB=1 but config/defaults.json is not reachable, "
+                FAIL() << "TRADE_NGIN_REQUIRE_DB=1 but TRADE_NGIN_TEST_DSN is not set, "
                           "so the E2-F4 portfolio scoping goes unverified";
             }
-            GTEST_SKIP() << "config/defaults.json not reachable; no database to exercise";
+            GTEST_SKIP() << "TRADE_NGIN_TEST_DSN not set; no database to exercise";
         }
         db_ = std::make_shared<PostgresDatabase>(conn_);
         auto connected = db_->connect();

--- a/tests/data/test_get_trading_days_scope_db.cpp
+++ b/tests/data/test_get_trading_days_scope_db.cpp
@@ -34,24 +34,13 @@
 namespace {
 
 std::string discover_connection_string() {
-    namespace fs = std::filesystem;
-    fs::path dir = fs::current_path();
-    for (int i = 0; i < 8 && !dir.empty(); ++i) {
-        fs::path candidate = dir / "config" / "defaults.json";
-        if (fs::exists(candidate)) {
-            try {
-                std::ifstream in(candidate);
-                nlohmann::json j = nlohmann::json::parse(in);
-                const auto& d = j.at("database");
-                return "postgresql://" + d.at("username").get<std::string>() + ":" +
-                       d.at("password").get<std::string>() + "@" +
-                       d.at("host").get<std::string>() + ":" + d.at("port").get<std::string>() +
-                       "/" + d.at("name").get<std::string>();
-            } catch (const std::exception&) {
-                return {};
-            }
-        }
-        dir = dir.parent_path();
+    // Database-backed tests connect ONLY through TRADE_NGIN_TEST_DSN. The previous
+    // behaviour walked up from the working directory looking for config/defaults.json,
+    // which pointed a test run inside any worktree of this checkout at the live
+    // database. Tests must never discover production credentials by accident.
+    const char* dsn = std::getenv("TRADE_NGIN_TEST_DSN");
+    if (dsn && *dsn) {
+        return std::string(dsn);
     }
     return {};
 }
@@ -67,9 +56,9 @@ protected:
         }();
         conn_ = discover_connection_string();
         if (conn_.empty()) {
-            if (require_db) FAIL() << "TRADE_NGIN_REQUIRE_DB=1 but config/defaults.json is "
-                                      "unreachable; E2-F6 scoping goes unverified";
-            GTEST_SKIP() << "config/defaults.json not reachable";
+            if (require_db) FAIL() << "TRADE_NGIN_REQUIRE_DB=1 but TRADE_NGIN_TEST_DSN is "
+                                       "not set; E2-F6 scoping goes unverified";
+            GTEST_SKIP() << "TRADE_NGIN_TEST_DSN not set";
         }
         try {
             c_ = std::make_unique<pqxx::connection>(conn_);

--- a/tests/live/corp_actions/test_broker_frame_db.cpp
+++ b/tests/live/corp_actions/test_broker_frame_db.cpp
@@ -43,24 +43,13 @@ constexpr const char* kTestStrategyId = "F8_TEST_STRATEGY";
 constexpr const char* kTestStrategyName = "F8_TEST_NAME";
 
 std::string discover_connection_string() {
-    namespace fs = std::filesystem;
-    fs::path dir = fs::current_path();
-    for (int i = 0; i < 8 && !dir.empty(); ++i) {
-        fs::path candidate = dir / "config" / "defaults.json";
-        if (fs::exists(candidate)) {
-            try {
-                std::ifstream in(candidate);
-                nlohmann::json j = nlohmann::json::parse(in);
-                const auto& d = j.at("database");
-                return "postgresql://" + d.at("username").get<std::string>() + ":" +
-                       d.at("password").get<std::string>() + "@" +
-                       d.at("host").get<std::string>() + ":" + d.at("port").get<std::string>() +
-                       "/" + d.at("name").get<std::string>();
-            } catch (const std::exception&) {
-                return {};
-            }
-        }
-        dir = dir.parent_path();
+    // Database-backed tests connect ONLY through TRADE_NGIN_TEST_DSN. The previous
+    // behaviour walked up from the working directory looking for config/defaults.json,
+    // which pointed a test run inside any worktree of this checkout at the live
+    // database. Tests must never discover production credentials by accident.
+    const char* dsn = std::getenv("TRADE_NGIN_TEST_DSN");
+    if (dsn && *dsn) {
+        return std::string(dsn);
     }
     return {};
 }
@@ -78,10 +67,10 @@ protected:
         conn_string_ = discover_connection_string();
         if (conn_string_.empty()) {
             if (require_db) {
-                FAIL() << "TRADE_NGIN_REQUIRE_DB=1 but config/defaults.json is not reachable, "
+                FAIL() << "TRADE_NGIN_REQUIRE_DB=1 but TRADE_NGIN_TEST_DSN is not set, "
                           "so the basis_ratio ledger column goes unverified";
             }
-            GTEST_SKIP() << "config/defaults.json not reachable; no database to exercise";
+            GTEST_SKIP() << "TRADE_NGIN_TEST_DSN not set; no database to exercise";
         }
         db_ = std::make_shared<PostgresDatabase>(conn_string_);
         auto connected = db_->connect();

--- a/tests/live/corp_actions/test_corp_action_query_bounds_db.cpp
+++ b/tests/live/corp_actions/test_corp_action_query_bounds_db.cpp
@@ -42,24 +42,13 @@ using namespace trade_ngin;
 namespace {
 
 std::string discover_connection_string() {
-    namespace fs = std::filesystem;
-    fs::path dir = fs::current_path();
-    for (int i = 0; i < 8 && !dir.empty(); ++i) {
-        fs::path candidate = dir / "config" / "defaults.json";
-        if (fs::exists(candidate)) {
-            try {
-                std::ifstream in(candidate);
-                nlohmann::json j = nlohmann::json::parse(in);
-                const auto& d = j.at("database");
-                return "postgresql://" + d.at("username").get<std::string>() + ":" +
-                       d.at("password").get<std::string>() + "@" +
-                       d.at("host").get<std::string>() + ":" + d.at("port").get<std::string>() +
-                       "/" + d.at("name").get<std::string>();
-            } catch (const std::exception&) {
-                return {};
-            }
-        }
-        dir = dir.parent_path();
+    // Database-backed tests connect ONLY through TRADE_NGIN_TEST_DSN. The previous
+    // behaviour walked up from the working directory looking for config/defaults.json,
+    // which pointed a test run inside any worktree of this checkout at the live
+    // database. Tests must never discover production credentials by accident.
+    const char* dsn = std::getenv("TRADE_NGIN_TEST_DSN");
+    if (dsn && *dsn) {
+        return std::string(dsn);
     }
     return {};
 }
@@ -77,10 +66,10 @@ protected:
         conn_string_ = discover_connection_string();
         if (conn_string_.empty()) {
             if (require_db) {
-                FAIL() << "TRADE_NGIN_REQUIRE_DB=1 but config/defaults.json is not reachable, "
+                FAIL() << "TRADE_NGIN_REQUIRE_DB=1 but TRADE_NGIN_TEST_DSN is not set, "
                           "so the corporate_action query bounds go unverified";
             }
-            GTEST_SKIP() << "config/defaults.json not reachable; no database to exercise";
+            GTEST_SKIP() << "TRADE_NGIN_TEST_DSN not set; no database to exercise";
         }
         db_ = std::make_shared<PostgresDatabase>(conn_string_);
         auto connected = db_->connect();

--- a/tests/live/corp_actions/test_denominator_range_db.cpp
+++ b/tests/live/corp_actions/test_denominator_range_db.cpp
@@ -35,24 +35,13 @@ namespace {
 constexpr const char* kDeepSymbol = "KO";
 
 std::string discover_connection_string() {
-    namespace fs = std::filesystem;
-    fs::path dir = fs::current_path();
-    for (int i = 0; i < 8 && !dir.empty(); ++i) {
-        fs::path candidate = dir / "config" / "defaults.json";
-        if (fs::exists(candidate)) {
-            try {
-                std::ifstream in(candidate);
-                nlohmann::json j = nlohmann::json::parse(in);
-                const auto& d = j.at("database");
-                return "postgresql://" + d.at("username").get<std::string>() + ":" +
-                       d.at("password").get<std::string>() + "@" +
-                       d.at("host").get<std::string>() + ":" + d.at("port").get<std::string>() +
-                       "/" + d.at("name").get<std::string>();
-            } catch (const std::exception&) {
-                return {};
-            }
-        }
-        dir = dir.parent_path();
+    // Database-backed tests connect ONLY through TRADE_NGIN_TEST_DSN. The previous
+    // behaviour walked up from the working directory looking for config/defaults.json,
+    // which pointed a test run inside any worktree of this checkout at the live
+    // database. Tests must never discover production credentials by accident.
+    const char* dsn = std::getenv("TRADE_NGIN_TEST_DSN");
+    if (dsn && *dsn) {
+        return std::string(dsn);
     }
     return {};
 }
@@ -70,10 +59,10 @@ protected:
         const std::string conn = discover_connection_string();
         if (conn.empty()) {
             if (require_db) {
-                FAIL() << "TRADE_NGIN_REQUIRE_DB=1 but config/defaults.json is not reachable, "
+                FAIL() << "TRADE_NGIN_REQUIRE_DB=1 but TRADE_NGIN_TEST_DSN is not set, "
                           "so the top-up range collapse goes unverified";
             }
-            GTEST_SKIP() << "config/defaults.json not reachable; no database to exercise";
+            GTEST_SKIP() << "TRADE_NGIN_TEST_DSN not set; no database to exercise";
         }
         db_ = std::make_shared<PostgresDatabase>(conn);
         auto connected = db_->connect();

--- a/tests/storage/test_live_results_key_roundtrip_db.cpp
+++ b/tests/storage/test_live_results_key_roundtrip_db.cpp
@@ -41,24 +41,13 @@ constexpr const char* kScratchStrategyName = "FIX0_ROUNDTRIP_PROBE_NAME";
 constexpr const char* kScratchPortfolio = "FIX0_ROUNDTRIP_PROBE_PORTFOLIO";
 
 std::string discover_connection_string() {
-    namespace fs = std::filesystem;
-    fs::path dir = fs::current_path();
-    for (int i = 0; i < 8 && !dir.empty(); ++i) {
-        fs::path candidate = dir / "config" / "defaults.json";
-        if (fs::exists(candidate)) {
-            try {
-                std::ifstream in(candidate);
-                nlohmann::json j = nlohmann::json::parse(in);
-                const auto& d = j.at("database");
-                return "postgresql://" + d.at("username").get<std::string>() + ":" +
-                       d.at("password").get<std::string>() + "@" +
-                       d.at("host").get<std::string>() + ":" + d.at("port").get<std::string>() +
-                       "/" + d.at("name").get<std::string>();
-            } catch (const std::exception&) {
-                return {};
-            }
-        }
-        dir = dir.parent_path();
+    // Database-backed tests connect ONLY through TRADE_NGIN_TEST_DSN. The previous
+    // behaviour walked up from the working directory looking for config/defaults.json,
+    // which pointed a test run inside any worktree of this checkout at the live
+    // database. Tests must never discover production credentials by accident.
+    const char* dsn = std::getenv("TRADE_NGIN_TEST_DSN");
+    if (dsn && *dsn) {
+        return std::string(dsn);
     }
     return {};
 }
@@ -96,10 +85,10 @@ protected:
         conn_ = discover_connection_string();
         if (conn_.empty()) {
             if (require_db) {
-                FAIL() << "TRADE_NGIN_REQUIRE_DB=1 but config/defaults.json is not reachable, "
+                FAIL() << "TRADE_NGIN_REQUIRE_DB=1 but TRADE_NGIN_TEST_DSN is not set, "
                           "so the FIX-0 write/read key agreement goes unverified";
             }
-            GTEST_SKIP() << "config/defaults.json not reachable; no database to exercise";
+            GTEST_SKIP() << "TRADE_NGIN_TEST_DSN not set; no database to exercise";
         }
         db_ = std::make_shared<PostgresDatabase>(conn_);
         auto connected = db_->connect();


### PR DESCRIPTION
The nine database-backed test files found their connection by walking up to eight parent directories for config/defaults.json. Run from a build directory anywhere inside the checkout, including a git worktree, that walk reaches the real configuration and the tests connect to the live database and write their probe rows there. The probes clean up after themselves, but a test suite should never discover production credentials by accident.

These tests now read the connection from TRADE_NGIN_TEST_DSN and skip when it is not set. TRADE_NGIN_REQUIRE_DB=1 still turns the skip into a failure, so a CI job that provides a database cannot silently lose coverage. No production code changes.

Verified locally: with no variable set the full suite runs from the build directory with 77 database tests skipped and nothing else changed; with TRADE_NGIN_REQUIRE_DB=1 and no DSN the database tests fail with a message naming the variable.